### PR TITLE
Migrating SparkContext to SparkSession

### DIFF
--- a/dataset/src/main/scala/frameless/FramelessSyntax.scala
+++ b/dataset/src/main/scala/frameless/FramelessSyntax.scala
@@ -12,6 +12,6 @@ trait FramelessSyntax {
   }
 
   implicit class DataframeSyntax(self: DataFrame){
-    def unsafeTyped[T: TypedEncoder] = TypedDataset.createUnsafe(self)
+    def unsafeTyped[T: TypedEncoder]: TypedDataset[T] = TypedDataset.createUnsafe(self)
   }
 }

--- a/dataset/src/main/scala/frameless/Job.scala
+++ b/dataset/src/main/scala/frameless/Job.scala
@@ -1,8 +1,8 @@
 package frameless
 
-import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
 
-sealed abstract class Job[A](implicit sc: SparkContext) { self =>
+sealed abstract class Job[A](implicit spark: SparkSession) { self =>
   /** Runs a new Spark job. */
   def run(): A
 
@@ -17,24 +17,24 @@ sealed abstract class Job[A](implicit sc: SparkContext) { self =>
   def withLocalProperty(key: String, value: String): Job[A] = {
     new Job[A] {
       def run(): A = {
-        sc.setLocalProperty(key, value)
+        spark.sparkContext.setLocalProperty(key, value)
         self.run()
       }
     }
   }
 
-  def map[B](fn: A => B): Job[B] = new Job[B]()(sc) {
+  def map[B](fn: A => B): Job[B] = new Job[B]()(spark) {
     def run(): B = fn(Job.this.run())
   }
 
-  def flatMap[B](fn: A => Job[B]): Job[B] = new Job[B]()(sc) {
+  def flatMap[B](fn: A => Job[B]): Job[B] = new Job[B]()(spark) {
     def run(): B = fn(Job.this.run()).run()
   }
 }
 
 
 object Job {
-  def apply[A](a: => A)(implicit sc: SparkContext): Job[A] = new Job[A] {
+  def apply[A](a: => A)(implicit spark: SparkSession): Job[A] = new Job[A] {
     def run(): A = a
   }
 }

--- a/dataset/src/test/scala/frameless/JobTests.scala
+++ b/dataset/src/test/scala/frameless/JobTests.scala
@@ -22,11 +22,9 @@ class JobTests extends FreeSpec with SparkTesting with GeneratorDrivenPropertyCh
     "composition" in forAll {
       i: Int => Job(i).map(f1).map(f2).run() shouldEqual Job(i).map(f1 andThen f2).run()
     }
-
   }
 
   "flatMap" - {
-
     val f1: Int => Job[Int] = (i: Int) => Job(i + 1)
     val f2: Int => Job[Int] = (i: Int) => Job(i * i)
 
@@ -43,4 +41,12 @@ class JobTests extends FreeSpec with SparkTesting with GeneratorDrivenPropertyCh
     }
   }
 
+  "properties" - {
+    "read back" in forAll {
+      (k:String, v: String) =>
+        val scopedKey = "frameless.tests." + k
+        Job(1).withLocalProperty(scopedKey,v).run()
+        sc.getLocalProperty(scopedKey) shouldBe v
+    }
+  }
 }

--- a/dataset/src/test/scala/frameless/TypedDatasetSuite.scala
+++ b/dataset/src/test/scala/frameless/TypedDatasetSuite.scala
@@ -1,29 +1,27 @@
 package frameless
 
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.scalactic.anyvals.PosZInt
 import org.scalatest.FunSuite
 import org.scalatest.prop.Checkers
 
 trait SparkTesting {
-  val appID = new java.util.Date().toString + math.floor(math.random * 10E4).toLong.toString
+  val appID: String = new java.util.Date().toString + math.floor(math.random * 10E4).toLong.toString
 
-  val conf = new SparkConf()
+  val conf: SparkConf = new SparkConf()
     .setMaster("local[*]")
     .setAppName("test")
     .set("spark.ui.enabled", "false")
     .set("spark.app.id", appID)
 
-  implicit def session = SparkSession.builder().config(conf).getOrCreate()
-  implicit def sc = session.sparkContext
-  implicit def sqlContext = session.sqlContext
+  implicit def session: SparkSession = SparkSession.builder().config(conf).getOrCreate()
+  implicit def sc: SparkContext = session.sparkContext
+  implicit def sqlContext: SQLContext = session.sqlContext
 }
 
 class TypedDatasetSuite extends FunSuite with Checkers with SparkTesting {
   // Limit size of generated collections and number of checks because Travis
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(sizeRange = PosZInt(10), minSize = PosZInt(10))
-
-
 }


### PR DESCRIPTION
Since Spark now uses the superset SparkSession, I think it make sense to have out APIs use this context compared to the older SparkContext. 