### PR TITLE
Adding a toString for TypedColumn and TypedAggregate

### DIFF
--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -13,6 +13,7 @@ import scala.annotation.implicitNotFound
 sealed trait UntypedExpression[T] {
   def expr: Expression
   def uencoder: TypedEncoder[_]
+  override def toString: String = expr.toString()
 }
 
 /** Expression used in `select`-like constructions.

--- a/dataset/src/test/scala/frameless/ColumnTests.scala
+++ b/dataset/src/test/scala/frameless/ColumnTests.scala
@@ -38,4 +38,9 @@ class ColumnTests extends TypedDatasetSuite {
     check(forAll(prop[SQLTimestamp] _))
     check(forAll(prop[String] _))
   }
+
+  test("toString") {
+    val t = TypedDataset.create((1,2)::Nil)
+    t('_1).toString ?= t.dataset.col("_1").toString()
+  }
 }

--- a/dataset/src/test/scala/frameless/FilterTests.scala
+++ b/dataset/src/test/scala/frameless/FilterTests.scala
@@ -37,6 +37,25 @@ class FilterTests extends TypedDatasetSuite {
     //check(forAll(prop[Vector[SQLTimestamp]] _)) // Commenting out since this fails randomly due to frameless Issue #124
   }
 
+  test("filter('a =!= 'b") {
+    def prop[A: TypedEncoder](elem: A, data: Vector[X2[A,A]]): Prop = {
+      val dataset = TypedDataset.create(data)
+      val cA = dataset.col('a)
+      val cB = dataset.col('b)
+
+      val dataset2 = dataset.filter(cA =!= cB).collect().run().toVector
+      val data2 = data.filter(x => x.a != x.b )
+
+      (dataset2 ?= data2).&&(dataset.filter(cA =!= cA).count().run() ?= 0)
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+    check(forAll(prop[Char] _))
+    check(forAll(prop[SQLTimestamp] _))
+    //check(forAll(prop[Vector[SQLTimestamp]] _)) // Commenting out since this fails randomly due to frameless Issue #124
+  }
+
   test("filter with arithmetic expressions: addition") {
     check(forAll { (data: Vector[X1[Int]]) =>
       val ds = TypedDataset.create(data)


### PR DESCRIPTION
## Typed columns show nicer on REPL

Before

```scala
scala> f('i) === None
res1: frameless.TypedColumn[Foo,Boolean] = frameless.TypedColumn@11fcc7d4
```

After

```scala
scala> f('i) === None
res2: frameless.TypedColumn[Foo,Boolean] = (i#1 = FramelessLit(None))
```

## And for aggregates 

Before 

```scala
scala> first(f('i))
res2: frameless.TypedAggregate[Foo,Option[Boolean]] = frameless.TypedAggregate@737e70c
```

After

```scala
scala> first(f('i))
res3: frameless.TypedAggregate[Foo,Option[Boolean]] = first(i#1, false)
```