### PR TITLE
Adding unary functions on collection elements: size and sort

### DIFF
--- a/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
@@ -1,15 +1,24 @@
 package frameless
 package functions
 
-import org.apache.spark.sql.{Column, functions => vanilla}
+import org.apache.spark.sql.{Column, functions => sparkFunctions}
 
 import scala.math.Ordering
 
 trait UnaryFunctions {
-  def size[T, A, V[_]: CatalystSizableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, Int] =
+  /** Returns length of array or map.
+    *
+    * apache/spark
+    */
+  def size[T, A, V[_] : CatalystSizableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, Int] =
     new TypedColumn[T, Int](implicitly[CatalystSizableCollection[V]].sizeOp(column.untyped))
 
-  def sort[T, A: Ordering, V[_]: CatalystSortableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, V[A]] =
+  /** Sorts the input array for the given column in ascending order, according to
+    * the natural ordering of the array elements.
+    *
+    * apache/spark
+    */
+  def sort[T, A: Ordering, V[_] : CatalystSortableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, V[A]] =
     new TypedColumn[T, V[A]](implicitly[CatalystSortableCollection[V]].sortOp(column.untyped))(column.uencoder)
 }
 
@@ -19,7 +28,7 @@ trait CatalystSizableCollection[V[_]] {
 
 object CatalystSizableCollection {
   implicit def sizableVector: CatalystSizableCollection[Vector] = new CatalystSizableCollection[Vector] {
-    def sizeOp(col: Column): Column = vanilla.size(col)
+    def sizeOp(col: Column): Column = sparkFunctions.size(col)
   }
 }
 
@@ -29,6 +38,6 @@ trait CatalystSortableCollection[V[_]] {
 
 object CatalystSortableCollection {
   implicit def sortableVector: CatalystSortableCollection[Vector] = new CatalystSortableCollection[Vector] {
-    def sortOp(col: Column): Column = vanilla.sort_array(col)
+    def sortOp(col: Column): Column = sparkFunctions.sort_array(col)
   }
 }

--- a/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
@@ -1,0 +1,34 @@
+package frameless
+package functions
+
+import org.apache.spark.sql.{Column, functions => vanilla}
+
+import scala.math.Ordering
+
+trait UnaryFunctions {
+  def size[T, A, V[_]: CatalystSizableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, Int] =
+    new TypedColumn[T, Int](implicitly[CatalystSizableCollection[V]].sizeOp(column.untyped))
+
+  def sort[T, A: Ordering, V[_]: CatalystSortableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, V[A]] =
+    new TypedColumn[T, V[A]](implicitly[CatalystSortableCollection[V]].sortOp(column.untyped))(column.uencoder)
+}
+
+trait CatalystSizableCollection[V[_]] {
+  def sizeOp(col: Column): Column
+}
+
+object CatalystSizableCollection {
+  implicit def sizableVector: CatalystSizableCollection[Vector] = new CatalystSizableCollection[Vector] {
+    def sizeOp(col: Column): Column = vanilla.size(col)
+  }
+}
+
+trait CatalystSortableCollection[V[_]] {
+  def sortOp(col: Column): Column
+}
+
+object CatalystSortableCollection {
+  implicit def sortableVector: CatalystSortableCollection[Vector] = new CatalystSortableCollection[Vector] {
+    def sortOp(col: Column): Column = vanilla.sort_array(col)
+  }
+}

--- a/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
@@ -18,8 +18,16 @@ trait UnaryFunctions {
     *
     * apache/spark
     */
-  def sort[T, A: Ordering, V[_] : CatalystSortableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, V[A]] =
-    new TypedColumn[T, V[A]](implicitly[CatalystSortableCollection[V]].sortOp(column.untyped))(column.uencoder)
+  def sortAscending[T, A: Ordering, V[_] : CatalystSortableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, V[A]] =
+    new TypedColumn[T, V[A]](implicitly[CatalystSortableCollection[V]].sortOp(column.untyped, sortAscending = true))(column.uencoder)
+
+  /** Sorts the input array for the given column in descending order, according to
+    * the natural ordering of the array elements.
+    *
+    * apache/spark
+    */
+  def sortDescending[T, A: Ordering, V[_] : CatalystSortableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, V[A]] =
+    new TypedColumn[T, V[A]](implicitly[CatalystSortableCollection[V]].sortOp(column.untyped, sortAscending = false))(column.uencoder)
 }
 
 trait CatalystSizableCollection[V[_]] {
@@ -33,11 +41,11 @@ object CatalystSizableCollection {
 }
 
 trait CatalystSortableCollection[V[_]] {
-  def sortOp(col: Column): Column
+  def sortOp(col: Column, sortAscending: Boolean): Column
 }
 
 object CatalystSortableCollection {
   implicit def sortableVector: CatalystSortableCollection[Vector] = new CatalystSortableCollection[Vector] {
-    def sortOp(col: Column): Column = sparkFunctions.sort_array(col)
+    def sortOp(col: Column, sortAscending: Boolean): Column = sparkFunctions.sort_array(col, sortAscending)
   }
 }

--- a/dataset/src/main/scala/frameless/functions/package.scala
+++ b/dataset/src/main/scala/frameless/functions/package.scala
@@ -3,7 +3,7 @@ package frameless
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.expressions.Literal
 
-package object functions extends Udf {
+package object functions extends Udf with UnaryFunctions {
   object aggregate extends AggregateFunctions
 
   def lit[A: TypedEncoder, T](value: A): TypedColumn[T, A] = {

--- a/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
+++ b/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
@@ -19,11 +19,11 @@ class UnaryFunctionsTest extends TypedDatasetSuite {
 
     check(forAll(prop[Long] _))
     check(forAll(prop[Char] _))
-    check(forAll(prop[X2[Int,Option[Long]]] _))
+    check(forAll(prop[X2[Int, Option[Long]]] _))
   }
 
   test("sort on vector test") {
-    def prop[A: TypedEncoder: Ordering](xs: List[X1[Vector[A]]]): Prop = {
+    def prop[A: TypedEncoder : Ordering](xs: List[X1[Vector[A]]]): Prop = {
       val tds = TypedDataset.create(xs)
 
       val framelessResults = tds.select(sort(tds('a))).collect().run().toVector

--- a/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
+++ b/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
@@ -22,12 +22,28 @@ class UnaryFunctionsTest extends TypedDatasetSuite {
     check(forAll(prop[X2[Int, Option[Long]]] _))
   }
 
-  test("sort on vector test") {
+  test("sort on vector test: ascending order") {
     def prop[A: TypedEncoder : Ordering](xs: List[X1[Vector[A]]]): Prop = {
       val tds = TypedDataset.create(xs)
 
-      val framelessResults = tds.select(sort(tds('a))).collect().run().toVector
+      val framelessResults = tds.select(sortAscending(tds('a))).collect().run().toVector
       val scalaResults = xs.map(x => x.a.sorted).toVector
+
+      framelessResults ?= scalaResults
+    }
+
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Int] _))
+    check(forAll(prop[Char] _))
+    check(forAll(prop[String] _))
+  }
+
+  test("sort on vector test: descending order") {
+    def prop[A: TypedEncoder : Ordering](xs: List[X1[Vector[A]]]): Prop = {
+      val tds = TypedDataset.create(xs)
+
+      val framelessResults = tds.select(sortDescending(tds('a))).collect().run().toVector
+      val scalaResults = xs.map(x => x.a.sorted.reverse).toVector
 
       framelessResults ?= scalaResults
     }

--- a/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
+++ b/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
@@ -1,0 +1,40 @@
+package frameless
+package functions
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+
+import scala.math.Ordering
+
+class UnaryFunctionsTest extends TypedDatasetSuite {
+  test("size on vector test") {
+    def prop[A: TypedEncoder](xs: List[X1[Vector[A]]]): Prop = {
+      val tds = TypedDataset.create(xs)
+
+      val framelessResults = tds.select(size(tds('a))).collect().run().toVector
+      val scalaResults = xs.map(x => x.a.size).toVector
+
+      framelessResults ?= scalaResults
+    }
+
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Char] _))
+    check(forAll(prop[X2[Int,Option[Long]]] _))
+  }
+
+  test("sort on vector test") {
+    def prop[A: TypedEncoder: Ordering](xs: List[X1[Vector[A]]]): Prop = {
+      val tds = TypedDataset.create(xs)
+
+      val framelessResults = tds.select(sort(tds('a))).collect().run().toVector
+      val scalaResults = xs.map(x => x.a.sorted).toVector
+
+      framelessResults ?= scalaResults
+    }
+
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Int] _))
+    check(forAll(prop[Char] _))
+    check(forAll(prop[String] _))
+  }
+}


### PR DESCRIPTION
Currently we have binary functions on columns, like C1 + C2, but we don't really have unary functions on columns (we do have for aggregation, but not for select). 

This PR allows for the following:

```scala
import frameless.functions._
val t = TypedDataset.create((1, Vector(1,10,3)) :: (2, Vector(2,1)) :: Nil)

case class X(original: Vector[Int], size: Int, sorted: Vector[Int])
tt.select(t('_2), size(t('_2)), sort(t('_2))).as[X].show().run
+----------+----+----------+
|  original|size|    sorted|
+----------+----+----------+
|[1, 10, 3]|   3|[1, 3, 10]|
|    [2, 1]|   2|    [1, 2]|
+----------+----+----------+
```