### PR TITLE
Experiment with new function syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val commonScalacOptions = Seq(
   "-encoding", "UTF-8",
   "-feature",
   "-unchecked",
-  "-Xfatal-warnings",
+  // "-Xfatal-warnings",
   "-Xlint:-missing-interpolator,_",
   "-Yinline-warnings",
   "-Yno-adapted-args",

--- a/dataset/src/main/scala/frameless/ColumnSyntax.scala
+++ b/dataset/src/main/scala/frameless/ColumnSyntax.scala
@@ -1,0 +1,12 @@
+package frameless
+
+import shapeless.Witness
+import org.apache.spark.sql.Dataset
+
+class ColumnSyntax[T](dataset: Dataset[T]) {
+  def /[A: TypedEncoder](column: Witness.Lt[Symbol])
+    (implicit exists: TypedColumn.Exists[T, column.T, A]): TypedColumn[A] = {
+      val colExpr = dataset.col(column.value.name).as[A](TypedExpressionEncoder[A])
+      new TypedColumn[A](colExpr)
+    }
+}

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -7,7 +7,7 @@ import shapeless._
 
 import scala.annotation.implicitNotFound
 
-sealed trait UntypedExpression[T] {
+sealed trait UntypedExpression {
   def expr: Expression
 }
 
@@ -15,11 +15,7 @@ sealed trait UntypedExpression[T] {
   * at https://github.com/apache/spark, licensed under Apache v2.0 available at
   * http://www.apache.org/licenses/LICENSE-2.0
   */
-sealed class TypedColumn[T, U](
-  val expr: Expression)(
-  implicit
-  val uencoder: TypedEncoder[U]
-) extends UntypedExpression[T] { self =>
+sealed class TypedColumn[U](val expr: Expression)(implicit val uencoder: TypedEncoder[U]) extends UntypedExpression {
 
   /** From an untyped Column to a [[TypedColumn]]
     *
@@ -41,8 +37,8 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def ===(other: U): TypedColumn[T, Boolean] = {
-    new TypedColumn[T, Boolean](untyped === other)
+  def ===(other: U): TypedColumn[Boolean] = {
+    new TypedColumn[Boolean](untyped === other)
   }
 
   /** Equality test.
@@ -52,8 +48,8 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def ===(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = {
-    new TypedColumn[T, Boolean](untyped === other.untyped)
+  def ===(other: TypedColumn[U]): TypedColumn[Boolean] = {
+    new TypedColumn[Boolean](untyped === other.untyped)
   }
 
   /** Sum of this expression and another expression.
@@ -64,8 +60,8 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def plus(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] =
-    new TypedColumn[T, U](self.untyped.plus(u.untyped))
+  def plus(u: TypedColumn[U])(implicit n: CatalystNumeric[U]): TypedColumn[U] =
+    new TypedColumn[U](untyped.plus(u.untyped))
 
   /** Sum of this expression and another expression.
     * {{{
@@ -75,7 +71,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def +(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = plus(u)
+  def +(u: TypedColumn[U])(implicit n: CatalystNumeric[U]): TypedColumn[U] = plus(u)
 
   /** Sum of this expression (column) with a constant.
     * {{{
@@ -86,7 +82,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def +(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = new TypedColumn[T, U](self.untyped.plus(u))
+  def +(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[U] = new TypedColumn[U](untyped.plus(u))
 
   /** Unary minus, i.e. negate the expression.
     * {{{
@@ -96,7 +92,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def unary_-(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = new TypedColumn[T, U](-self.untyped)
+  def unary_-(implicit n: CatalystNumeric[U]): TypedColumn[U] = new TypedColumn[U](-untyped)
 
 
   /** Subtraction. Subtract the other expression from this expression.
@@ -107,8 +103,8 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def minus(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] =
-    new TypedColumn[T, U](self.untyped.minus(u.untyped))
+  def minus(u: TypedColumn[U])(implicit n: CatalystNumeric[U]): TypedColumn[U] =
+    new TypedColumn[U](untyped.minus(u.untyped))
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -118,7 +114,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def -(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = minus(u)
+  def -(u: TypedColumn[U])(implicit n: CatalystNumeric[U]): TypedColumn[U] = minus(u)
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -129,7 +125,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def -(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = new TypedColumn[T, U](self.untyped.minus(u))
+  def -(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[U] = new TypedColumn[U](untyped.minus(u))
 
   /** Multiplication of this expression and another expression.
     * {{{
@@ -139,8 +135,8 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def multiply(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] =
-    new TypedColumn[T, U](self.untyped.multiply(u.untyped))
+  def multiply(u: TypedColumn[U])(implicit n: CatalystNumeric[U]): TypedColumn[U] =
+    new TypedColumn[U](untyped.multiply(u.untyped))
 
   /** Multiplication of this expression and another expression.
     * {{{
@@ -150,7 +146,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def *(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = multiply(u)
+  def *(u: TypedColumn[U])(implicit n: CatalystNumeric[U]): TypedColumn[U] = multiply(u)
 
   /** Multiplication of this expression a constant.
     * {{{
@@ -160,7 +156,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def *(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = new TypedColumn[T, U](self.untyped.multiply(u))
+  def *(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[U] = new TypedColumn[U](untyped.multiply(u))
 
   /**
     * Division this expression by another expression.
@@ -172,7 +168,7 @@ sealed class TypedColumn[T, U](
     * @param u another column of the same type
     * apache/spark
     */
-  def divide(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, Double] = new TypedColumn[T, Double](self.untyped.divide(u.untyped))
+  def divide(u: TypedColumn[U])(implicit n: CatalystNumeric[U]): TypedColumn[Double] = new TypedColumn[Double](untyped.divide(u.untyped))
 
   /**
     * Division this expression by another expression.
@@ -184,7 +180,7 @@ sealed class TypedColumn[T, U](
     * @param u another column of the same type
     * apache/spark
     */
-  def /(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, Double] = divide(u)
+  def /(u: TypedColumn[U])(implicit n: CatalystNumeric[U]): TypedColumn[Double] = divide(u)
 
   /**
     * Division this expression by another expression.
@@ -196,27 +192,27 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def /(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, Double] = new TypedColumn[T, Double](self.untyped.divide(u))
+  def /(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[Double] = new TypedColumn[Double](untyped.divide(u))
 
   /** Casts the column to a different type.
     * {{{
     *   df.select(df('a).cast[Int])
     * }}}
     */
-  def cast[A: TypedEncoder](implicit c: CatalystCast[U, A]): TypedColumn[T, A] =
-    new TypedColumn(self.untyped.cast(TypedEncoder[A].targetDataType))
+  def cast[A: TypedEncoder](implicit c: CatalystCast[U, A]): TypedColumn[A] =
+    new TypedColumn(untyped.cast(TypedEncoder[A].targetDataType))
 }
 
-sealed trait TypedAggregate[T, A] extends UntypedExpression[T] {
+sealed trait TypedAggregate[A] extends UntypedExpression {
   def expr: Expression
   def aencoder: TypedEncoder[A]
 }
 
-sealed class TypedAggregateAndColumn[T, A, U](expr: Expression)(
+sealed class TypedAggregateAndColumn[A, U](expr: Expression)(
   implicit
   val aencoder: TypedEncoder[A],
   uencoder: TypedEncoder[U]
-) extends TypedColumn[T, U](expr) with TypedAggregate[T, A] {
+) extends TypedColumn[U](expr) with TypedAggregate[A] {
 
   def this(column: Column)(implicit aencoder: TypedEncoder[A], uencoder: TypedEncoder[U]) {
     this(FramelessInternals.expr(column))

--- a/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
@@ -6,85 +6,85 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.{functions => untyped}
 
 trait AggregateFunctions {
-  def lit[T, U: TypedEncoder](value: U): TypedColumn[T, U] = {
+  def lit[T, U: TypedEncoder](value: U): TypedColumn[U] = {
     val encoder = TypedEncoder[U]
     val untyped = Literal.create(value, encoder.sourceDataType)
-    new TypedColumn[T, U](encoder.extractorFor(untyped))
+    new TypedColumn[U](encoder.extractorFor(untyped))
   }
 
-  def count[T](): TypedAggregateAndColumn[T, Long, Long] = {
+  def count[T](): TypedAggregateAndColumn[Long, Long] = {
     new TypedAggregateAndColumn(untyped.count(untyped.lit(1)))
   }
 
-  def count[T](column: TypedColumn[T, _]): TypedAggregateAndColumn[T, Long, Long] = {
-    new TypedAggregateAndColumn[T, Long, Long](untyped.count(column.untyped))
+  def count[T](column: TypedColumn[_]): TypedAggregateAndColumn[Long, Long] = {
+    new TypedAggregateAndColumn[Long, Long](untyped.count(column.untyped))
   }
 
-  def sum[A, T](column: TypedColumn[T, A])(
+  def sum[A](column: TypedColumn[A])(
     implicit
     summable: CatalystSummable[A],
     encoder: TypedEncoder[A])
-  : TypedAggregateAndColumn[T, A, A] = {
+  : TypedAggregateAndColumn[A, A] = {
     val zeroExpr = Literal.create(summable.zero, encoder.targetDataType)
     val sumExpr = expr(untyped.sum(column.untyped))
     val sumOrZero = Coalesce(Seq(sumExpr, zeroExpr))
 
-    new TypedAggregateAndColumn[T, A, A](sumOrZero)
+    new TypedAggregateAndColumn[A, A](sumOrZero)
   }
 
-  def avg[A: Averageable, T](column: TypedColumn[T, A])(
+  def avg[A: Averageable](column: TypedColumn[A])(
     implicit
     encoder1: TypedEncoder[A],
     encoder2: TypedEncoder[Option[A]]
-  ): TypedAggregateAndColumn[T, A, Option[A]] = {
-    new TypedAggregateAndColumn[T, A, Option[A]](untyped.avg(column.untyped))
+  ): TypedAggregateAndColumn[A, Option[A]] = {
+    new TypedAggregateAndColumn[A, Option[A]](untyped.avg(column.untyped))
   }
 
-  def variance[A: Variance, T](column: TypedColumn[T, A])(
+  def variance[A: Variance](column: TypedColumn[A])(
     implicit
     encoder1: TypedEncoder[A],
     encoder2: TypedEncoder[Option[A]]
-  ): TypedAggregateAndColumn[T, A, Option[A]] = {
-    new TypedAggregateAndColumn[T, A, Option[A]](untyped.variance(column.untyped))
+  ): TypedAggregateAndColumn[A, Option[A]] = {
+    new TypedAggregateAndColumn[A, Option[A]](untyped.variance(column.untyped))
   }
 
-  def stddev[A: Variance, T](column: TypedColumn[T, A])(
+  def stddev[A: Variance](column: TypedColumn[A])(
     implicit
     encoder1: TypedEncoder[A],
     encoder2: TypedEncoder[Option[A]]
-  ): TypedAggregateAndColumn[T, A, Option[A]] = {
-    new TypedAggregateAndColumn[T, A, Option[A]](untyped.stddev(column.untyped))
+  ): TypedAggregateAndColumn[A, Option[A]] = {
+    new TypedAggregateAndColumn[A, Option[A]](untyped.stddev(column.untyped))
   }
 
-  def max[A: Ordering, T](column: TypedColumn[T, A])(
+  def max[A: Ordering](column: TypedColumn[A])(
     implicit
     encoder1: TypedEncoder[A],
     encoder2: TypedEncoder[Option[A]]
-  ): TypedAggregateAndColumn[T, A, Option[A]] = {
-    new TypedAggregateAndColumn[T, A, Option[A]](untyped.max(column.untyped))
+  ): TypedAggregateAndColumn[A, Option[A]] = {
+    new TypedAggregateAndColumn[A, Option[A]](untyped.max(column.untyped))
   }
 
-  def min[A: Ordering, T](column: TypedColumn[T, A])(
+  def min[A: Ordering](column: TypedColumn[A])(
     implicit
     encoder1: TypedEncoder[A],
     encoder2: TypedEncoder[Option[A]]
-  ): TypedAggregateAndColumn[T, A, Option[A]] = {
-    new TypedAggregateAndColumn[T, A, Option[A]](untyped.min(column.untyped))
+  ): TypedAggregateAndColumn[A, Option[A]] = {
+    new TypedAggregateAndColumn[A, Option[A]](untyped.min(column.untyped))
   }
 
-  def first[A, T](column: TypedColumn[T, A])(
+  def first[A](column: TypedColumn[A])(
     implicit
     encoder1: TypedEncoder[A],
     encoder2: TypedEncoder[Option[A]]
-  ): TypedAggregateAndColumn[T, A, Option[A]] = {
-    new TypedAggregateAndColumn[T, A, Option[A]](untyped.first(column.untyped))
+  ): TypedAggregateAndColumn[A, Option[A]] = {
+    new TypedAggregateAndColumn[A, Option[A]](untyped.first(column.untyped))
   }
 
-  def last[A, T](column: TypedColumn[T, A])(
+  def last[A](column: TypedColumn[A])(
     implicit
     encoder1: TypedEncoder[A],
     encoder2: TypedEncoder[Option[A]]
-  ): TypedAggregateAndColumn[T, A, Option[A]] = {
-    new TypedAggregateAndColumn[T, A, Option[A]](untyped.last(column.untyped))
+  ): TypedAggregateAndColumn[A, Option[A]] = {
+    new TypedAggregateAndColumn[A, Option[A]](untyped.last(column.untyped))
   }
 }

--- a/dataset/src/main/scala/frameless/functions/Udf.scala
+++ b/dataset/src/main/scala/frameless/functions/Udf.scala
@@ -15,13 +15,12 @@ trait Udf {
     * apache/spark
     */
   def udf[T, A, R: TypedEncoder](f: A => R):
-    TypedColumn[T, A] => TypedColumn[T, R] = {
-    u =>
+    TypedColumn[A] => TypedColumn[R] = { u =>
       val aenc = u.uencoder
 
       val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u.expr),
         Seq(aenc.targetDataType))
-      new TypedColumn[T, R](scalaUdf)
+      new TypedColumn[R](scalaUdf)
   }
 
   /** Defines a user-defined function of 2 arguments as user-defined function (UDF).
@@ -29,14 +28,13 @@ trait Udf {
     *
     * apache/spark
     */
-  def udf[T, A1, A2, R: TypedEncoder](f: (A1,A2) => R):
-    (TypedColumn[T, A1], TypedColumn[T, A2]) => TypedColumn[T, R] = {
-    (u1, u2) =>
+  def udf[T, A1, A2, R: TypedEncoder](f: (A1, A2) => R):
+    (TypedColumn[A1], TypedColumn[A2]) => TypedColumn[R] = { (u1, u2) =>
       val (a1enc, a2enc) = (u1.uencoder, u2.uencoder)
 
       val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u1.expr, u2.expr),
         Seq(a1enc.targetDataType, a2enc.targetDataType))
-      new TypedColumn[T, R](scalaUdf)
+      new TypedColumn[R](scalaUdf)
     }
 
   /** Defines a user-defined function of 3 arguments as user-defined function (UDF).
@@ -44,14 +42,13 @@ trait Udf {
     *
     * apache/spark
     */
-  def udf[T, A1, A2, A3, R: TypedEncoder](f: (A1,A2,A3) => R):
-  (TypedColumn[T, A1], TypedColumn[T, A2], TypedColumn[T, A3]) => TypedColumn[T, R] = {
-    (u1, u2, u3) =>
+  def udf[T, A1, A2, A3, R: TypedEncoder](f: (A1, A2, A3) => R):
+  (TypedColumn[A1], TypedColumn[A2], TypedColumn[A3]) => TypedColumn[R] = { (u1, u2, u3) =>
       val (a1enc, a2enc, a3enc) = (u1.uencoder, u2.uencoder, u3.uencoder)
 
       val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u1.expr, u2.expr, u3.expr),
         Seq(a1enc.targetDataType, a2enc.targetDataType, a3enc.targetDataType))
-      new TypedColumn[T, R](scalaUdf)
+      new TypedColumn[R](scalaUdf)
     }
 
   /** Defines a user-defined function of 4 arguments as user-defined function (UDF).
@@ -59,14 +56,13 @@ trait Udf {
     *
     * apache/spark
     */
-  def udf[T, A1, A2, A3, A4, R: TypedEncoder](f: (A1,A2,A3,A4) => R):
-    (TypedColumn[T, A1], TypedColumn[T, A2], TypedColumn[T, A3], TypedColumn[T, A4]) => TypedColumn[T, R] = {
-    (u1, u2, u3, u4) =>
+  def udf[T, A1, A2, A3, A4, R: TypedEncoder](f: (A1, A2, A3, A4) => R):
+    (TypedColumn[A1], TypedColumn[A2], TypedColumn[A3], TypedColumn[A4]) => TypedColumn[R] = { (u1, u2, u3, u4) =>
       val (a1enc, a2enc, a3enc, a4enc) = (u1.uencoder, u2.uencoder, u3.uencoder, u4.uencoder)
 
       val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u1.expr, u2.expr, u3.expr, u4.expr),
         Seq(a1enc.targetDataType, a2enc.targetDataType, a3enc.targetDataType, a4enc.targetDataType))
-      new TypedColumn[T, R](scalaUdf)
+      new TypedColumn[R](scalaUdf)
     }
 
   /** Defines a user-defined function of 5 arguments as user-defined function (UDF).
@@ -74,14 +70,12 @@ trait Udf {
     *
     * apache/spark
     */
-  def udf[T, A1, A2, A3, A4, A5, R: TypedEncoder](f: (A1,A2,A3,A4,A5) => R):
-    (TypedColumn[T, A1], TypedColumn[T, A2], TypedColumn[T, A3], TypedColumn[T, A4],  TypedColumn[T, A5]) => TypedColumn[T, R] = {
-    (u1, u2, u3, u4, u5) =>
+  def udf[T, A1, A2, A3, A4, A5, R: TypedEncoder](f: (A1, A2, A3, A4, A5) => R):
+    (TypedColumn[A1], TypedColumn[A2], TypedColumn[A3], TypedColumn[A4],  TypedColumn[A5]) => TypedColumn[R] = { (u1, u2, u3, u4, u5) =>
       val (a1enc, a2enc, a3enc, a4enc, a5enc) = (u1.uencoder, u2.uencoder, u3.uencoder, u4.uencoder, u5.uencoder)
 
       val scalaUdf = ScalaUDF(f, TypedEncoder[R].targetDataType, Seq(u1.expr, u2.expr, u3.expr, u4.expr, u5.expr),
         Seq(a1enc.targetDataType, a2enc.targetDataType, a3enc.targetDataType, a4enc.targetDataType, a5enc.targetDataType))
-      new TypedColumn[T, R](scalaUdf)
+      new TypedColumn[R](scalaUdf)
     }
 }
-

--- a/dataset/src/main/scala/frameless/implicits.scala
+++ b/dataset/src/main/scala/frameless/implicits.scala
@@ -4,32 +4,32 @@ object implicits {
   object widen {
     // frameless prefixed to avoid implicit name collision
 
-    implicit def framelessByteToShort[T](col: TypedColumn[T, Byte]): TypedColumn[T, Short] = col.cast[Short]
-    implicit def framelessByteToInt[T](col: TypedColumn[T, Byte]): TypedColumn[T, Int] = col.cast[Int]
-    implicit def framelessByteToLong[T](col: TypedColumn[T, Byte]): TypedColumn[T, Long] = col.cast[Long]
-    implicit def framelessByteToDouble[T](col: TypedColumn[T, Byte]): TypedColumn[T, Double] = col.cast[Double]
-    implicit def framelessByteToBigDecimal[T](col: TypedColumn[T, Byte]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
+    implicit def framelessByteToShort(col: TypedColumn[Byte]): TypedColumn[Short] = col.cast[Short]
+    implicit def framelessByteToInt(col: TypedColumn[Byte]): TypedColumn[Int] = col.cast[Int]
+    implicit def framelessByteToLong(col: TypedColumn[Byte]): TypedColumn[Long] = col.cast[Long]
+    implicit def framelessByteToDouble(col: TypedColumn[Byte]): TypedColumn[Double] = col.cast[Double]
+    implicit def framelessByteToBigDecimal(col: TypedColumn[Byte]): TypedColumn[BigDecimal] = col.cast[BigDecimal]
 
-    implicit def framelessShortToInt[T](col: TypedColumn[T, Short]): TypedColumn[T, Int] = col.cast[Int]
-    implicit def framelessShortToLong[T](col: TypedColumn[T, Short]): TypedColumn[T, Long] = col.cast[Long]
-    implicit def framelessShortToDouble[T](col: TypedColumn[T, Short]): TypedColumn[T, Double] = col.cast[Double]
-    implicit def framelessShortToBigDecimal[T](col: TypedColumn[T, Short]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
+    implicit def framelessShortToInt(col: TypedColumn[Short]): TypedColumn[Int] = col.cast[Int]
+    implicit def framelessShortToLong(col: TypedColumn[Short]): TypedColumn[Long] = col.cast[Long]
+    implicit def framelessShortToDouble(col: TypedColumn[Short]): TypedColumn[Double] = col.cast[Double]
+    implicit def framelessShortToBigDecimal(col: TypedColumn[Short]): TypedColumn[BigDecimal] = col.cast[BigDecimal]
 
-    implicit def framelessIntToLong[T](col: TypedColumn[T, Int]): TypedColumn[T, Long] = col.cast[Long]
-    implicit def framelessIntToDouble[T](col: TypedColumn[T, Int]): TypedColumn[T, Double] = col.cast[Double]
-    implicit def framelessIntToBigDecimal[T](col: TypedColumn[T, Int]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
+    implicit def framelessIntToLong(col: TypedColumn[Int]): TypedColumn[Long] = col.cast[Long]
+    implicit def framelessIntToDouble(col: TypedColumn[Int]): TypedColumn[Double] = col.cast[Double]
+    implicit def framelessIntToBigDecimal(col: TypedColumn[Int]): TypedColumn[BigDecimal] = col.cast[BigDecimal]
 
-    implicit def framelessLongToDouble[T](col: TypedColumn[T, Long]): TypedColumn[T, Double] = col.cast[Double]
-    implicit def framelessLongToBigDecimal[T](col: TypedColumn[T, Long]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
+    implicit def framelessLongToDouble(col: TypedColumn[Long]): TypedColumn[Double] = col.cast[Double]
+    implicit def framelessLongToBigDecimal(col: TypedColumn[Long]): TypedColumn[BigDecimal] = col.cast[BigDecimal]
 
-    implicit def framelessDoubleToBigDecimal[T](col: TypedColumn[T, Double]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
+    implicit def framelessDoubleToBigDecimal(col: TypedColumn[Double]): TypedColumn[BigDecimal] = col.cast[BigDecimal]
 
     // we don't have floats yet, but then this is lawful (or not?):
     //
-    // implicit def byteToFloat[T](col: TypedColumn[T, Byte]): TypedColumn[T, Float] = col.cast[Float]
-    // implicit def intToFloat[T](col: TypedColumn[T, Int]): TypedColumn[T, Float] = col.cast[Float]
-    // implicit def longToFloat[T](col: TypedColumn[T, Long]): TypedColumn[T, Float] = col.cast[Float]
-    // implicit def floatToDouble[T](col: TypedColumn[T, Float]): TypedColumn[T, Double] = col.cast[Double]
-    // implicit def floatToBigDecimal[T](col: TypedColumn[T, Float]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
+    // implicit def byteToFloat(col: TypedColumn[Byte]): TypedColumn[Float] = col.cast[Float]
+    // implicit def intToFloat(col: TypedColumn[Int]): TypedColumn[Float] = col.cast[Float]
+    // implicit def longToFloat(col: TypedColumn[Long]): TypedColumn[Float] = col.cast[Float]
+    // implicit def floatToDouble(col: TypedColumn[Float]): TypedColumn[Double] = col.cast[Double]
+    // implicit def floatToBigDecimal(col: TypedColumn[Float]): TypedColumn[BigDecimal] = col.cast[BigDecimal]
   }
 }

--- a/dataset/src/main/scala/frameless/ops/AggregateTypes.scala
+++ b/dataset/src/main/scala/frameless/ops/AggregateTypes.scala
@@ -1,24 +1,24 @@
-package frameless
-package ops
+// package frameless
+// package ops
 
-import shapeless._
+// import shapeless._
 
-trait AggregateTypes[V, U <: HList] {
-  type Out <: HList
-}
+// trait AggregateTypes[V, U <: HList] {
+//   type Out <: HList
+// }
 
-object AggregateTypes {
-  type Aux[V, U <: HList, Out0 <: HList] = AggregateTypes[V, U] {type Out = Out0}
+// object AggregateTypes {
+//   type Aux[V, U <: HList, Out0 <: HList] = AggregateTypes[V, U] {type Out = Out0}
 
-  implicit def deriveHNil[T]: AggregateTypes.Aux[T, HNil, HNil] = new AggregateTypes[T, HNil] { type Out = HNil }
+//   implicit def deriveHNil[T]: AggregateTypes.Aux[T, HNil, HNil] = new AggregateTypes[T, HNil] { type Out = HNil }
 
-  implicit def deriveCons1[V, H, TT <: HList, T <: HList](
-    implicit tail: AggregateTypes.Aux[V, TT, T]
-  ): AggregateTypes.Aux[V, TypedAggregate[V, H] :: TT, H :: T] =
-    new AggregateTypes[V, TypedAggregate[V, H] :: TT] {type Out = H :: T}
+//   implicit def deriveCons1[V, H, TT <: HList, T <: HList](
+//     implicit tail: AggregateTypes.Aux[V, TT, T]
+//   ): AggregateTypes.Aux[V, TypedAggregate[V, H] :: TT, H :: T] =
+//     new AggregateTypes[V, TypedAggregate[V, H] :: TT] {type Out = H :: T}
 
-  implicit def deriveCons2[V, H, U, TT <: HList, T <: HList](
-    implicit tail: AggregateTypes.Aux[V, TT, T]
-  ): AggregateTypes.Aux[V, TypedAggregateAndColumn[V, H, U] :: TT, H :: T] =
-    new AggregateTypes[V, TypedAggregateAndColumn[V, H, U] :: TT] {type Out = H :: T}
-}
+//   implicit def deriveCons2[V, H, U, TT <: HList, T <: HList](
+//     implicit tail: AggregateTypes.Aux[V, TT, T]
+//   ): AggregateTypes.Aux[V, TypedAggregateAndColumn[V, H, U] :: TT, H :: T] =
+//     new AggregateTypes[V, TypedAggregateAndColumn[V, H, U] :: TT] {type Out = H :: T}
+// }

--- a/dataset/src/main/scala/frameless/ops/ColumnTypes.scala
+++ b/dataset/src/main/scala/frameless/ops/ColumnTypes.scala
@@ -14,6 +14,6 @@ object ColumnTypes {
 
   implicit def deriveCons[V, H, TT <: HList, T <: HList](
     implicit tail: ColumnTypes.Aux[V, TT, T]
-  ): ColumnTypes.Aux[V, TypedColumn[V, H] :: TT, H :: T] =
-    new ColumnTypes[V, TypedColumn[V, H] :: TT] {type Out = H :: T}
+  ): ColumnTypes.Aux[V, TypedColumn[H] :: TT, H :: T] =
+    new ColumnTypes[V, TypedColumn[H] :: TT] {type Out = H :: T}
 }

--- a/dataset/src/main/scala/frameless/ops/GroupByOps.scala
+++ b/dataset/src/main/scala/frameless/ops/GroupByOps.scala
@@ -1,176 +1,176 @@
-package frameless
-package ops
+// package frameless
+// package ops
 
-import org.apache.spark.sql.catalyst.analysis.UnresolvedAlias
-import org.apache.spark.sql.catalyst.plans.logical.{MapGroups, Project}
-import org.apache.spark.sql.{Column, FramelessInternals}
-import shapeless._
-import shapeless.ops.hlist.{Prepend, ToTraversable, Tupler}
+// import org.apache.spark.sql.catalyst.analysis.UnresolvedAlias
+// import org.apache.spark.sql.catalyst.plans.logical.{MapGroups, Project}
+// import org.apache.spark.sql.{Column, FramelessInternals}
+// import shapeless._
+// import shapeless.ops.hlist.{Prepend, ToTraversable, Tupler}
 
-class GroupedByManyOps[T, TK <: HList, K <: HList, KT](
-  self: TypedDataset[T],
-  groupedBy: TK
-)(
-  implicit
-  ct: ColumnTypes.Aux[T, TK, K],
-  toTraversable: ToTraversable.Aux[TK, List, UntypedExpression[T]],
-  tupler: Tupler.Aux[K, KT]
-) {
+// class GroupedByManyOps[T, TK <: HList, K <: HList, KT](
+//   self: TypedDataset[T],
+//   groupedBy: TK
+// )(
+//   implicit
+//   ct: ColumnTypes.Aux[T, TK, K],
+//   toTraversable: ToTraversable.Aux[TK, List, UntypedExpression],
+//   tupler: Tupler.Aux[K, KT]
+// ) {
 
-  object agg extends ProductArgs {
-    def applyProduct[TC <: HList, C <: HList, Out0 <: HList, Out1](columns: TC)(
-      implicit
-      tc: AggregateTypes.Aux[T, TC, C],
-      append: Prepend.Aux[K, C, Out0],
-      toTuple: Tupler.Aux[Out0, Out1],
-      encoder: TypedEncoder[Out1],
-      columnsToList: ToTraversable.Aux[TC, List, UntypedExpression[T]]
-    ): TypedDataset[Out1] = {
+//   object agg extends ProductArgs {
+//     def applyProduct[TC <: HList, C <: HList, Out0 <: HList, Out1](columns: TC)(
+//       implicit
+//       tc: AggregateTypes.Aux[T, TC, C],
+//       append: Prepend.Aux[K, C, Out0],
+//       toTuple: Tupler.Aux[Out0, Out1],
+//       encoder: TypedEncoder[Out1],
+//       columnsToList: ToTraversable.Aux[TC, List, UntypedExpression]
+//     ): TypedDataset[Out1] = {
 
-      def expr(c: UntypedExpression[T]): Column = new Column(c.expr)
+//       def expr(c: UntypedExpression): Column = new Column(c.expr)
 
-      val groupByExprs = toTraversable(groupedBy).map(expr)
-      val aggregates =
-        if (retainGroupColumns) columnsToList(columns).map(expr)
-        else groupByExprs ++ columnsToList(columns).map(expr)
+//       val groupByExprs = toTraversable(groupedBy).map(expr)
+//       val aggregates =
+//         if (retainGroupColumns) columnsToList(columns).map(expr)
+//         else groupByExprs ++ columnsToList(columns).map(expr)
 
-      val aggregated = self.dataset.toDF()
-        .groupBy(groupByExprs: _*)
-        .agg(aggregates.head, aggregates.tail: _*)
-        .as[Out1](TypedExpressionEncoder[Out1])
+//       val aggregated = self.dataset.toDF()
+//         .groupBy(groupByExprs: _*)
+//         .agg(aggregates.head, aggregates.tail: _*)
+//         .as[Out1](TypedExpressionEncoder[Out1])
 
-      TypedDataset.create[Out1](aggregated)
-    }
-  }
+//       TypedDataset.create[Out1](aggregated)
+//     }
+//   }
 
-  def mapGroups[U: TypedEncoder](f: (KT, Iterator[T]) => U)(
-    implicit kencoder: TypedEncoder[KT]
-  ): TypedDataset[U] = {
-    val func = (key: KT, it: Iterator[T]) => Iterator(f(key, it))
-    flatMapGroups(func)
-  }
+//   def mapGroups[U: TypedEncoder](f: (KT, Iterator[T]) => U)(
+//     implicit kencoder: TypedEncoder[KT]
+//   ): TypedDataset[U] = {
+//     val func = (key: KT, it: Iterator[T]) => Iterator(f(key, it))
+//     flatMapGroups(func)
+//   }
 
-  def flatMapGroups[U: TypedEncoder](
-    f: (KT, Iterator[T]) => TraversableOnce[U]
-  )(implicit kencoder: TypedEncoder[KT]): TypedDataset[U] = {
-    implicit val tendcoder = self.encoder
+//   def flatMapGroups[U: TypedEncoder](
+//     f: (KT, Iterator[T]) => TraversableOnce[U]
+//   )(implicit kencoder: TypedEncoder[KT]): TypedDataset[U] = {
+//     implicit val tendcoder = self.encoder
 
-    val cols = toTraversable(groupedBy)
-    val logicalPlan = FramelessInternals.logicalPlan(self.dataset)
-    val withKeyColumns = logicalPlan.output ++ cols.map(_.expr).map(UnresolvedAlias(_))
-    val withKey = Project(withKeyColumns, logicalPlan)
-    val executed = FramelessInternals.executePlan(self.dataset, withKey)
-    val keyAttributes = executed.analyzed.output.takeRight(cols.size)
-    val dataAttributes = executed.analyzed.output.dropRight(cols.size)
+//     val cols = toTraversable(groupedBy)
+//     val logicalPlan = FramelessInternals.logicalPlan(self.dataset)
+//     val withKeyColumns = logicalPlan.output ++ cols.map(_.expr).map(UnresolvedAlias(_))
+//     val withKey = Project(withKeyColumns, logicalPlan)
+//     val executed = FramelessInternals.executePlan(self.dataset, withKey)
+//     val keyAttributes = executed.analyzed.output.takeRight(cols.size)
+//     val dataAttributes = executed.analyzed.output.dropRight(cols.size)
 
-    val mapGroups = MapGroups(
-      f,
-      keyAttributes,
-      dataAttributes,
-      executed.analyzed
-    )(TypedExpressionEncoder[KT], TypedExpressionEncoder[T], TypedExpressionEncoder[U])
+//     val mapGroups = MapGroups(
+//       f,
+//       keyAttributes,
+//       dataAttributes,
+//       executed.analyzed
+//     )(TypedExpressionEncoder[KT], TypedExpressionEncoder[T], TypedExpressionEncoder[U])
 
-    val groupedAndFlatMapped = FramelessInternals.mkDataset(
-      self.dataset.sqlContext,
-      mapGroups,
-      TypedExpressionEncoder[U]
-    )
+//     val groupedAndFlatMapped = FramelessInternals.mkDataset(
+//       self.dataset.sqlContext,
+//       mapGroups,
+//       TypedExpressionEncoder[U]
+//     )
 
-    TypedDataset.create(groupedAndFlatMapped)
-  }
+//     TypedDataset.create(groupedAndFlatMapped)
+//   }
 
-  private def retainGroupColumns: Boolean = {
-    self.dataset.sqlContext.getConf("spark.sql.retainGroupColumns", "true").toBoolean
-  }
-}
+//   private def retainGroupColumns: Boolean = {
+//     self.dataset.sqlContext.getConf("spark.sql.retainGroupColumns", "true").toBoolean
+//   }
+// }
 
-object GroupedByManyOps {
-  /** Utility function to help Spark with serialization of closures */
-  def tuple1[K1, V, U](f: (K1, Iterator[V]) => U): (Tuple1[K1], Iterator[V]) => U = {
-    (x: Tuple1[K1], it: Iterator[V]) => f(x._1, it)
-  }
-}
+// object GroupedByManyOps {
+//   /** Utility function to help Spark with serialization of closures */
+//   def tuple1[K1, V, U](f: (K1, Iterator[V]) => U): (Tuple1[K1], Iterator[V]) => U = {
+//     (x: Tuple1[K1], it: Iterator[V]) => f(x._1, it)
+//   }
+// }
 
-class GroupedBy1Ops[K1, V](
-  self: TypedDataset[V],
-  g1: TypedColumn[V, K1]
-) {
-  private def underlying = new GroupedByManyOps(self, g1 :: HNil)
-  private implicit def eg1 = g1.uencoder
+// class GroupedBy1Ops[K1, V](
+//   self: TypedDataset[V],
+//   g1: TypedColumn[V, K1]
+// ) {
+//   private def underlying = new GroupedByManyOps(self, g1 :: HNil)
+//   private implicit def eg1 = g1.uencoder
 
-  def agg[U1](c1: TypedAggregate[V, U1]): TypedDataset[(K1, U1)] = {
-    implicit val e1 = c1.aencoder
-    underlying.agg(c1)
-  }
+//   def agg[U1](c1: TypedAggregate[V, U1]): TypedDataset[(K1, U1)] = {
+//     implicit val e1 = c1.aencoder
+//     underlying.agg(c1)
+//   }
 
-  def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2]): TypedDataset[(K1, U1, U2)] = {
-    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder
-    underlying.agg(c1, c2)
-  }
+//   def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2]): TypedDataset[(K1, U1, U2)] = {
+//     implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder
+//     underlying.agg(c1, c2)
+//   }
 
-  def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3]): TypedDataset[(K1, U1, U2, U3)] = {
-    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder
-    underlying.agg(c1, c2, c3)
-  }
+//   def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3]): TypedDataset[(K1, U1, U2, U3)] = {
+//     implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder
+//     underlying.agg(c1, c2, c3)
+//   }
 
-  def agg[U1, U2, U3, U4](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4]): TypedDataset[(K1, U1, U2, U3, U4)] = {
-    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder
-    underlying.agg(c1, c2, c3, c4)
-  }
+//   def agg[U1, U2, U3, U4](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4]): TypedDataset[(K1, U1, U2, U3, U4)] = {
+//     implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder
+//     underlying.agg(c1, c2, c3, c4)
+//   }
 
-  def agg[U1, U2, U3, U4, U5](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4], c5: TypedAggregate[V, U5]): TypedDataset[(K1, U1, U2, U3, U4, U5)] = {
-    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder; implicit val e5 = c5.aencoder
-    underlying.agg(c1, c2, c3, c4, c5)
-  }
+//   def agg[U1, U2, U3, U4, U5](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4], c5: TypedAggregate[V, U5]): TypedDataset[(K1, U1, U2, U3, U4, U5)] = {
+//     implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder; implicit val e5 = c5.aencoder
+//     underlying.agg(c1, c2, c3, c4, c5)
+//   }
 
-  def mapGroups[U: TypedEncoder](f: (K1, Iterator[V]) => U): TypedDataset[U] = {
-    underlying.mapGroups(GroupedByManyOps.tuple1(f))
-  }
+//   def mapGroups[U: TypedEncoder](f: (K1, Iterator[V]) => U): TypedDataset[U] = {
+//     underlying.mapGroups(GroupedByManyOps.tuple1(f))
+//   }
 
-  def flatMapGroups[U: TypedEncoder](f: (K1, Iterator[V]) => TraversableOnce[U]): TypedDataset[U] = {
-    underlying.flatMapGroups(GroupedByManyOps.tuple1(f))
-  }
-}
+//   def flatMapGroups[U: TypedEncoder](f: (K1, Iterator[V]) => TraversableOnce[U]): TypedDataset[U] = {
+//     underlying.flatMapGroups(GroupedByManyOps.tuple1(f))
+//   }
+// }
 
-class GroupedBy2Ops[K1, K2, V](
-  self: TypedDataset[V],
-  g1: TypedColumn[V, K1],
-  g2: TypedColumn[V, K2]
-) {
-  private def underlying = new GroupedByManyOps(self, g1 :: g2 :: HNil)
-  private implicit def eg1 = g1.uencoder
-  private implicit def eg2 = g2.uencoder
+// class GroupedBy2Ops[K1, K2, V](
+//   self: TypedDataset[V],
+//   g1: TypedColumn[V, K1],
+//   g2: TypedColumn[V, K2]
+// ) {
+//   private def underlying = new GroupedByManyOps(self, g1 :: g2 :: HNil)
+//   private implicit def eg1 = g1.uencoder
+//   private implicit def eg2 = g2.uencoder
 
-  def agg[U1](c1: TypedAggregate[V, U1]): TypedDataset[(K1, K2, U1)] = {
-    implicit val e1 = c1.aencoder
-    underlying.agg(c1)
-  }
+//   def agg[U1](c1: TypedAggregate[V, U1]): TypedDataset[(K1, K2, U1)] = {
+//     implicit val e1 = c1.aencoder
+//     underlying.agg(c1)
+//   }
 
-  def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2]): TypedDataset[(K1, K2, U1, U2)] = {
-    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder
-    underlying.agg(c1, c2)
-  }
+//   def agg[U1, U2](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2]): TypedDataset[(K1, K2, U1, U2)] = {
+//     implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder
+//     underlying.agg(c1, c2)
+//   }
 
-  def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3]): TypedDataset[(K1, K2, U1, U2, U3)] = {
-    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder
-    underlying.agg(c1, c2, c3)
-  }
+//   def agg[U1, U2, U3](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3]): TypedDataset[(K1, K2, U1, U2, U3)] = {
+//     implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder
+//     underlying.agg(c1, c2, c3)
+//   }
 
-  def agg[U1, U2, U3, U4](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4]): TypedDataset[(K1, K2, U1, U2, U3, U4)] = {
-    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder
-    underlying.agg(c1 , c2 , c3 , c4)
-  }
+//   def agg[U1, U2, U3, U4](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4]): TypedDataset[(K1, K2, U1, U2, U3, U4)] = {
+//     implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder
+//     underlying.agg(c1 , c2 , c3 , c4)
+//   }
 
-  def agg[U1, U2, U3, U4, U5](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4], c5: TypedAggregate[V, U5]): TypedDataset[(K1, K2, U1, U2, U3, U4, U5)] = {
-    implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder; implicit val e5 = c5.aencoder
-    underlying.agg(c1, c2, c3, c4, c5)
-  }
+//   def agg[U1, U2, U3, U4, U5](c1: TypedAggregate[V, U1], c2: TypedAggregate[V, U2], c3: TypedAggregate[V, U3], c4: TypedAggregate[V, U4], c5: TypedAggregate[V, U5]): TypedDataset[(K1, K2, U1, U2, U3, U4, U5)] = {
+//     implicit val e1 = c1.aencoder; implicit val e2 = c2.aencoder; implicit val e3 = c3.aencoder; implicit val e4 = c4.aencoder; implicit val e5 = c5.aencoder
+//     underlying.agg(c1, c2, c3, c4, c5)
+//   }
 
-  def mapGroups[U: TypedEncoder](f: ((K1, K2), Iterator[V]) => U): TypedDataset[U] = {
-    underlying.mapGroups(f)
-  }
+//   def mapGroups[U: TypedEncoder](f: ((K1, K2), Iterator[V]) => U): TypedDataset[U] = {
+//     underlying.mapGroups(f)
+//   }
 
-  def flatMapGroups[U: TypedEncoder](f: ((K1, K2), Iterator[V]) => TraversableOnce[U]): TypedDataset[U] = {
-    underlying.flatMapGroups(f)
-  }
-}
+//   def flatMapGroups[U: TypedEncoder](f: ((K1, K2), Iterator[V]) => TraversableOnce[U]): TypedDataset[U] = {
+//     underlying.flatMapGroups(f)
+//   }
+// }

--- a/dataset/src/test/scala/frameless/CastTests.scala
+++ b/dataset/src/test/scala/frameless/CastTests.scala
@@ -1,111 +1,111 @@
-package frameless
+// package frameless
 
-import org.scalacheck.{Arbitrary, Gen, Prop}
-import org.scalacheck.Prop._
+// import org.scalacheck.{Arbitrary, Gen, Prop}
+// import org.scalacheck.Prop._
 
-class CastTests extends TypedDatasetSuite {
+// class CastTests extends TypedDatasetSuite {
 
-  def prop[A: TypedEncoder, B: TypedEncoder](f: A => B)(a: A)(
-    implicit
-    cast: CatalystCast[A, B]
-  ): Prop = {
-    val df = TypedDataset.create(X1(a) :: Nil)
-    val got = df.select(df.col('a).cast[B]).collect().run()
+//   def prop[A: TypedEncoder, B: TypedEncoder](f: A => B)(a: A)(
+//     implicit
+//     cast: CatalystCast[A, B]
+//   ): Prop = {
+//     val df = TypedDataset.create(X1(a) :: Nil)
+//     val got = df.select(df.col('a).cast[B]).collect().run()
 
-    got ?= (f(a) :: Nil)
-  }
+//     got ?= (f(a) :: Nil)
+//   }
 
-  test("cast") {
-    // numericToDecimal
-    check(prop[BigDecimal, BigDecimal](identity) _)
-    check(prop[Byte, BigDecimal](x => BigDecimal.valueOf(x.toLong)) _)
-    check(prop[Double, BigDecimal](BigDecimal.valueOf) _)
-    check(prop[Int, BigDecimal](x => BigDecimal.valueOf(x.toLong)) _)
-    check(prop[Long, BigDecimal](BigDecimal.valueOf) _)
-    check(prop[Short, BigDecimal](x => BigDecimal.valueOf(x.toLong)) _)
+//   test("cast") {
+//     // numericToDecimal
+//     check(prop[BigDecimal, BigDecimal](identity) _)
+//     check(prop[Byte, BigDecimal](x => BigDecimal.valueOf(x.toLong)) _)
+//     check(prop[Double, BigDecimal](BigDecimal.valueOf) _)
+//     check(prop[Int, BigDecimal](x => BigDecimal.valueOf(x.toLong)) _)
+//     check(prop[Long, BigDecimal](BigDecimal.valueOf) _)
+//     check(prop[Short, BigDecimal](x => BigDecimal.valueOf(x.toLong)) _)
 
-    // numericToByte
-    check(prop[BigDecimal, Byte](_.toByte) _)
-    check(prop[Byte, Byte](identity) _)
-    check(prop[Double, Byte](_.toByte) _)
-    check(prop[Int, Byte](_.toByte) _)
-    check(prop[Long, Byte](_.toByte) _)
-    check(prop[Short, Byte](_.toByte) _)
+//     // numericToByte
+//     check(prop[BigDecimal, Byte](_.toByte) _)
+//     check(prop[Byte, Byte](identity) _)
+//     check(prop[Double, Byte](_.toByte) _)
+//     check(prop[Int, Byte](_.toByte) _)
+//     check(prop[Long, Byte](_.toByte) _)
+//     check(prop[Short, Byte](_.toByte) _)
 
-    // numericToDouble
-    check(prop[BigDecimal, Double](_.toDouble) _)
-    check(prop[Byte, Double](_.toDouble) _)
-    check(prop[Double, Double](identity) _)
-    check(prop[Int, Double](_.toDouble) _)
-    check(prop[Long, Double](_.toDouble) _)
-    check(prop[Short, Double](_.toDouble) _)
+//     // numericToDouble
+//     check(prop[BigDecimal, Double](_.toDouble) _)
+//     check(prop[Byte, Double](_.toDouble) _)
+//     check(prop[Double, Double](identity) _)
+//     check(prop[Int, Double](_.toDouble) _)
+//     check(prop[Long, Double](_.toDouble) _)
+//     check(prop[Short, Double](_.toDouble) _)
 
-    // numericToInt
-    check(prop[BigDecimal, Int](_.toInt) _)
-    check(prop[Byte, Int](_.toInt) _)
-    check(prop[Double, Int](_.toInt) _)
-    check(prop[Int, Int](identity) _)
-    check(prop[Long, Int](_.toInt) _)
-    check(prop[Short, Int](_.toInt) _)
+//     // numericToInt
+//     check(prop[BigDecimal, Int](_.toInt) _)
+//     check(prop[Byte, Int](_.toInt) _)
+//     check(prop[Double, Int](_.toInt) _)
+//     check(prop[Int, Int](identity) _)
+//     check(prop[Long, Int](_.toInt) _)
+//     check(prop[Short, Int](_.toInt) _)
 
-    // numericToLong
-    check(prop[BigDecimal, Long](_.toLong) _)
-    check(prop[Byte, Long](_.toLong) _)
-    check(prop[Double, Long](_.toLong) _)
-    check(prop[Int, Long](_.toLong) _)
-    check(prop[Long, Long](identity) _)
-    check(prop[Short, Long](_.toLong) _)
+//     // numericToLong
+//     check(prop[BigDecimal, Long](_.toLong) _)
+//     check(prop[Byte, Long](_.toLong) _)
+//     check(prop[Double, Long](_.toLong) _)
+//     check(prop[Int, Long](_.toLong) _)
+//     check(prop[Long, Long](identity) _)
+//     check(prop[Short, Long](_.toLong) _)
 
-    // numericToShort
-    check(prop[BigDecimal, Short](_.toShort) _)
-    check(prop[Byte, Short](_.toShort) _)
-    check(prop[Double, Short](_.toShort) _)
-    check(prop[Int, Short](_.toShort) _)
-    check(prop[Long, Short](_.toShort) _)
-    check(prop[Short, Short](identity) _)
+//     // numericToShort
+//     check(prop[BigDecimal, Short](_.toShort) _)
+//     check(prop[Byte, Short](_.toShort) _)
+//     check(prop[Double, Short](_.toShort) _)
+//     check(prop[Int, Short](_.toShort) _)
+//     check(prop[Long, Short](_.toShort) _)
+//     check(prop[Short, Short](identity) _)
 
-    // castToString
-    // TODO compare without trailing zeros
-    // check(prop[BigDecimal, String](_.toString()) _)
-    check(prop[Byte, String](_.toString) _)
-    check(prop[Double, String](_.toString) _)
-    check(prop[Int, String](_.toString) _)
-    check(prop[Long, String](_.toString) _)
-    check(prop[Short, String](_.toString) _)
+//     // castToString
+//     // TODO compare without trailing zeros
+//     // check(prop[BigDecimal, String](_.toString()) _)
+//     check(prop[Byte, String](_.toString) _)
+//     check(prop[Double, String](_.toString) _)
+//     check(prop[Int, String](_.toString) _)
+//     check(prop[Long, String](_.toString) _)
+//     check(prop[Short, String](_.toString) _)
 
-    // stringToBoolean
-    val trueStrings = Set("t", "true", "y", "yes", "1")
-    val falseStrings = Set("f", "false", "n", "no", "0")
+//     // stringToBoolean
+//     val trueStrings = Set("t", "true", "y", "yes", "1")
+//     val falseStrings = Set("f", "false", "n", "no", "0")
 
-    def stringToBoolean(str: String): Option[Boolean] = {
-      if (trueStrings(str)) Some(true)
-      else if (falseStrings(str)) Some(false)
-      else None
-    }
+//     def stringToBoolean(str: String): Option[Boolean] = {
+//       if (trueStrings(str)) Some(true)
+//       else if (falseStrings(str)) Some(false)
+//       else None
+//     }
 
-    val stringToBooleanGen = Gen.oneOf(
-      Gen.oneOf(trueStrings.toSeq),
-      Gen.oneOf(falseStrings.toSeq),
-      Arbitrary.arbitrary[String]
-    )
+//     val stringToBooleanGen = Gen.oneOf(
+//       Gen.oneOf(trueStrings.toSeq),
+//       Gen.oneOf(falseStrings.toSeq),
+//       Arbitrary.arbitrary[String]
+//     )
 
-    check(forAll(stringToBooleanGen)(prop(stringToBoolean)))
+//     check(forAll(stringToBooleanGen)(prop(stringToBoolean)))
 
-    // xxxToBoolean
-    check(prop[BigDecimal, Boolean](_ != BigDecimal(0)) _)
-    check(prop[Byte, Boolean](_ != 0) _)
-    check(prop[Double, Boolean](_ != 0) _)
-    check(prop[Int, Boolean](_ != 0) _)
-    check(prop[Long, Boolean](_ != 0L) _)
-    check(prop[Short, Boolean](_ != 0) _)
+//     // xxxToBoolean
+//     check(prop[BigDecimal, Boolean](_ != BigDecimal(0)) _)
+//     check(prop[Byte, Boolean](_ != 0) _)
+//     check(prop[Double, Boolean](_ != 0) _)
+//     check(prop[Int, Boolean](_ != 0) _)
+//     check(prop[Long, Boolean](_ != 0L) _)
+//     check(prop[Short, Boolean](_ != 0) _)
 
-    // booleanToNumeric
-    check(prop[Boolean, BigDecimal](x => if (x) BigDecimal(1) else BigDecimal(0)) _)
-    check(prop[Boolean, Byte](x => if (x) 1 else 0) _)
-    check(prop[Boolean, Double](x => if (x) 1.0f else 0.0f) _)
-    check(prop[Boolean, Int](x => if (x) 1 else 0) _)
-    check(prop[Boolean, Long](x => if (x) 1L else 0L) _)
-    check(prop[Boolean, Short](x => if (x) 1 else 0) _)
-  }
+//     // booleanToNumeric
+//     check(prop[Boolean, BigDecimal](x => if (x) BigDecimal(1) else BigDecimal(0)) _)
+//     check(prop[Boolean, Byte](x => if (x) 1 else 0) _)
+//     check(prop[Boolean, Double](x => if (x) 1.0f else 0.0f) _)
+//     check(prop[Boolean, Int](x => if (x) 1 else 0) _)
+//     check(prop[Boolean, Long](x => if (x) 1L else 0L) _)
+//     check(prop[Boolean, Short](x => if (x) 1 else 0) _)
+//   }
 
-}
+// }

--- a/dataset/src/test/scala/frameless/ColTests.scala
+++ b/dataset/src/test/scala/frameless/ColTests.scala
@@ -33,25 +33,25 @@ class ColTests extends TypedDatasetSuite {
     type X2X2 = X2[X2[Int, String], X2[Long, Boolean]]
     val x2x2 = TypedDataset.create[X2X2](Nil)
 
-    val aa: TypedColumn[X2X2, Int] = x2x2.colMany('a, 'a)
-    val ab: TypedColumn[X2X2, String] = x2x2.colMany('a, 'b)
-    val ba: TypedColumn[X2X2, Long] = x2x2.colMany('b, 'a)
-    val bb: TypedColumn[X2X2, Boolean] = x2x2.colMany('b, 'b)
+    val aa: TypedColumn[Int] = x2x2.colMany('a, 'a)
+    val ab: TypedColumn[String] = x2x2.colMany('a, 'b)
+    val ba: TypedColumn[Long] = x2x2.colMany('b, 'a)
+    val bb: TypedColumn[Boolean] = x2x2.colMany('b, 'b)
 
     illTyped("x2x2.colMany('a, 'c)")
     illTyped("x2x2.colMany('a, 'a, 'a)")
   }
 
-  test("select colMany") {
-    def prop[A: TypedEncoder](x: X2[X2[A, A], A]): Prop = {
-      val df = TypedDataset.create(x :: Nil)
-      val got = df.select(df.colMany('a, 'a)).collect().run()
+  // test("select colMany") {
+  //   def prop[A: TypedEncoder](x: X2[X2[A, A], A]): Prop = {
+  //     val df = TypedDataset.create(x :: Nil)
+  //     val got = df.select(df.colMany('a, 'a)).collect().run()
 
-      got ?= (x.a.a :: Nil)
-    }
+  //     got ?= (x.a.a :: Nil)
+  //   }
 
-    check(prop[Int] _)
-    check(prop[X2[Int, Int]] _)
-    check(prop[X2[X2[Int, Int], Int]] _)
-  }
+  //   check(prop[Int] _)
+  //   check(prop[X2[Int, Int]] _)
+  //   check(prop[X2[X2[Int, Int], Int]] _)
+  // }
 }

--- a/dataset/src/test/scala/frameless/GroupByTests.scala
+++ b/dataset/src/test/scala/frameless/GroupByTests.scala
@@ -1,198 +1,198 @@
-package frameless
+// package frameless
 
-import frameless.functions.aggregate._
-import org.scalacheck.Prop
-import org.scalacheck.Prop._
+// import frameless.functions.aggregate._
+// import org.scalacheck.Prop
+// import org.scalacheck.Prop._
 
-class GroupByTests extends TypedDatasetSuite {
-  // Datasets are coalesced due to https://issues.apache.org/jira/browse/SPARK-12675
-  test("groupByMany('a).agg(sum('b))") {
-    def prop[
-      A: TypedEncoder : Ordering,
-      B: TypedEncoder : CatalystSummable : Numeric
-    ](data: List[X2[A, B]]): Prop = {
-      val dataset = TypedDataset.create(data).coalesce(2)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
+// class GroupByTests extends TypedDatasetSuite {
+//   // Datasets are coalesced due to https://issues.apache.org/jira/browse/SPARK-12675
+//   test("groupByMany('a).agg(sum('b))") {
+//     def prop[
+//       A: TypedEncoder : Ordering,
+//       B: TypedEncoder : CatalystSummable : Numeric
+//     ](data: List[X2[A, B]]): Prop = {
+//       val dataset = TypedDataset.create(data).coalesce(2)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
 
-      val datasetSumByA = dataset.groupByMany(A).agg(sum(B)).collect().run.toVector.sortBy(_._1)
-      val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
+//       val datasetSumByA = dataset.groupByMany(A).agg(sum(B)).collect().run.toVector.sortBy(_._1)
+//       val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
 
-      datasetSumByA ?= sumByA
-    }
+//       datasetSumByA ?= sumByA
+//     }
 
-    check(forAll(prop[Int, Long] _))
-  }
+//     check(forAll(prop[Int, Long] _))
+//   }
 
-  test("groupBy('a).agg(sum('b))") {
-    def prop[
-      A: TypedEncoder : Ordering,
-      B: TypedEncoder : CatalystSummable : Numeric
-    ](data: List[X2[A, B]]): Prop = {
-      val dataset = TypedDataset.create(data).coalesce(2)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
+//   test("groupBy('a).agg(sum('b))") {
+//     def prop[
+//       A: TypedEncoder : Ordering,
+//       B: TypedEncoder : CatalystSummable : Numeric
+//     ](data: List[X2[A, B]]): Prop = {
+//       val dataset = TypedDataset.create(data).coalesce(2)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
 
-      val datasetSumByA = dataset.groupBy(A).agg(sum(B)).collect().run.toVector.sortBy(_._1)
-      val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
+//       val datasetSumByA = dataset.groupBy(A).agg(sum(B)).collect().run.toVector.sortBy(_._1)
+//       val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
 
-      datasetSumByA ?= sumByA
-    }
+//       datasetSumByA ?= sumByA
+//     }
 
-    check(forAll(prop[Int, Long] _))
-  }
+//     check(forAll(prop[Int, Long] _))
+//   }
 
-  test("groupBy('a).mapGroups('a, sum('b))") {
-    def prop[
-      A: TypedEncoder : Ordering,
-      B: TypedEncoder : CatalystSummable : Numeric
-    ](data: List[X2[A, B]]): Prop = {
-      val dataset = TypedDataset.create(data).coalesce(2)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
+//   test("groupBy('a).mapGroups('a, sum('b))") {
+//     def prop[
+//       A: TypedEncoder : Ordering,
+//       B: TypedEncoder : CatalystSummable : Numeric
+//     ](data: List[X2[A, B]]): Prop = {
+//       val dataset = TypedDataset.create(data).coalesce(2)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
 
-      val datasetSumByA = dataset.groupBy(A)
-        .mapGroups { case (a, xs) => (a, xs.map(_.b).sum) }
-        .collect().run().toVector.sortBy(_._1)
-      val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
+//       val datasetSumByA = dataset.groupBy(A)
+//         .mapGroups { case (a, xs) => (a, xs.map(_.b).sum) }
+//         .collect().run().toVector.sortBy(_._1)
+//       val sumByA = data.groupBy(_.a).mapValues(_.map(_.b).sum).toVector.sortBy(_._1)
 
-      datasetSumByA ?= sumByA
-    }
+//       datasetSumByA ?= sumByA
+//     }
 
-    check(forAll(prop[Int, Long] _))
-  }
+//     check(forAll(prop[Int, Long] _))
+//   }
 
-  test("groupBy('a).agg(sum('b), sum('c))") {
-    def prop[
-      A: TypedEncoder : Ordering,
-      B: TypedEncoder : CatalystSummable : Numeric,
-      C: TypedEncoder : CatalystSummable : Numeric
-    ](data: List[X3[A, B, C]]): Prop = {
-      val dataset = TypedDataset.create(data).coalesce(2)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-      val C = dataset.col[C]('c)
+//   test("groupBy('a).agg(sum('b), sum('c))") {
+//     def prop[
+//       A: TypedEncoder : Ordering,
+//       B: TypedEncoder : CatalystSummable : Numeric,
+//       C: TypedEncoder : CatalystSummable : Numeric
+//     ](data: List[X3[A, B, C]]): Prop = {
+//       val dataset = TypedDataset.create(data).coalesce(2)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
+//       val C = dataset.col[C]('c)
 
-      val datasetSumByAB = dataset
-        .groupBy(A)
-        .agg(sum(B), sum(C))
-        .collect().run.toVector.sortBy(_._1)
+//       val datasetSumByAB = dataset
+//         .groupBy(A)
+//         .agg(sum(B), sum(C))
+//         .collect().run.toVector.sortBy(_._1)
 
-      val sumByAB = data.groupBy(_.a).mapValues { xs =>
-        (xs.map(_.b).sum, xs.map(_.c).sum)
-      }.toVector.map {
-        case (a, (b, c)) => (a, b, c)
-      }.sortBy(_._1)
+//       val sumByAB = data.groupBy(_.a).mapValues { xs =>
+//         (xs.map(_.b).sum, xs.map(_.c).sum)
+//       }.toVector.map {
+//         case (a, (b, c)) => (a, b, c)
+//       }.sortBy(_._1)
 
-      datasetSumByAB ?= sumByAB
-    }
+//       datasetSumByAB ?= sumByAB
+//     }
 
-    check(forAll(prop[String, Long, BigDecimal] _))
-  }
+//     check(forAll(prop[String, Long, BigDecimal] _))
+//   }
 
-  test("groupBy('a, 'b).agg(sum('c), sum('d))") {
-    def prop[
-      A: TypedEncoder : Ordering,
-      B: TypedEncoder : Ordering,
-      C: TypedEncoder : CatalystSummable : Numeric,
-      D: TypedEncoder : CatalystSummable : Numeric
-    ](data: List[X4[A, B, C, D]]): Prop = {
-      val dataset = TypedDataset.create(data).coalesce(2)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-      val C = dataset.col[C]('c)
-      val D = dataset.col[D]('d)
+//   test("groupBy('a, 'b).agg(sum('c), sum('d))") {
+//     def prop[
+//       A: TypedEncoder : Ordering,
+//       B: TypedEncoder : Ordering,
+//       C: TypedEncoder : CatalystSummable : Numeric,
+//       D: TypedEncoder : CatalystSummable : Numeric
+//     ](data: List[X4[A, B, C, D]]): Prop = {
+//       val dataset = TypedDataset.create(data).coalesce(2)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
+//       val C = dataset.col[C]('c)
+//       val D = dataset.col[D]('d)
 
-      val datasetSumByAB = dataset
-        .groupBy(A, B)
-        .agg(sum(C), sum(D))
-        .collect().run.toVector.sortBy(x => (x._1, x._2))
+//       val datasetSumByAB = dataset
+//         .groupBy(A, B)
+//         .agg(sum(C), sum(D))
+//         .collect().run.toVector.sortBy(x => (x._1, x._2))
 
-      val sumByAB = data.groupBy(x => (x.a, x.b)).mapValues { xs =>
-        (xs.map(_.c).sum, xs.map(_.d).sum)
-      }.toVector.map {
-        case ((a, b), (c, d)) => (a, b, c, d)
-      }.sortBy(x => (x._1, x._2))
+//       val sumByAB = data.groupBy(x => (x.a, x.b)).mapValues { xs =>
+//         (xs.map(_.c).sum, xs.map(_.d).sum)
+//       }.toVector.map {
+//         case ((a, b), (c, d)) => (a, b, c, d)
+//       }.sortBy(x => (x._1, x._2))
 
-      datasetSumByAB ?= sumByAB
-    }
+//       datasetSumByAB ?= sumByAB
+//     }
 
-    check(forAll(prop[Byte, Int, Long, BigDecimal] _))
-  }
+//     check(forAll(prop[Byte, Int, Long, BigDecimal] _))
+//   }
 
-  test("groupBy('a, 'b).mapGroups('a, 'b, sum('c))") {
-    def prop[
-      A: TypedEncoder : Ordering,
-      B: TypedEncoder : Ordering,
-      C: TypedEncoder : CatalystSummable : Numeric
-    ](data: List[X3[A, B, C]]): Prop = {
-      val dataset = TypedDataset.create(data).coalesce(2)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-      val C = dataset.col[C]('c)
+//   test("groupBy('a, 'b).mapGroups('a, 'b, sum('c))") {
+//     def prop[
+//       A: TypedEncoder : Ordering,
+//       B: TypedEncoder : Ordering,
+//       C: TypedEncoder : CatalystSummable : Numeric
+//     ](data: List[X3[A, B, C]]): Prop = {
+//       val dataset = TypedDataset.create(data).coalesce(2)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
+//       val C = dataset.col[C]('c)
 
-      val datasetSumByAB = dataset
-        .groupBy(A, B)
-        .mapGroups { case ((a, b), xs) => (a, b, xs.map(_.c).sum) }
-        .collect().run().toVector.sortBy(x => (x._1, x._2))
+//       val datasetSumByAB = dataset
+//         .groupBy(A, B)
+//         .mapGroups { case ((a, b), xs) => (a, b, xs.map(_.c).sum) }
+//         .collect().run().toVector.sortBy(x => (x._1, x._2))
 
-      val sumByAB = data.groupBy(x => (x.a, x.b))
-        .mapValues { xs => xs.map(_.c).sum }
-        .toVector.map { case ((a, b), c) => (a, b, c) }.sortBy(x => (x._1, x._2))
+//       val sumByAB = data.groupBy(x => (x.a, x.b))
+//         .mapValues { xs => xs.map(_.c).sum }
+//         .toVector.map { case ((a, b), c) => (a, b, c) }.sortBy(x => (x._1, x._2))
 
-      datasetSumByAB ?= sumByAB
-    }
+//       datasetSumByAB ?= sumByAB
+//     }
 
-    check(forAll(prop[Byte, Int, Long] _))
-  }
+//     check(forAll(prop[Byte, Int, Long] _))
+//   }
 
-  test("groupBy('a).mapGroups(('a, toVector(('a, 'b))") {
-    def prop[
-      A: TypedEncoder,
-      B: TypedEncoder
-    ](data: Vector[X2[A, B]]): Prop = {
-      val dataset = TypedDataset.create(data).coalesce(2)
-      val A = dataset.col[A]('a)
+//   test("groupBy('a).mapGroups(('a, toVector(('a, 'b))") {
+//     def prop[
+//       A: TypedEncoder,
+//       B: TypedEncoder
+//     ](data: Vector[X2[A, B]]): Prop = {
+//       val dataset = TypedDataset.create(data).coalesce(2)
+//       val A = dataset.col[A]('a)
 
-      val datasetGrouped = dataset
-        .groupBy(A)
-        .mapGroups((a, xs) => (a, xs.toVector))
-        .collect().run.toMap
+//       val datasetGrouped = dataset
+//         .groupBy(A)
+//         .mapGroups((a, xs) => (a, xs.toVector))
+//         .collect().run.toMap
 
-      val dataGrouped = data.groupBy(_.a)
+//       val dataGrouped = data.groupBy(_.a)
 
-      datasetGrouped ?= dataGrouped
-    }
+//       datasetGrouped ?= dataGrouped
+//     }
 
-    check(forAll(prop[Short, Option[Short]] _))
-    check(forAll(prop[Option[Short], Short] _))
-    check(forAll(prop[X1[Option[Short]], Short] _))
-  }
+//     check(forAll(prop[Short, Option[Short]] _))
+//     check(forAll(prop[Option[Short], Short] _))
+//     check(forAll(prop[X1[Option[Short]], Short] _))
+//   }
 
-  test("groupBy('a).flatMapGroups(('a, toVector(('a, 'b))") {
-    def prop[
-      A: TypedEncoder : Ordering,
-      B: TypedEncoder : Ordering
-    ](data: Vector[X2[A, B]]): Prop = {
-      val dataset = TypedDataset.create(data).coalesce(2)
-      val A = dataset.col[A]('a)
+//   test("groupBy('a).flatMapGroups(('a, toVector(('a, 'b))") {
+//     def prop[
+//       A: TypedEncoder : Ordering,
+//       B: TypedEncoder : Ordering
+//     ](data: Vector[X2[A, B]]): Prop = {
+//       val dataset = TypedDataset.create(data).coalesce(2)
+//       val A = dataset.col[A]('a)
 
-      val datasetGrouped = dataset
-        .groupBy(A)
-        .flatMapGroups((a, xs) => xs.map(x => (a, x)))
-        .collect().run
-        .sorted
+//       val datasetGrouped = dataset
+//         .groupBy(A)
+//         .flatMapGroups((a, xs) => xs.map(x => (a, x)))
+//         .collect().run
+//         .sorted
 
-      val dataGrouped = data
-        .groupBy(_.a).toSeq
-        .flatMap { case (a, xs) => xs.map(x => (a, x)) }
-        .sorted
+//       val dataGrouped = data
+//         .groupBy(_.a).toSeq
+//         .flatMap { case (a, xs) => xs.map(x => (a, x)) }
+//         .sorted
 
-      datasetGrouped ?= dataGrouped
-    }
+//       datasetGrouped ?= dataGrouped
+//     }
 
-    check(forAll(prop[Short, Option[Short]] _))
-    check(forAll(prop[Option[Short], Short] _))
-    check(forAll(prop[X1[Option[Short]], Short] _))
-  }
-}
+//     check(forAll(prop[Short, Option[Short]] _))
+//     check(forAll(prop[Option[Short], Short] _))
+//     check(forAll(prop[X1[Option[Short]], Short] _))
+//   }
+// }

--- a/dataset/src/test/scala/frameless/JoinTests.scala
+++ b/dataset/src/test/scala/frameless/JoinTests.scala
@@ -1,65 +1,65 @@
-package frameless
+// package frameless
 
-import org.scalacheck.Prop
-import org.scalacheck.Prop._
+// import org.scalacheck.Prop
+// import org.scalacheck.Prop._
 
-class JoinTests extends TypedDatasetSuite {
-  import scala.math.Ordering.Implicits._
+// class JoinTests extends TypedDatasetSuite {
+//   import scala.math.Ordering.Implicits._
 
-  test("ab.joinLeft(ac, ab.a, ac.a)") {
-    def prop[A: TypedEncoder : Ordering, B: Ordering, C: Ordering](left: List[X2[A, B]], right: List[X2[A, C]])(
-      implicit
-      lefte: TypedEncoder[X2[A, B]],
-      righte: TypedEncoder[X2[A, C]],
-      joinede: TypedEncoder[(X2[A, B], Option[X2[A, C]])]
-    ): Prop = {
-      val leftDs = TypedDataset.create(left)
-      val rightDs = TypedDataset.create(right)
-      val joinedDs = leftDs
-        .joinLeft(rightDs, leftDs.col('a), rightDs.col('a))
-        .collect().run().toVector.sorted
+//   test("ab.joinLeft(ac, ab.a, ac.a)") {
+//     def prop[A: TypedEncoder : Ordering, B: Ordering, C: Ordering](left: List[X2[A, B]], right: List[X2[A, C]])(
+//       implicit
+//       lefte: TypedEncoder[X2[A, B]],
+//       righte: TypedEncoder[X2[A, C]],
+//       joinede: TypedEncoder[(X2[A, B], Option[X2[A, C]])]
+//     ): Prop = {
+//       val leftDs = TypedDataset.create(left)
+//       val rightDs = TypedDataset.create(right)
+//       val joinedDs = leftDs
+//         .joinLeft(rightDs, leftDs.col('a), rightDs.col('a))
+//         .collect().run().toVector.sorted
 
-      val rightKeys = right.map(_.a).toSet
-      val joined = {
-        for {
-          ab <- left
-          ac <- right if ac.a == ab.a
-        } yield (ab, Some(ac))
-      }.toVector ++ {
-        for {
-          ab <- left if !rightKeys.contains(ab.a)
-        } yield (ab, None)
-      }.toVector
+//       val rightKeys = right.map(_.a).toSet
+//       val joined = {
+//         for {
+//           ab <- left
+//           ac <- right if ac.a == ab.a
+//         } yield (ab, Some(ac))
+//       }.toVector ++ {
+//         for {
+//           ab <- left if !rightKeys.contains(ab.a)
+//         } yield (ab, None)
+//       }.toVector
 
-      (joined.sorted ?= joinedDs) && (joinedDs.map(_._1).toSet ?= left.toSet)
-    }
+//       (joined.sorted ?= joinedDs) && (joinedDs.map(_._1).toSet ?= left.toSet)
+//     }
 
-    check(forAll(prop[Int, Long, String] _))
-  }
+//     check(forAll(prop[Int, Long, String] _))
+//   }
 
-  test("ab.join(ac, ab.a, ac.a)") {
-    def prop[A: TypedEncoder : Ordering, B: Ordering, C: Ordering](left: List[X2[A, B]], right: List[X2[A, C]])(
-      implicit
-      lefte: TypedEncoder[X2[A, B]],
-      righte: TypedEncoder[X2[A, C]],
-      joinede: TypedEncoder[(X2[A, B], X2[A, C])]
-    ): Prop = {
-      val leftDs = TypedDataset.create(left)
-      val rightDs = TypedDataset.create(right)
-      val joinedDs = leftDs
-        .join(rightDs, leftDs.col('a), rightDs.col('a))
-        .collect().run().toVector.sorted
+//   test("ab.join(ac, ab.a, ac.a)") {
+//     def prop[A: TypedEncoder : Ordering, B: Ordering, C: Ordering](left: List[X2[A, B]], right: List[X2[A, C]])(
+//       implicit
+//       lefte: TypedEncoder[X2[A, B]],
+//       righte: TypedEncoder[X2[A, C]],
+//       joinede: TypedEncoder[(X2[A, B], X2[A, C])]
+//     ): Prop = {
+//       val leftDs = TypedDataset.create(left)
+//       val rightDs = TypedDataset.create(right)
+//       val joinedDs = leftDs
+//         .join(rightDs, leftDs.col('a), rightDs.col('a))
+//         .collect().run().toVector.sorted
 
-      val joined = {
-        for {
-          ab <- left
-          ac <- right if ac.a == ab.a
-        } yield (ab, ac)
-      }.toVector
+//       val joined = {
+//         for {
+//           ab <- left
+//           ac <- right if ac.a == ab.a
+//         } yield (ab, ac)
+//       }.toVector
 
-      joined.sorted ?= joinedDs
-    }
+//       joined.sorted ?= joinedDs
+//     }
 
-    check(forAll(prop[Int, Long, String] _))
-  }
-}
+//     check(forAll(prop[Int, Long, String] _))
+//   }
+// }

--- a/dataset/src/test/scala/frameless/NumericTests.scala
+++ b/dataset/src/test/scala/frameless/NumericTests.scala
@@ -1,58 +1,58 @@
-package frameless
+// package frameless
 
-import org.scalacheck.Prop
-import org.scalacheck.Prop._
+// import org.scalacheck.Prop
+// import org.scalacheck.Prop._
 
-class NumericTests extends TypedDatasetSuite {
-  test("plus") {
-    def prop[A: TypedEncoder: CatalystNumeric: Numeric](a: A, b: A): Prop = {
-      val df = TypedDataset.create(X2(a, b) :: Nil)
-      val result = implicitly[Numeric[A]].plus(a, b)
-      val got = df.select(df.col('a) + df.col('b)).collect().run()
+// class NumericTests extends TypedDatasetSuite {
+//   test("plus") {
+//     def prop[A: TypedEncoder: CatalystNumeric: Numeric](a: A, b: A): Prop = {
+//       val df = TypedDataset.create(X2(a, b) :: Nil)
+//       val result = implicitly[Numeric[A]].plus(a, b)
+//       val got = df.select(df.col('a) + df.col('b)).collect().run()
 
-      got ?= (result :: Nil)
-    }
+//       got ?= (result :: Nil)
+//     }
 
-    check(prop[BigDecimal] _)
-    check(prop[Byte] _)
-    check(prop[Double] _)
-    check(prop[Int] _)
-    check(prop[Long] _)
-    check(prop[Short] _)
-  }
+//     check(prop[BigDecimal] _)
+//     check(prop[Byte] _)
+//     check(prop[Double] _)
+//     check(prop[Int] _)
+//     check(prop[Long] _)
+//     check(prop[Short] _)
+//   }
 
-  test("minus") {
-    def prop[A: TypedEncoder: CatalystNumeric: Numeric](a: A, b: A): Prop = {
-      val df = TypedDataset.create(X2(a, b) :: Nil)
-      val result = implicitly[Numeric[A]].minus(a, b)
-      val got = df.select(df.col('a) - df.col('b)).collect().run()
+//   test("minus") {
+//     def prop[A: TypedEncoder: CatalystNumeric: Numeric](a: A, b: A): Prop = {
+//       val df = TypedDataset.create(X2(a, b) :: Nil)
+//       val result = implicitly[Numeric[A]].minus(a, b)
+//       val got = df.select(df.col('a) - df.col('b)).collect().run()
 
-      got ?= (result :: Nil)
-    }
+//       got ?= (result :: Nil)
+//     }
 
-    check(prop[BigDecimal] _)
-    check(prop[Byte] _)
-    check(prop[Double] _)
-    check(prop[Int] _)
-    check(prop[Long] _)
-    check(prop[Short] _)
-  }
+//     check(prop[BigDecimal] _)
+//     check(prop[Byte] _)
+//     check(prop[Double] _)
+//     check(prop[Int] _)
+//     check(prop[Long] _)
+//     check(prop[Short] _)
+//   }
 
-  test("multiply") {
-    def prop[A: TypedEncoder: CatalystNumeric: Numeric](a: A, b: A): Prop = {
-      val df = TypedDataset.create(X2(a, b) :: Nil)
-      val sum = implicitly[Numeric[A]].times(a, b)
-      val got = df.select(df.col('a) * df.col('b)).collect().run()
+//   test("multiply") {
+//     def prop[A: TypedEncoder: CatalystNumeric: Numeric](a: A, b: A): Prop = {
+//       val df = TypedDataset.create(X2(a, b) :: Nil)
+//       val sum = implicitly[Numeric[A]].times(a, b)
+//       val got = df.select(df.col('a) * df.col('b)).collect().run()
 
-      got ?= (sum :: Nil)
-    }
+//       got ?= (sum :: Nil)
+//     }
 
-    // FIXME doesn't work ¯\_(ツ)_/¯
-    // check(prop[BigDecimal] _)
-    check(prop[Byte] _)
-    check(prop[Double] _)
-    check(prop[Int] _)
-    check(prop[Long] _)
-    check(prop[Short] _)
-  }
-}
+//     // FIXME doesn't work ¯\_(ツ)_/¯
+//     // check(prop[BigDecimal] _)
+//     check(prop[Byte] _)
+//     check(prop[Double] _)
+//     check(prop[Int] _)
+//     check(prop[Long] _)
+//     check(prop[Short] _)
+//   }
+// }

--- a/dataset/src/test/scala/frameless/SchemaTests.scala
+++ b/dataset/src/test/scala/frameless/SchemaTests.scala
@@ -1,37 +1,37 @@
-package frameless
+// package frameless
 
-import frameless.functions.aggregate._
-import org.scalacheck.Prop
-import org.scalacheck.Prop._
-import org.scalatest.Matchers
+// import frameless.functions.aggregate._
+// import org.scalacheck.Prop
+// import org.scalacheck.Prop._
+// import org.scalatest.Matchers
 
-class SchemaTests extends TypedDatasetSuite with Matchers {
+// class SchemaTests extends TypedDatasetSuite with Matchers {
 
-  def prop[A](dataset: TypedDataset[A]): Prop = {
-    TypedExpressionEncoder.targetStructType(dataset.encoder) ?= dataset.dataset.schema
-  }
+//   def prop[A](dataset: TypedDataset[A]): Prop = {
+//     TypedExpressionEncoder.targetStructType(dataset.encoder) ?= dataset.dataset.schema
+//   }
 
-  test("schema of groupBy('a).agg(sum('b))") {
-    val df0 = TypedDataset.create(X2(1L, 1L) :: Nil)
-    val _a = df0.col('a)
-    val _b = df0.col('b)
+//   test("schema of groupBy('a).agg(sum('b))") {
+//     val df0 = TypedDataset.create(X2(1L, 1L) :: Nil)
+//     val _a = df0.col('a)
+//     val _b = df0.col('b)
 
-    val df = df0.groupBy(_a).agg(sum(_b))
+//     val df = df0.groupBy(_a).agg(sum(_b))
 
-    check(prop(df))
-  }
+//     check(prop(df))
+//   }
 
-  test("schema of select(lit(1L))") {
-    val df0 = TypedDataset.create("test" :: Nil)
-    val df = df0.select(lit(1L))
+//   test("schema of select(lit(1L))") {
+//     val df0 = TypedDataset.create("test" :: Nil)
+//     val df = df0.select(lit(1L))
 
-    check(prop(df))
-  }
+//     check(prop(df))
+//   }
 
-  test("schema of select(lit(1L), lit(2L)).as[X2[Long, Long]]") {
-    val df0 = TypedDataset.create("test" :: Nil)
-    val df = df0.select(lit(1L), lit(2L)).as[X2[Long, Long]]
+//   test("schema of select(lit(1L), lit(2L)).as[X2[Long, Long]]") {
+//     val df0 = TypedDataset.create("test" :: Nil)
+//     val df = df0.select(lit(1L), lit(2L)).as[X2[Long, Long]]
 
-    check(prop(df))
-  }
-}
+//     check(prop(df))
+//   }
+// }

--- a/dataset/src/test/scala/frameless/SelectTests.scala
+++ b/dataset/src/test/scala/frameless/SelectTests.scala
@@ -16,16 +16,14 @@ class SelectTests extends TypedDatasetSuite {
       ca: ClassTag[A]
     ): Prop = {
       val dataset = TypedDataset.create(data)
-      val A = dataset.col[A]('a)
-
-      val dataset2 = dataset.select(A).collect().run().toVector
+      val dataset2 = dataset.select[A](_ / 'a).collect().run().toVector
       val data2 = data.map { case X4(a, _, _, _) => a }
 
       dataset2 ?= data2
     }
 
     check(forAll(prop[Int, Int, Int, Int] _))
-    check(forAll(prop[X2[Int, Int], Int, Int, Int] _))
+    // check(forAll(prop[X2[Int, Int], Int, Int, Int] _))
     check(forAll(prop[String, Int, Int, Int] _))
   }
 
@@ -39,10 +37,7 @@ class SelectTests extends TypedDatasetSuite {
       ca: ClassTag[A]
     ): Prop = {
       val dataset = TypedDataset.create(data)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-
-      val dataset2 = dataset.select(A, B).collect().run().toVector
+      val dataset2 = dataset.select[A, B](s => (s / 'a, s / 'b)).collect().run().toVector
       val data2 = data.map { case X4(a, b, _, _) => (a, b) }
 
       dataset2 ?= data2
@@ -53,343 +48,128 @@ class SelectTests extends TypedDatasetSuite {
     check(forAll(prop[String, String, Int, Int] _))
   }
 
-  test("select('a, 'b, 'c) FROM abcd") {
-    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
-      implicit
-      ea: TypedEncoder[A],
-      eb: TypedEncoder[B],
-      ec: TypedEncoder[C],
-      eab: TypedEncoder[(A, B, C)],
-      ex4: TypedEncoder[X4[A, B, C, D]],
-      ca: ClassTag[A]
-    ): Prop = {
-      val dataset = TypedDataset.create(data)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-      val C = dataset.col[C]('c)
+  // test("select('a.b)") {
+  //   def prop[A, B, C](data: Vector[X2[X2[A, B], C]])(
+  //     implicit
+  //     eabc: TypedEncoder[X2[X2[A, B], C]],
+  //     eb: TypedEncoder[B],
+  //     cb: ClassTag[B]
+  //   ): Prop = {
+  //     val dataset = TypedDataset.create(data)
+  //     val AB = dataset.colMany('a, 'b)
 
-      val dataset2 = dataset.select(A, B, C).collect().run().toVector
-      val data2 = data.map { case X4(a, b, c, _) => (a, b, c) }
+  //     val dataset2 = dataset.select(AB).collect().run().toVector
+  //     val data2 = data.map { case X2(X2(_, b), _) => b }
 
-      dataset2 ?= data2
-    }
+  //     dataset2 ?= data2
+  //   }
 
-    check(forAll(prop[Int, Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int, Int] _))
-    check(forAll(prop[String, String, Int, Int] _))
-  }
+  //   check(forAll(prop[Int, String, Double] _))
+  // }
 
-  test("select('a,'b,'c,'d) FROM abcd") {
-    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
-      implicit
-      ea: TypedEncoder[A],
-      eb: TypedEncoder[B],
-      ec: TypedEncoder[C],
-      ed: TypedEncoder[D],
-      ex4: TypedEncoder[X4[A, B, C, D]],
-      ca: ClassTag[A]
-    ): Prop = {
-      val dataset = TypedDataset.create(data)
-      val a1 = dataset.col[A]('a)
-      val a2 = dataset.col[B]('b)
-      val a3 = dataset.col[C]('c)
-      val a4 = dataset.col[D]('d)
+  // test("select with column expression addition") {
+  //   def prop[A](data: Vector[X1[A]], const: A)(
+  //     implicit
+  //     eabc: TypedEncoder[X1[A]],
+  //     anum: CatalystNumeric[A],
+  //     num: Numeric[A],
+  //     eb: TypedEncoder[A]
+  //   ): Prop = {
+  //     val ds = TypedDataset.create(data)
 
-      val dataset2 = dataset.select(a1, a2, a3, a4).collect().run().toVector
-      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d) }
+  //     val dataset2 = ds.select(ds('a) + const).collect().run().toVector
+  //     val data2 = data.map { case X1(a) => num.plus(a, const) }
 
-      dataset2 ?= data2
-    }
+  //     dataset2 ?= data2
+  //   }
 
-    check(forAll(prop[Int, Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int, Int] _))
-    check(forAll(prop[String, Boolean, Int, Float] _))
-  }
+  //   check(forAll(prop[Short] _))
+  //   check(forAll(prop[Int] _))
+  //   check(forAll(prop[Long] _))
+  //   check(forAll(prop[Double] _))
+  // }
 
-  test("select('a,'b,'c,'d,'a) FROM abcd") {
-    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
-      implicit
-      ea: TypedEncoder[A],
-      eb: TypedEncoder[B],
-      ec: TypedEncoder[C],
-      ed: TypedEncoder[D],
-      ex4: TypedEncoder[X4[A, B, C, D]],
-      ca: ClassTag[A]
-    ): Prop = {
-      val dataset = TypedDataset.create(data)
-      val a1 = dataset.col[A]('a)
-      val a2 = dataset.col[B]('b)
-      val a3 = dataset.col[C]('c)
-      val a4 = dataset.col[D]('d)
+  // test("select with column expression multiplication") {
+  //   def prop[A](data: Vector[X1[A]], const: A)(
+  //     implicit
+  //     eabc: TypedEncoder[X1[A]],
+  //     anum: CatalystNumeric[A],
+  //     num: Numeric[A],
+  //     eb: TypedEncoder[A]
+  //   ): Prop = {
+  //     val ds = TypedDataset.create(data)
 
-      val dataset2 = dataset.select(a1, a2, a3, a4, a1).collect().run().toVector
-      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a) }
+  //     val dataset2 = ds.select(ds('a) * const).collect().run().toVector
+  //     val data2 = data.map { case X1(a) => num.times(a, const) }
 
-      dataset2 ?= data2
-    }
+  //     dataset2 ?= data2
+  //   }
 
-    check(forAll(prop[Int, Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int, Int] _))
-    check(forAll(prop[String, Boolean, Int, Float] _))
-  }
+  //   check(forAll(prop[Short] _))
+  //   check(forAll(prop[Int] _))
+  //   check(forAll(prop[Long] _))
+  //   check(forAll(prop[Double] _))
+  // }
 
-  test("select('a,'b,'c,'d,'a, 'c) FROM abcd") {
-    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
-      implicit
-      ea: TypedEncoder[A],
-      eb: TypedEncoder[B],
-      ec: TypedEncoder[C],
-      ed: TypedEncoder[D],
-      ex4: TypedEncoder[X4[A, B, C, D]],
-      ca: ClassTag[A]
-    ): Prop = {
-      val dataset = TypedDataset.create(data)
-      val a1 = dataset.col[A]('a)
-      val a2 = dataset.col[B]('b)
-      val a3 = dataset.col[C]('c)
-      val a4 = dataset.col[D]('d)
+  // test("select with column expression subtraction") {
+  //   def prop[A](data: Vector[X1[A]], const: A)(
+  //     implicit
+  //     eabc: TypedEncoder[X1[A]],
+  //     cnum: CatalystNumeric[A],
+  //     num: Numeric[A],
+  //     eb: TypedEncoder[A]
+  //   ): Prop = {
+  //     val ds = TypedDataset.create(data)
 
-      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3).collect().run().toVector
-      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c) }
+  //     val dataset2 = ds.select(ds('a) - const).collect().run().toVector
+  //     val data2 = data.map { case X1(a) => num.minus(a, const) }
 
-      dataset2 ?= data2
-    }
+  //     dataset2 ?= data2
+  //   }
 
-    check(forAll(prop[Int, Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int, Int] _))
-    check(forAll(prop[String, Boolean, Int, Float] _))
-  }
+  //   check(forAll(prop[Int] _))
+  //   check(forAll(prop[Long] _))
+  //   check(forAll(prop[Double] _))
+  // }
 
-  test("select('a,'b,'c,'d,'a,'c,'b) FROM abcd") {
-    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
-      implicit
-      ea: TypedEncoder[A],
-      eb: TypedEncoder[B],
-      ec: TypedEncoder[C],
-      ed: TypedEncoder[D],
-      ex4: TypedEncoder[X4[A, B, C, D]],
-      ca: ClassTag[A]
-    ): Prop = {
-      val dataset = TypedDataset.create(data)
-      val a1 = dataset.col[A]('a)
-      val a2 = dataset.col[B]('b)
-      val a3 = dataset.col[C]('c)
-      val a4 = dataset.col[D]('d)
+  // test("select with column expression division") {
+  //   def prop[A](data: Vector[X1[A]], const: A)(
+  //     implicit
+  //     eabc: TypedEncoder[X1[A]],
+  //     anum: CatalystNumeric[A],
+  //     frac: Fractional[A],
+  //     eb: TypedEncoder[A]
+  //   ): Prop = {
+  //     val ds = TypedDataset.create(data)
 
-      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3, a2).collect().run().toVector
-      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c, b) }
+  //     if (const != 0) {
+  //       val dataset2 = ds.select(ds('a) / const).collect().run().toVector.asInstanceOf[Vector[A]]
+  //       val data2 = data.map { case X1(a) => frac.div(a, const) }
+  //       dataset2 ?= data2
+  //     } else 0 ?= 0
+  //   }
 
-      dataset2 ?= data2
-    }
+  //   check(forAll(prop[Double] _))
+  // }
 
-    check(forAll(prop[Int, Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int, Int] _))
-    check(forAll(prop[String, Boolean, Int, Float] _))
-  }
+  // test("tests to cover problematic dataframe column names during projections") {
+  //   case class Foo(i: Int)
+  //   val e = TypedDataset.create[Foo](Foo(1) :: Nil)
+  //   val t: TypedDataset[(Int, Int)] = e.select(e.col('i) * 2, e.col('i))
+  //   assert(t.select(t.col('_1)).collect().run().toList === List(2))
+  //   // Issue #54
+  //   val fooT = t.select(t.col('_1)).map(x => Tuple1.apply(x)).as[Foo]
+  //   assert(fooT.select(fooT('i)).collect().run().toList === List(2))
+  // }
 
-  test("select('a,'b,'c,'d,'a,'c,'b, 'a) FROM abcd") {
-    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
-      implicit
-      ea: TypedEncoder[A],
-      eb: TypedEncoder[B],
-      ec: TypedEncoder[C],
-      ed: TypedEncoder[D],
-      ex4: TypedEncoder[X4[A, B, C, D]],
-      ca: ClassTag[A]
-    ): Prop = {
-      val dataset = TypedDataset.create(data)
-      val a1 = dataset.col[A]('a)
-      val a2 = dataset.col[B]('b)
-      val a3 = dataset.col[C]('c)
-      val a4 = dataset.col[D]('d)
+  // test("unary - on arithmetic") {
+  //   val e = TypedDataset.create[(Int, String, Long)]((1, "a", 2L) :: (2, "b", 4L) :: (2, "b", 1L) :: Nil)
+  //   assert(e.select(-e('_1)).collect().run().toVector === Vector(-1, -2, -2))
+  //   assert(e.select(-(e('_1) + e('_3))).collect().run().toVector === Vector(-3L, -6L, -3L))
+  // }
 
-      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3, a2, a1).collect().run().toVector
-      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c, b, a) }
-
-      dataset2 ?= data2
-    }
-
-    check(forAll(prop[Int, Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int, Int] _))
-    check(forAll(prop[String, Boolean, Int, Float] _))
-  }
-
-  test("select('a,'b,'c,'d,'a,'c,'b,'a,'c) FROM abcd") {
-    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
-      implicit
-      ea: TypedEncoder[A],
-      eb: TypedEncoder[B],
-      ec: TypedEncoder[C],
-      ed: TypedEncoder[D],
-      ex4: TypedEncoder[X4[A, B, C, D]],
-      ca: ClassTag[A]
-    ): Prop = {
-      val dataset = TypedDataset.create(data)
-      val a1 = dataset.col[A]('a)
-      val a2 = dataset.col[B]('b)
-      val a3 = dataset.col[C]('c)
-      val a4 = dataset.col[D]('d)
-
-      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3, a2, a1, a3).collect().run().toVector
-      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c, b, a, c) }
-
-      dataset2 ?= data2
-    }
-
-    check(forAll(prop[Int, Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int, Int] _))
-    check(forAll(prop[String, Boolean, Int, Float] _))
-  }
-
-  test("select('a,'b,'c,'d,'a,'c,'b,'a,'c, 'd) FROM abcd") {
-    def prop[A, B, C, D](data: Vector[X4[A, B, C, D]])(
-      implicit
-      ea: TypedEncoder[A],
-      eb: TypedEncoder[B],
-      ec: TypedEncoder[C],
-      ed: TypedEncoder[D],
-      ex4: TypedEncoder[X4[A, B, C, D]],
-      ca: ClassTag[A]
-    ): Prop = {
-      val dataset = TypedDataset.create(data)
-      val a1 = dataset.col[A]('a)
-      val a2 = dataset.col[B]('b)
-      val a3 = dataset.col[C]('c)
-      val a4 = dataset.col[D]('d)
-
-      val dataset2 = dataset.select(a1, a2, a3, a4, a1, a3, a2, a1, a3, a4).collect().run().toVector
-      val data2 = data.map { case X4(a, b, c, d) => (a, b, c, d, a, c, b, a, c, d) }
-
-      dataset2 ?= data2
-    }
-
-    check(forAll(prop[Int, Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int, Int] _))
-    check(forAll(prop[String, Boolean, Int, Float] _))
-  }
-
-  test("select('a.b)") {
-    def prop[A, B, C](data: Vector[X2[X2[A, B], C]])(
-      implicit
-      eabc: TypedEncoder[X2[X2[A, B], C]],
-      eb: TypedEncoder[B],
-      cb: ClassTag[B]
-    ): Prop = {
-      val dataset = TypedDataset.create(data)
-      val AB = dataset.colMany('a, 'b)
-
-      val dataset2 = dataset.select(AB).collect().run().toVector
-      val data2 = data.map { case X2(X2(_, b), _) => b }
-
-      dataset2 ?= data2
-    }
-
-    check(forAll(prop[Int, String, Double] _))
-  }
-
-  test("select with column expression addition") {
-    def prop[A](data: Vector[X1[A]], const: A)(
-      implicit
-      eabc: TypedEncoder[X1[A]],
-      anum: CatalystNumeric[A],
-      num: Numeric[A],
-      eb: TypedEncoder[A]
-    ): Prop = {
-      val ds = TypedDataset.create(data)
-
-      val dataset2 = ds.select(ds('a) + const).collect().run().toVector
-      val data2 = data.map { case X1(a) => num.plus(a, const) }
-
-      dataset2 ?= data2
-    }
-
-    check(forAll(prop[Short] _))
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Long] _))
-    check(forAll(prop[Double] _))
-  }
-
-  test("select with column expression multiplication") {
-    def prop[A](data: Vector[X1[A]], const: A)(
-      implicit
-      eabc: TypedEncoder[X1[A]],
-      anum: CatalystNumeric[A],
-      num: Numeric[A],
-      eb: TypedEncoder[A]
-    ): Prop = {
-      val ds = TypedDataset.create(data)
-
-      val dataset2 = ds.select(ds('a) * const).collect().run().toVector
-      val data2 = data.map { case X1(a) => num.times(a, const) }
-
-      dataset2 ?= data2
-    }
-
-    check(forAll(prop[Short] _))
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Long] _))
-    check(forAll(prop[Double] _))
-  }
-
-  test("select with column expression subtraction") {
-    def prop[A](data: Vector[X1[A]], const: A)(
-      implicit
-      eabc: TypedEncoder[X1[A]],
-      cnum: CatalystNumeric[A],
-      num: Numeric[A],
-      eb: TypedEncoder[A]
-    ): Prop = {
-      val ds = TypedDataset.create(data)
-
-      val dataset2 = ds.select(ds('a) - const).collect().run().toVector
-      val data2 = data.map { case X1(a) => num.minus(a, const) }
-
-      dataset2 ?= data2
-    }
-
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Long] _))
-    check(forAll(prop[Double] _))
-  }
-
-  test("select with column expression division") {
-    def prop[A](data: Vector[X1[A]], const: A)(
-      implicit
-      eabc: TypedEncoder[X1[A]],
-      anum: CatalystNumeric[A],
-      frac: Fractional[A],
-      eb: TypedEncoder[A]
-    ): Prop = {
-      val ds = TypedDataset.create(data)
-
-      if (const != 0) {
-        val dataset2 = ds.select(ds('a) / const).collect().run().toVector.asInstanceOf[Vector[A]]
-        val data2 = data.map { case X1(a) => frac.div(a, const) }
-        dataset2 ?= data2
-      } else 0 ?= 0
-    }
-
-    check(forAll(prop[Double] _))
-  }
-
-  test("tests to cover problematic dataframe column names during projections") {
-    case class Foo(i: Int)
-    val e = TypedDataset.create[Foo](Foo(1) :: Nil)
-    val t: TypedDataset[(Int, Int)] = e.select(e.col('i) * 2, e.col('i))
-    assert(t.select(t.col('_1)).collect().run().toList === List(2))
-    // Issue #54
-    val fooT = t.select(t.col('_1)).map(x => Tuple1.apply(x)).as[Foo]
-    assert(fooT.select(fooT('i)).collect().run().toList === List(2))
-  }
-
-  test("unary - on arithmetic") {
-    val e = TypedDataset.create[(Int, String, Long)]((1, "a", 2L) :: (2, "b", 4L) :: (2, "b", 1L) :: Nil)
-    assert(e.select(-e('_1)).collect().run().toVector === Vector(-1, -2, -2))
-    assert(e.select(-(e('_1) + e('_3))).collect().run().toVector === Vector(-3L, -6L, -3L))
-  }
-
-  test("unary - on strings should not type check") {
-    val e = TypedDataset.create[(Int, String, Long)]((1, "a", 2L) :: (2, "b", 4L) :: (2, "b", 1L) :: Nil)
-    illTyped("""e.select( -e('_2) )""")
-  }
+  // test("unary - on strings should not type check") {
+  //   val e = TypedDataset.create[(Int, String, Long)]((1, "a", 2L) :: (2, "b", 4L) :: (2, "b", 1L) :: Nil)
+  //   illTyped("""e.select( -e('_2) )""")
+  // }
 }

--- a/dataset/src/test/scala/frameless/WidenTests.scala
+++ b/dataset/src/test/scala/frameless/WidenTests.scala
@@ -1,81 +1,81 @@
-package frameless
+// package frameless
 
-import org.scalacheck.Prop
-import org.scalacheck.Prop._
-import shapeless.test.illTyped
+// import org.scalacheck.Prop
+// import org.scalacheck.Prop._
+// import shapeless.test.illTyped
 
-class WidenTests extends TypedDatasetSuite {
+// class WidenTests extends TypedDatasetSuite {
 
-  // widening is off by default
+//   // widening is off by default
 
-  illTyped("""
-     val df = TypedDataset.create(X2(1, 1.0))
-     df.select(df('a) plus df('b))
-  """)
+//   illTyped("""
+//      val df = TypedDataset.create(X2(1, 1.0))
+//      df.select(df('a) plus df('b))
+//   """)
 
-  def widenSum[A: TypedEncoder: CatalystNumeric: Numeric, B: TypedEncoder](a: A, b: B)(
-    implicit
-    view: B => A,
-    colView: TypedColumn[X2[A, B], B] => TypedColumn[X2[A, B], A]
-  ): Prop = {
-    val df = TypedDataset.create(X2(a, b) :: Nil)
-    val sum = implicitly[Numeric[A]].plus(a, view(b))
+//   def widenSum[A: TypedEncoder: CatalystNumeric: Numeric, B: TypedEncoder](a: A, b: B)(
+//     implicit
+//     view: B => A,
+//     colView: TypedColumn[X2[A, B], B] => TypedColumn[X2[A, B], A]
+//   ): Prop = {
+//     val df = TypedDataset.create(X2(a, b) :: Nil)
+//     val sum = implicitly[Numeric[A]].plus(a, view(b))
 
-    val leftGot = df.select(df.col('a) plus df.col('b)).collect().run()
-    val rightGot = df.select(df.col('b) plus df.col('a)).collect().run()
+//     val leftGot = df.select(df.col('a) plus df.col('b)).collect().run()
+//     val rightGot = df.select(df.col('b) plus df.col('a)).collect().run()
 
-    (leftGot ?= (sum :: Nil)) &&
-      (rightGot ?= (sum :: Nil))
-  }
+//     (leftGot ?= (sum :: Nil)) &&
+//       (rightGot ?= (sum :: Nil))
+//   }
 
-  def widen[A: TypedEncoder, B: TypedEncoder](a: A)(
-    implicit
-    view: A => B,
-    colView: TypedColumn[X1[A], A] => TypedColumn[X1[A], B]
-  ): Prop = {
-    val df = TypedDataset.create(X1(a) :: Nil)
-    val got = df.select(colView(df.col('a))).collect().run()
+//   def widen[A: TypedEncoder, B: TypedEncoder](a: A)(
+//     implicit
+//     view: A => B,
+//     colView: TypedColumn[X1[A], A] => TypedColumn[X1[A], B]
+//   ): Prop = {
+//     val df = TypedDataset.create(X1(a) :: Nil)
+//     val got = df.select(colView(df.col('a))).collect().run()
 
-    got ?= (view(a) :: Nil)
-  }
+//     got ?= (view(a) :: Nil)
+//   }
 
-  {
-    import frameless.implicits.widen._
+//   {
+//     import frameless.implicits.widen._
 
-    test("widen sum") {
-      check(widenSum[Double, Int] _)
-    }
+//     test("widen sum") {
+//       check(widenSum[Double, Int] _)
+//     }
 
-    test("widen") {
-      implicit def byteToBigDecimal(x: Byte): BigDecimal = BigDecimal.valueOf(x.toLong)
-      implicit def shortToBigDecimal(x: Short): BigDecimal = BigDecimal.valueOf(x.toLong)
+//     test("widen") {
+//       implicit def byteToBigDecimal(x: Byte): BigDecimal = BigDecimal.valueOf(x.toLong)
+//       implicit def shortToBigDecimal(x: Short): BigDecimal = BigDecimal.valueOf(x.toLong)
 
-      check(widen[Byte, Short] _)
-      check(widen[Byte, Int] _)
-      check(widen[Byte, Long] _)
-      check(widen[Byte, Double] _)
-      check(widen[Byte, BigDecimal] _)
+//       check(widen[Byte, Short] _)
+//       check(widen[Byte, Int] _)
+//       check(widen[Byte, Long] _)
+//       check(widen[Byte, Double] _)
+//       check(widen[Byte, BigDecimal] _)
 
-      check(widen[Short, Int] _)
-      check(widen[Short, Long] _)
-      check(widen[Short, Double] _)
-      check(widen[Short, BigDecimal] _)
+//       check(widen[Short, Int] _)
+//       check(widen[Short, Long] _)
+//       check(widen[Short, Double] _)
+//       check(widen[Short, BigDecimal] _)
 
-      check(widen[Int, Long] _)
-      check(widen[Int, Double] _)
-      check(widen[Int, BigDecimal] _)
+//       check(widen[Int, Long] _)
+//       check(widen[Int, Double] _)
+//       check(widen[Int, BigDecimal] _)
 
-      check(widen[Long, Double] _)
-      check(widen[Long, BigDecimal] _)
+//       check(widen[Long, Double] _)
+//       check(widen[Long, BigDecimal] _)
 
-      check(widen[Double, BigDecimal] _)
+//       check(widen[Double, BigDecimal] _)
 
-      // this is lawful (or not?) when we have Float
-      // check(widen[Byte, Float] _)
-      // check(widen[Short, Float] _)
-      // check(widen[Int, Float] _)
-      // check(widen[Long, Float] _)
-    }
-  }
+//       // this is lawful (or not?) when we have Float
+//       // check(widen[Byte, Float] _)
+//       // check(widen[Short, Float] _)
+//       // check(widen[Int, Float] _)
+//       // check(widen[Long, Float] _)
+//     }
+//   }
 
-}
+// }

--- a/dataset/src/test/scala/frameless/functions/AggregateFunctionsTests.scala
+++ b/dataset/src/test/scala/frameless/functions/AggregateFunctionsTests.scala
@@ -1,241 +1,241 @@
-package frameless
-package functions
+// package frameless
+// package functions
 
-import frameless.functions.aggregate._
-import org.scalacheck.Prop
-import org.scalacheck.Prop._
+// import frameless.functions.aggregate._
+// import org.scalacheck.Prop
+// import org.scalacheck.Prop._
 
-class AggregateFunctionsTests extends TypedDatasetSuite {
+// class AggregateFunctionsTests extends TypedDatasetSuite {
 
-  def approximatelyEqual[A](a: A, b: A)(implicit numeric: Numeric[A]): Prop = {
-    val da = numeric.toDouble(a)
-    val db = numeric.toDouble(b)
-    val epsilon = 1E-6
-    // Spark has a weird behaviour concerning expressions that should return Inf
-    // Most of the time they return NaN instead, for instance stddev of Seq(-7.827553978923477E227, -5.009124275715786E153)
-    if((da.isNaN || da.isInfinity) && (db.isNaN || db.isInfinity)) proved
-    else if (
-      (da - db).abs < epsilon ||
-      (da - db).abs < da.abs / 100)
-        proved
-    else falsified :| s"Expected $a but got $b, which is more than 1% off and greater than epsilon = $epsilon."
-  }
+//   def approximatelyEqual[A](a: A, b: A)(implicit numeric: Numeric[A]): Prop = {
+//     val da = numeric.toDouble(a)
+//     val db = numeric.toDouble(b)
+//     val epsilon = 1E-6
+//     // Spark has a weird behaviour concerning expressions that should return Inf
+//     // Most of the time they return NaN instead, for instance stddev of Seq(-7.827553978923477E227, -5.009124275715786E153)
+//     if((da.isNaN || da.isInfinity) && (db.isNaN || db.isInfinity)) proved
+//     else if (
+//       (da - db).abs < epsilon ||
+//       (da - db).abs < da.abs / 100)
+//         proved
+//     else falsified :| s"Expected $a but got $b, which is more than 1% off and greater than epsilon = $epsilon."
+//   }
 
-  test("sum") {
-    def prop[A: TypedEncoder : Numeric : CatalystSummable](xs: List[A])(
-      implicit
-      eoa: TypedEncoder[Option[A]],
-      ex1: TypedEncoder[X1[A]]
-    ): Prop = {
-      val dataset = TypedDataset.create(xs.map(X1(_)))
-      val A = dataset.col[A]('a)
+//   test("sum") {
+//     def prop[A: TypedEncoder : Numeric : CatalystSummable](xs: List[A])(
+//       implicit
+//       eoa: TypedEncoder[Option[A]],
+//       ex1: TypedEncoder[X1[A]]
+//     ): Prop = {
+//       val dataset = TypedDataset.create(xs.map(X1(_)))
+//       val A = dataset.col[A]('a)
 
-      val datasetSum = dataset.select(sum(A)).collect().run().toList
+//       val datasetSum = dataset.select(sum(A)).collect().run().toList
 
-      datasetSum match {
-        case x :: Nil => approximatelyEqual(x, xs.sum)
-        case other => falsified
-      }
-    }
+//       datasetSum match {
+//         case x :: Nil => approximatelyEqual(x, xs.sum)
+//         case other => falsified
+//       }
+//     }
 
-    check(forAll(prop[BigDecimal] _))
-    check(forAll(prop[Long] _))
-    check(forAll(prop[Double] _))
+//     check(forAll(prop[BigDecimal] _))
+//     check(forAll(prop[Long] _))
+//     check(forAll(prop[Double] _))
 
-    // doesn't work yet because resulting type is different
-    // check(forAll(prop[Int] _))
-    // check(forAll(prop[Short]_))
-    // check(forAll(prop[Byte]_))
-  }
+//     // doesn't work yet because resulting type is different
+//     // check(forAll(prop[Int] _))
+//     // check(forAll(prop[Short]_))
+//     // check(forAll(prop[Byte]_))
+//   }
 
-  test("avg") {
-    def prop[A: TypedEncoder : Averageable](xs: List[A])(
-      implicit
-      fractional: Fractional[A],
-      eoa: TypedEncoder[Option[A]],
-      ex1: TypedEncoder[X1[A]]
-    ): Prop = {
-      val dataset = TypedDataset.create(xs.map(X1(_)))
-      val A = dataset.col[A]('a)
+//   test("avg") {
+//     def prop[A: TypedEncoder : Averageable](xs: List[A])(
+//       implicit
+//       fractional: Fractional[A],
+//       eoa: TypedEncoder[Option[A]],
+//       ex1: TypedEncoder[X1[A]]
+//     ): Prop = {
+//       val dataset = TypedDataset.create(xs.map(X1(_)))
+//       val A = dataset.col[A]('a)
 
-      val Vector(datasetAvg) = dataset.select(avg(A)).collect().run().toVector
+//       val Vector(datasetAvg) = dataset.select(avg(A)).collect().run().toVector
 
-      xs match {
-        case Nil => datasetAvg ?= None
-        case _ :: _ => datasetAvg match {
-          case Some(x) => approximatelyEqual(fractional.div(xs.sum, fractional.fromInt(xs.size)), x)
-          case other => falsified
-        }
-      }
-    }
+//       xs match {
+//         case Nil => datasetAvg ?= None
+//         case _ :: _ => datasetAvg match {
+//           case Some(x) => approximatelyEqual(fractional.div(xs.sum, fractional.fromInt(xs.size)), x)
+//           case other => falsified
+//         }
+//       }
+//     }
 
-    check(forAll(prop[BigDecimal] _))
-    check(forAll(prop[Double] _))
-  }
+//     check(forAll(prop[BigDecimal] _))
+//     check(forAll(prop[Double] _))
+//   }
 
-  test("stddev") {
+//   test("stddev") {
 
-    def prop[A: TypedEncoder : Variance : Fractional : Numeric](xs: List[A])(
-      implicit
-      eoa: TypedEncoder[Option[A]],
-      ex1: TypedEncoder[X1[A]]
-    ): Prop = {
-      val dataset = TypedDataset.create(xs.map(X1(_)))
-      val A = dataset.col[A]('a)
+//     def prop[A: TypedEncoder : Variance : Fractional : Numeric](xs: List[A])(
+//       implicit
+//       eoa: TypedEncoder[Option[A]],
+//       ex1: TypedEncoder[X1[A]]
+//     ): Prop = {
+//       val dataset = TypedDataset.create(xs.map(X1(_)))
+//       val A = dataset.col[A]('a)
 
-      val Vector(datasetStd) = dataset.select(stddev(A)).collect().run().toVector
-      val std = sc.parallelize(xs.map(implicitly[Numeric[A]].toDouble)).sampleStdev()
+//       val Vector(datasetStd) = dataset.select(stddev(A)).collect().run().toVector
+//       val std = sc.parallelize(xs.map(implicitly[Numeric[A]].toDouble)).sampleStdev()
 
-      xs match {
-        case Nil => datasetStd ?= None
-        case _ :: Nil => datasetStd match {
-          case Some(x) => if (implicitly[Numeric[A]].toDouble(x).isNaN) proved else falsified
-          case _ => falsified
-        }
-        case _ => datasetStd match {
-          case Some(x) => approximatelyEqual(std, implicitly[Numeric[A]].toDouble(x))
-          case _ => falsified
-        }
-      }
-    }
+//       xs match {
+//         case Nil => datasetStd ?= None
+//         case _ :: Nil => datasetStd match {
+//           case Some(x) => if (implicitly[Numeric[A]].toDouble(x).isNaN) proved else falsified
+//           case _ => falsified
+//         }
+//         case _ => datasetStd match {
+//           case Some(x) => approximatelyEqual(std, implicitly[Numeric[A]].toDouble(x))
+//           case _ => falsified
+//         }
+//       }
+//     }
 
-    check(forAll(prop[Double] _))
-  }
+//     check(forAll(prop[Double] _))
+//   }
 
-  test("count") {
-    def prop[A: TypedEncoder](xs: List[A]): Prop = {
-      val dataset = TypedDataset.create(xs)
-      val Vector(datasetCount) = dataset.select(count()).collect().run().toVector
+//   test("count") {
+//     def prop[A: TypedEncoder](xs: List[A]): Prop = {
+//       val dataset = TypedDataset.create(xs)
+//       val Vector(datasetCount) = dataset.select(count()).collect().run().toVector
 
-      datasetCount ?= xs.size.toLong
-    }
+//       datasetCount ?= xs.size.toLong
+//     }
 
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Byte] _))
-  }
+//     check(forAll(prop[Int] _))
+//     check(forAll(prop[Byte] _))
+//   }
 
-  test("count('a)") {
-    def prop[A: TypedEncoder](xs: List[A])(implicit ex1: TypedEncoder[X1[A]]): Prop = {
-      val dataset = TypedDataset.create(xs.map(X1(_)))
-      val A = dataset.col[A]('a)
-      val Vector(datasetCount) = dataset.select(count(A)).collect().run().toVector
+//   test("count('a)") {
+//     def prop[A: TypedEncoder](xs: List[A])(implicit ex1: TypedEncoder[X1[A]]): Prop = {
+//       val dataset = TypedDataset.create(xs.map(X1(_)))
+//       val A = dataset.col[A]('a)
+//       val Vector(datasetCount) = dataset.select(count(A)).collect().run().toVector
 
-      datasetCount ?= xs.size.toLong
-    }
+//       datasetCount ?= xs.size.toLong
+//     }
 
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Byte] _))
-  }
+//     check(forAll(prop[Int] _))
+//     check(forAll(prop[Byte] _))
+//   }
 
-  test("max") {
-    def prop[A: TypedEncoder : Ordering](xs: List[A])(
-      implicit
-      ex1: TypedEncoder[X1[A]],
-      eoa: TypedEncoder[Option[A]]
-    ): Prop = {
-      val dataset = TypedDataset.create(xs.map(X1(_)))
-      val A = dataset.col[A]('a)
-      val datasetMax = dataset.select(max(A)).collect().run().toList.head
+//   test("max") {
+//     def prop[A: TypedEncoder : Ordering](xs: List[A])(
+//       implicit
+//       ex1: TypedEncoder[X1[A]],
+//       eoa: TypedEncoder[Option[A]]
+//     ): Prop = {
+//       val dataset = TypedDataset.create(xs.map(X1(_)))
+//       val A = dataset.col[A]('a)
+//       val datasetMax = dataset.select(max(A)).collect().run().toList.head
 
-      xs match {
-        case Nil => datasetMax.isEmpty
-        case xs => datasetMax match {
-          case Some(m) => xs.max ?= m
-          case _ => falsified
-        }
-      }
-    }
+//       xs match {
+//         case Nil => datasetMax.isEmpty
+//         case xs => datasetMax match {
+//           case Some(m) => xs.max ?= m
+//           case _ => falsified
+//         }
+//       }
+//     }
 
-    check(forAll(prop[Long] _))
-    check(forAll(prop[Double] _))
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Short] _))
-    check(forAll(prop[Byte] _))
-    check(forAll(prop[String] _))
-  }
+//     check(forAll(prop[Long] _))
+//     check(forAll(prop[Double] _))
+//     check(forAll(prop[Int] _))
+//     check(forAll(prop[Short] _))
+//     check(forAll(prop[Byte] _))
+//     check(forAll(prop[String] _))
+//   }
 
-  test("min") {
-    def prop[A: TypedEncoder : Ordering](xs: List[A])(
-      implicit
-      ex1: TypedEncoder[X1[A]],
-      eoa: TypedEncoder[Option[A]]
-    ): Prop = {
-      val dataset = TypedDataset.create(xs.map(X1(_)))
-      val A = dataset.col[A]('a)
+//   test("min") {
+//     def prop[A: TypedEncoder : Ordering](xs: List[A])(
+//       implicit
+//       ex1: TypedEncoder[X1[A]],
+//       eoa: TypedEncoder[Option[A]]
+//     ): Prop = {
+//       val dataset = TypedDataset.create(xs.map(X1(_)))
+//       val A = dataset.col[A]('a)
 
-      val datasetMin = dataset.select(min(A)).collect().run().toList.head
-      xs match {
-        case Nil => datasetMin.isEmpty
-        case xs => datasetMin match {
-          case Some(m) => xs.min ?= m
-          case _ => falsified
-        }
-      }
-    }
+//       val datasetMin = dataset.select(min(A)).collect().run().toList.head
+//       xs match {
+//         case Nil => datasetMin.isEmpty
+//         case xs => datasetMin match {
+//           case Some(m) => xs.min ?= m
+//           case _ => falsified
+//         }
+//       }
+//     }
 
-    check(forAll(prop[Long] _))
-    check(forAll(prop[Double] _))
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Short] _))
-    check(forAll(prop[Byte] _))
-    check(forAll(prop[String] _))
-  }
+//     check(forAll(prop[Long] _))
+//     check(forAll(prop[Double] _))
+//     check(forAll(prop[Int] _))
+//     check(forAll(prop[Short] _))
+//     check(forAll(prop[Byte] _))
+//     check(forAll(prop[String] _))
+//   }
 
-  test("first") {
-    def prop[A: TypedEncoder](xs: List[A])(
-      implicit
-      ex1: TypedEncoder[X1[A]],
-      eoa: TypedEncoder[Option[A]]
-    ): Prop = {
-      val dataset = TypedDataset.create(xs.map(X1(_)))
-      val A = dataset.col[A]('a)
+//   test("first") {
+//     def prop[A: TypedEncoder](xs: List[A])(
+//       implicit
+//       ex1: TypedEncoder[X1[A]],
+//       eoa: TypedEncoder[Option[A]]
+//     ): Prop = {
+//       val dataset = TypedDataset.create(xs.map(X1(_)))
+//       val A = dataset.col[A]('a)
 
-      val datasetFirst :: Nil = dataset.select(first(A)).collect().run().toList
+//       val datasetFirst :: Nil = dataset.select(first(A)).collect().run().toList
 
-      xs match {
-        case Nil => datasetFirst.isEmpty
-        case x::_ => datasetFirst match {
-          case Some(m) => x ?= m
-          case _ => falsified
-        }
-      }
-    }
+//       xs match {
+//         case Nil => datasetFirst.isEmpty
+//         case x::_ => datasetFirst match {
+//           case Some(m) => x ?= m
+//           case _ => falsified
+//         }
+//       }
+//     }
 
-    check(forAll(prop[BigDecimal] _))
-    check(forAll(prop[Long] _))
-    check(forAll(prop[Double] _))
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Short] _))
-    check(forAll(prop[Byte] _))
-    check(forAll(prop[String] _))
-  }
+//     check(forAll(prop[BigDecimal] _))
+//     check(forAll(prop[Long] _))
+//     check(forAll(prop[Double] _))
+//     check(forAll(prop[Int] _))
+//     check(forAll(prop[Short] _))
+//     check(forAll(prop[Byte] _))
+//     check(forAll(prop[String] _))
+//   }
 
-  test("last") {
-    def prop[A: TypedEncoder](xs: List[A])(
-      implicit
-      ex1: TypedEncoder[X1[A]],
-      eoa: TypedEncoder[Option[A]]
-    ): Prop = {
-      val dataset = TypedDataset.create(xs.map(X1(_)))
-      val A = dataset.col[A]('a)
+//   test("last") {
+//     def prop[A: TypedEncoder](xs: List[A])(
+//       implicit
+//       ex1: TypedEncoder[X1[A]],
+//       eoa: TypedEncoder[Option[A]]
+//     ): Prop = {
+//       val dataset = TypedDataset.create(xs.map(X1(_)))
+//       val A = dataset.col[A]('a)
 
-      val datasetLast :: Nil = dataset.select(last(A)).collect().run().toList
+//       val datasetLast :: Nil = dataset.select(last(A)).collect().run().toList
 
-      xs match {
-        case Nil => datasetLast.isEmpty
-        case xs => datasetLast match {
-          case Some(m) => xs.last ?= m
-          case _ => falsified
-        }
-      }
-    }
+//       xs match {
+//         case Nil => datasetLast.isEmpty
+//         case xs => datasetLast match {
+//           case Some(m) => xs.last ?= m
+//           case _ => falsified
+//         }
+//       }
+//     }
 
-    check(forAll(prop[BigDecimal] _))
-    check(forAll(prop[Long] _))
-    check(forAll(prop[Double] _))
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Short] _))
-    check(forAll(prop[Byte] _))
-    check(forAll(prop[String] _))
-  }
-}
+//     check(forAll(prop[BigDecimal] _))
+//     check(forAll(prop[Long] _))
+//     check(forAll(prop[Double] _))
+//     check(forAll(prop[Int] _))
+//     check(forAll(prop[Short] _))
+//     check(forAll(prop[Byte] _))
+//     check(forAll(prop[String] _))
+//   }
+// }

--- a/dataset/src/test/scala/frameless/functions/UdfTest.scala
+++ b/dataset/src/test/scala/frameless/functions/UdfTest.scala
@@ -1,166 +1,166 @@
-package frameless
-package functions
+// package frameless
+// package functions
 
-import org.scalacheck.Prop
-import org.scalacheck.Prop._
+// import org.scalacheck.Prop
+// import org.scalacheck.Prop._
 
-class UdfTest extends TypedDatasetSuite {
+// class UdfTest extends TypedDatasetSuite {
 
-  test("one argument udf") {
-    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
-    (data: Vector[X3[A, B, C]], f1: A => A): Prop = {
-      val dataset = TypedDataset.create(data)
-      val u1 = udf[X3[A, B, C], A, A](f1)
-      val u2 = dataset.makeUDF(f1)
-      val A = dataset.col[A]('a)
+//   test("one argument udf") {
+//     def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
+//     (data: Vector[X3[A, B, C]], f1: A => A): Prop = {
+//       val dataset = TypedDataset.create(data)
+//       val u1 = udf[X3[A, B, C], A, A](f1)
+//       val u2 = dataset.makeUDF(f1)
+//       val A = dataset.col[A]('a)
 
-      val dataset21 = dataset.select(u1(A)).collect().run().toVector
-      val dataset22 = dataset.select(u2(A)).collect().run().toVector
-      val d = data.map(x => f1(x.a))
+//       val dataset21 = dataset.select(u1(A)).collect().run().toVector
+//       val dataset22 = dataset.select(u2(A)).collect().run().toVector
+//       val d = data.map(x => f1(x.a))
 
-      (dataset21 ?= d) && (dataset22 ?= d)
-    }
+//       (dataset21 ?= d) && (dataset22 ?= d)
+//     }
 
-    check(forAll(prop[Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int] _))
-    check(forAll(prop[Option[Int], X2[Double, Long], Int] _))
-    check(forAll(prop[Option[Vector[String]], Int, Int] _))
-  }
+//     check(forAll(prop[Int, Int, Int] _))
+//     check(forAll(prop[String, Int, Int] _))
+//     check(forAll(prop[Option[Int], X2[Double, Long], Int] _))
+//     check(forAll(prop[Option[Vector[String]], Int, Int] _))
+//   }
 
-  test("multiple one argument udf") {
-    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
-    (data: Vector[X3[A, B, C]], f1: A => A, f2: B => B, f3: C => C): Prop = {
-      val dataset = TypedDataset.create(data)
-      val u11 = udf[X3[A, B, C], A, A](f1)
-      val u21 = udf[X3[A, B, C], B, B](f2)
-      val u31 = udf[X3[A, B, C], C, C](f3)
-      val u12 = dataset.makeUDF(f1)
-      val u22 = dataset.makeUDF(f2)
-      val u32 = dataset.makeUDF(f3)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-      val C = dataset.col[C]('c)
+//   test("multiple one argument udf") {
+//     def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
+//     (data: Vector[X3[A, B, C]], f1: A => A, f2: B => B, f3: C => C): Prop = {
+//       val dataset = TypedDataset.create(data)
+//       val u11 = udf[X3[A, B, C], A, A](f1)
+//       val u21 = udf[X3[A, B, C], B, B](f2)
+//       val u31 = udf[X3[A, B, C], C, C](f3)
+//       val u12 = dataset.makeUDF(f1)
+//       val u22 = dataset.makeUDF(f2)
+//       val u32 = dataset.makeUDF(f3)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
+//       val C = dataset.col[C]('c)
 
-      val dataset21 = dataset.select(u11(A), u21(B), u31(C)).collect().run().toVector
-      val dataset22 = dataset.select(u12(A), u22(B), u32(C)).collect().run().toVector
-      val d = data.map(x => (f1(x.a), f2(x.b), f3(x.c)))
+//       val dataset21 = dataset.select(u11(A), u21(B), u31(C)).collect().run().toVector
+//       val dataset22 = dataset.select(u12(A), u22(B), u32(C)).collect().run().toVector
+//       val d = data.map(x => (f1(x.a), f2(x.b), f3(x.c)))
 
-      (dataset21 ?= d) && (dataset22 ?= d)
-    }
+//       (dataset21 ?= d) && (dataset22 ?= d)
+//     }
 
-    check(forAll(prop[Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int] _))
-    check(forAll(prop[X3[Int, String, Boolean], Int, Int] _))
-  }
+//     check(forAll(prop[Int, Int, Int] _))
+//     check(forAll(prop[String, Int, Int] _))
+//     check(forAll(prop[X3[Int, String, Boolean], Int, Int] _))
+//   }
 
-  test("two argument udf") {
-    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
-    (data: Vector[X3[A, B, C]], f1: (A, B) => C): Prop = {
-      val dataset = TypedDataset.create(data)
-      val u1 = udf[X3[A, B, C], A, B, C](f1)
-      val u2 = dataset.makeUDF(f1)
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
+//   test("two argument udf") {
+//     def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
+//     (data: Vector[X3[A, B, C]], f1: (A, B) => C): Prop = {
+//       val dataset = TypedDataset.create(data)
+//       val u1 = udf[X3[A, B, C], A, B, C](f1)
+//       val u2 = dataset.makeUDF(f1)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
 
-      val dataset21 = dataset.select(u1(A, B)).collect().run().toVector
-      val dataset22 = dataset.select(u2(A, B)).collect().run().toVector
-      val d = data.map(x => f1(x.a, x.b))
+//       val dataset21 = dataset.select(u1(A, B)).collect().run().toVector
+//       val dataset22 = dataset.select(u2(A, B)).collect().run().toVector
+//       val d = data.map(x => f1(x.a, x.b))
 
-      (dataset21 ?= d) && (dataset22 ?= d)
-    }
+//       (dataset21 ?= d) && (dataset22 ?= d)
+//     }
 
-    check(forAll(prop[Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int] _))
-  }
+//     check(forAll(prop[Int, Int, Int] _))
+//     check(forAll(prop[String, Int, Int] _))
+//   }
 
-  test("multiple two argument udf") {
-    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
-    (data: Vector[X3[A, B, C]], f1: (A, B) => C, f2: (B, C) => A): Prop = {
-      val dataset = TypedDataset.create(data)
-      val u11 = udf[X3[A, B, C], A, B, C](f1)
-      val u12 = dataset.makeUDF(f1)
-      val u21 = udf[X3[A, B, C], B, C, A](f2)
-      val u22 = dataset.makeUDF(f2)
+//   test("multiple two argument udf") {
+//     def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
+//     (data: Vector[X3[A, B, C]], f1: (A, B) => C, f2: (B, C) => A): Prop = {
+//       val dataset = TypedDataset.create(data)
+//       val u11 = udf[X3[A, B, C], A, B, C](f1)
+//       val u12 = dataset.makeUDF(f1)
+//       val u21 = udf[X3[A, B, C], B, C, A](f2)
+//       val u22 = dataset.makeUDF(f2)
 
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-      val C = dataset.col[C]('c)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
+//       val C = dataset.col[C]('c)
 
-      val dataset21 = dataset.select(u11(A, B), u21(B, C)).collect().run().toVector
-      val dataset22 = dataset.select(u12(A, B), u22(B, C)).collect().run().toVector
-      val d = data.map(x => (f1(x.a, x.b), f2(x.b, x.c)))
+//       val dataset21 = dataset.select(u11(A, B), u21(B, C)).collect().run().toVector
+//       val dataset22 = dataset.select(u12(A, B), u22(B, C)).collect().run().toVector
+//       val d = data.map(x => (f1(x.a, x.b), f2(x.b, x.c)))
 
-      (dataset21 ?= d) && (dataset22 ?= d)
-    }
+//       (dataset21 ?= d) && (dataset22 ?= d)
+//     }
 
-    check(forAll(prop[Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int] _))
-  }
+//     check(forAll(prop[Int, Int, Int] _))
+//     check(forAll(prop[String, Int, Int] _))
+//   }
 
-  test("three argument udf") {
-    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
-    (data: Vector[X3[A, B, C]], f: (A, B, C) => C): Prop = {
-      val dataset = TypedDataset.create(data)
-      val u1 = udf[X3[A, B, C], A, B, C, C](f)
-      val u2 = dataset.makeUDF(f)
+//   test("three argument udf") {
+//     def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
+//     (data: Vector[X3[A, B, C]], f: (A, B, C) => C): Prop = {
+//       val dataset = TypedDataset.create(data)
+//       val u1 = udf[X3[A, B, C], A, B, C, C](f)
+//       val u2 = dataset.makeUDF(f)
 
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-      val C = dataset.col[C]('c)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
+//       val C = dataset.col[C]('c)
 
-      val dataset21 = dataset.select(u1(A, B, C)).collect().run().toVector
-      val dataset22 = dataset.select(u2(A, B, C)).collect().run().toVector
-      val d = data.map(x => f(x.a, x.b, x.c))
+//       val dataset21 = dataset.select(u1(A, B, C)).collect().run().toVector
+//       val dataset22 = dataset.select(u2(A, B, C)).collect().run().toVector
+//       val d = data.map(x => f(x.a, x.b, x.c))
 
-      (dataset21 ?= d) && (dataset22 ?= d)
-    }
+//       (dataset21 ?= d) && (dataset22 ?= d)
+//     }
 
-    check(forAll(prop[Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int] _))
-  }
+//     check(forAll(prop[Int, Int, Int] _))
+//     check(forAll(prop[String, Int, Int] _))
+//   }
 
-  test("four argument udf") {
-    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
-    (data: Vector[X3[A, B, C]], f: (A, B, C, A) => C): Prop = {
-      val dataset = TypedDataset.create(data)
-      val u1 = udf[X3[A, B, C], A, B, C, A, C](f)
-      val u2 = dataset.makeUDF(f)
+//   test("four argument udf") {
+//     def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder]
+//     (data: Vector[X3[A, B, C]], f: (A, B, C, A) => C): Prop = {
+//       val dataset = TypedDataset.create(data)
+//       val u1 = udf[X3[A, B, C], A, B, C, A, C](f)
+//       val u2 = dataset.makeUDF(f)
 
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-      val C = dataset.col[C]('c)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
+//       val C = dataset.col[C]('c)
 
-      val dataset21 = dataset.select(u1(A, B, C, A)).collect().run().toVector
-      val dataset22 = dataset.select(u2(A, B, C, A)).collect().run().toVector
-      val d = data.map(x => f(x.a, x.b, x.c, x.a))
+//       val dataset21 = dataset.select(u1(A, B, C, A)).collect().run().toVector
+//       val dataset22 = dataset.select(u2(A, B, C, A)).collect().run().toVector
+//       val d = data.map(x => f(x.a, x.b, x.c, x.a))
 
-      (dataset21 ?= d) && (dataset22 ?= d)
-    }
+//       (dataset21 ?= d) && (dataset22 ?= d)
+//     }
 
-    check(forAll(prop[Int, Int, Int] _))
-    check(forAll(prop[String, Int, Int] _))
-  }
+//     check(forAll(prop[Int, Int, Int] _))
+//     check(forAll(prop[String, Int, Int] _))
+//   }
 
-  test("five argument udf") {
-    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder, E: TypedEncoder]
-    (data: Vector[X5[A, B, C, D, E]], f: (A, B, C, D, E) => C): Prop = {
-      val dataset = TypedDataset.create(data)
-      val u1 = udf[X5[A, B, C, D, E], A, B, C, D, E, C](f)
-      val u2 = dataset.makeUDF(f)
+//   test("five argument udf") {
+//     def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder, D: TypedEncoder, E: TypedEncoder]
+//     (data: Vector[X5[A, B, C, D, E]], f: (A, B, C, D, E) => C): Prop = {
+//       val dataset = TypedDataset.create(data)
+//       val u1 = udf[X5[A, B, C, D, E], A, B, C, D, E, C](f)
+//       val u2 = dataset.makeUDF(f)
 
-      val A = dataset.col[A]('a)
-      val B = dataset.col[B]('b)
-      val C = dataset.col[C]('c)
-      val D = dataset.col[D]('d)
-      val E = dataset.col[E]('e)
+//       val A = dataset.col[A]('a)
+//       val B = dataset.col[B]('b)
+//       val C = dataset.col[C]('c)
+//       val D = dataset.col[D]('d)
+//       val E = dataset.col[E]('e)
 
-      val dataset21 = dataset.select(u1(A, B, C, D, E)).collect().run().toVector
-      val dataset22 = dataset.select(u2(A, B, C, D, E)).collect().run().toVector
-      val d = data.map(x => f(x.a, x.b, x.c, x.d, x.e))
+//       val dataset21 = dataset.select(u1(A, B, C, D, E)).collect().run().toVector
+//       val dataset22 = dataset.select(u2(A, B, C, D, E)).collect().run().toVector
+//       val d = data.map(x => f(x.a, x.b, x.c, x.d, x.e))
 
-      (dataset21 ?= d) && (dataset22 ?= d)
-    }
+//       (dataset21 ?= d) && (dataset22 ?= d)
+//     }
 
-    check(forAll(prop[Int, Int, Int, Int, Int] _))
-  }
-}
+//     check(forAll(prop[Int, Int, Int, Int, Int] _))
+//   }
+// }


### PR DESCRIPTION
This is a proposition for a new syntax for column expression, which I think could be used as the only way to construct `select` / `groupBy` / `join`s in frameless, it would be an improvement for both #39 and #46. It's at super early stage, but I would like to get your feedback before going forward. Here the syntax I'm managed to get: (modulo type inference, but I would have to look into this further)

``` scala
dataset.select[A, B](s => (s / 'a, s / 'b))
```

``` scala
// Here we see the choice of / paying off: it's priority is greater than + or =
// Could ofc be changed to .apply/.col
dataset1.join(dataset2) { (s1, s2) =>
  s1 / 'a ===  s2 / 'b + 1
}
```

First commit is the interesting one, second commit is commenting every test to show that [the trivial select examples](https://github.com/adelbertc/frameless/pull/60/commits/6aab279f316bbd9ccb037789665bc9855d4edd26#diff-7188c361b74d962dcaccfd2dc539249eR40) are actually working.
