### PR TITLE
Fixing equality on nullable types

### DIFF
--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -44,6 +44,13 @@ sealed class TypedColumn[T, U](
     */
   def untyped: Column = new Column(expr)
 
+  private def withExpr(newExpr: Expression): Column = new Column(newExpr)
+
+  private def equalsTo(other: TypedColumn[T, U]): TypedColumn[T, Boolean]= withExpr {
+    if (uencoder.nullable) EqualNullSafe(self.expr, other.expr)
+    else EqualTo(self.expr, other.expr)
+  }.typed
+
   /** Equality test.
     * {{{
     *   df.filter( df.col('a) === 1 )
@@ -51,7 +58,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def ===(other: U): TypedColumn[T, Boolean] = (untyped === lit(other).untyped).typed
+  def ===(other: U): TypedColumn[T, Boolean] = equalsTo(lit(other))
 
   /** Equality test.
     * {{{
@@ -60,7 +67,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def ===(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (untyped === other.untyped).typed
+  def ===(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = equalsTo(other)
 
   /** Inequality test.
     * {{{
@@ -69,7 +76,9 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def =!=(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (self.untyped =!= other.untyped).typed
+  def =!=(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = withExpr {
+    Not(equalsTo(other).expr)
+  }.typed
 
   /** Inequality test.
     * {{{
@@ -78,7 +87,21 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def =!=(other: U): TypedColumn[T, Boolean] = (self.untyped =!= lit(other).untyped).typed
+  def =!=(other: U): TypedColumn[T, Boolean] = withExpr {
+    Not(equalsTo(lit(other)).expr)
+  }.typed
+
+  /** True if the current expression is an Option and it's None.
+    *
+    * apache/spark
+    */
+  def isNone(implicit isOption: U <:< Option[_]): TypedColumn[T, Boolean] = self.untyped.isNull.typed
+
+  /** True if the current expression is an Option and it's not None.
+    *
+    * apache/spark
+    */
+  def isNotNone(implicit isOption: U <:< Option[_]): TypedColumn[T, Boolean] = self.untyped.isNotNull.typed
 
   /** Sum of this expression and another expression.
     * {{{

--- a/dataset/src/test/scala/frameless/FilterTests.scala
+++ b/dataset/src/test/scala/frameless/FilterTests.scala
@@ -97,7 +97,9 @@ class FilterTests extends TypedDatasetSuite {
     check(forAll(prop[Option[Boolean]] _))
     check(forAll(prop[Option[SQLDate]] _))
     check(forAll(prop[Option[SQLTimestamp]] _))
-    //check(forAll(prop[Option[X1[String]]] _))
+    check(forAll(prop[Option[X1[String]]] _))
+    check(forAll(prop[Option[X1[X1[String]]]] _))
+    check(forAll(prop[Option[X1[X1[Vector[Option[Int]]]]]] _))
   }
 
   test("Option equality/inequality for lit") {
@@ -117,6 +119,8 @@ class FilterTests extends TypedDatasetSuite {
     check(forAll(prop[Option[SQLDate]] _))
     check(forAll(prop[Option[SQLTimestamp]] _))
     check(forAll(prop[Option[String]] _))
-    //check(forAll(prop[Option[X1[String]]] _)) // Throws exception java.lang.IllegalArgumentException: Cannot compare UnsafeRow to org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+    check(forAll(prop[Option[X1[String]]] _))
+    check(forAll(prop[Option[X1[X1[String]]]] _))
+    check(forAll(prop[Option[X1[X1[Vector[Option[Int]]]]]] _))
   }
 }


### PR DESCRIPTION
Before, equality on nullable types (ie `Option[T]`) will not work. For example `f.filter(f('a) === None)` will not work even if there were None values in column `a`. With this fix, it will work as expected.

This fix also adds an `isNone` and `isNotNone` method on columns that operate only on `Option[T]` types. 

See more details on Issue #121.