### PR TITLE
Add `lit`

### DIFF
--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -1,6 +1,7 @@
 package frameless
 
 import frameless.syntax._
+import frameless.functions._
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.{Column, FramelessInternals}
@@ -49,7 +50,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def ===(other: U): TypedColumn[T, Boolean] = (untyped === other).typed
+  def ===(other: U): TypedColumn[T, Boolean] = (untyped === lit(other).untyped).typed
 
   /** Equality test.
     * {{{

--- a/dataset/src/main/scala/frameless/functions/Lit.scala
+++ b/dataset/src/main/scala/frameless/functions/Lit.scala
@@ -1,0 +1,56 @@
+package frameless.functions
+
+import frameless.TypedEncoder
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, NonSQLExpression}
+import org.apache.spark.sql.types.DataType
+
+case class FramelessLit[A](obj: A, encoder: TypedEncoder[A]) extends Expression with NonSQLExpression {
+  override def nullable: Boolean = encoder.nullable
+  override def toString: String = s"FramelessLit($obj)"
+
+  def eval(input: InternalRow): Any = {
+    val ctx = new CodegenContext()
+    val eval = genCode(ctx)
+
+    val codeBody = s"""
+      public scala.Function1<InternalRow, Object> generate(Object[] references) {
+        return new FramelessLitEvalImpl(references);
+      }
+
+      class FramelessLitEvalImpl extends scala.runtime.AbstractFunction1<InternalRow, Object> {
+        private final Object[] references;
+        ${ctx.declareMutableStates()}
+        ${ctx.declareAddedFunctions()}
+
+        public FramelessLitEvalImpl(Object[] references) {
+          this.references = references;
+          ${ctx.initMutableStates()}
+        }
+
+        public java.lang.Object apply(java.lang.Object z) {
+          InternalRow ${ctx.INPUT_ROW} = (InternalRow) z;
+          ${eval.code}
+          return ${eval.isNull} ? ((Object)null) : ((Object)${eval.value});
+        }
+      }
+    """
+
+    val code = CodeFormatter.stripOverlappingComments(
+      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+
+    val codegen = CodeGenerator.compile(code).generate(ctx.references.toArray).asInstanceOf[InternalRow => AnyRef]
+
+    codegen(input)
+  }
+
+  def dataType: DataType = encoder.targetDataType
+  def children: Seq[Expression] = Nil
+
+  override def genCode(ctx: CodegenContext): ExprCode = {
+    encoder.extractorFor(new Literal(obj, encoder.sourceDataType)).genCode(ctx)
+  }
+
+  protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = ???
+}

--- a/dataset/src/main/scala/frameless/functions/package.scala
+++ b/dataset/src/main/scala/frameless/functions/package.scala
@@ -1,5 +1,20 @@
 package frameless
 
+import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.catalyst.expressions.Literal
+
 package object functions extends Udf {
   object aggregate extends AggregateFunctions
+
+  def lit[A: TypedEncoder, T](value: A): TypedColumn[T, A] = {
+    val encoder = TypedEncoder[A]
+
+    if (ScalaReflection.isNativeType(encoder.sourceDataType) && encoder.targetDataType == encoder.sourceDataType) {
+      val expr = Literal(value, encoder.targetDataType)
+      new TypedColumn(expr)
+    } else {
+      val expr = FramelessLit(value, encoder)
+      new TypedColumn(expr)
+    }
+  }
 }

--- a/dataset/src/test/scala/frameless/LitTests.scala
+++ b/dataset/src/test/scala/frameless/LitTests.scala
@@ -1,0 +1,52 @@
+package frameless
+
+import frameless.functions.lit
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+
+class LitTests extends TypedDatasetSuite {
+
+  def prop[A: TypedEncoder](value: A): Prop = {
+    val df = TypedDataset.create(1 :: Nil)
+
+    // filter forces whole codegen
+    val elems = df.filter(_ => true).select(lit(value))
+      .collect()
+      .run()
+      .toVector
+
+    // otherwise it uses local relation
+    val localElems = df.select(lit(value))
+      .collect()
+      .run()
+      .toVector
+
+
+    (localElems ?= Vector(value)) && (elems ?= Vector(value))
+  }
+
+  test("select(lit(...))") {
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[String] _)
+    check(prop[SQLDate] _)
+
+    check(prop[Option[Int]] _)
+    check(prop[Option[String]] _)
+
+    check(prop[Vector[Long]] _)
+    check(prop[Vector[X1[Long]]] _)
+
+    check(prop[Vector[String]] _)
+    check(prop[Vector[X1[String]]] _)
+
+    check(prop[X1[Int]] _)
+    check(prop[X1[X1[Int]]] _)
+
+    check(prop[Food] _)
+
+    // doesn't work, object has to be serializable
+    // check(prop[frameless.LocalDateTime] _)
+  }
+}


### PR DESCRIPTION
Had to do the same trick as in `FramelessUdf` because our encoders don't
support `eval`.

As in Spark, doesn't work unless value is Serializable. If our encoders
supported `eval`, we could value before distributing it among cluster
nodes. It's hardly doable right now, not sure if it worth spending time.

It's open question if we should implement `eval` in `TypedEncoder` or
not, at the moment it's still not required.