### PR TITLE
[Final] Unifying typed column and aggregate column.

### DIFF
--- a/dataset/src/main/scala/frameless/FramelessSyntax.scala
+++ b/dataset/src/main/scala/frameless/FramelessSyntax.scala
@@ -4,7 +4,8 @@ import org.apache.spark.sql.{Column, DataFrame, Dataset}
 
 trait FramelessSyntax {
   implicit class ColumnSyntax(self: Column) {
-    def typed[T, U: TypedEncoder]: TypedColumn[T, U] = new TypedColumn[T, U](self)
+    def typedColumn[T, U: TypedEncoder]: TypedColumn[T, U] = new TypedColumn[T, U](self)
+    def typedAggregate[T, U: TypedEncoder]: TypedAggregate[T, U] = new TypedAggregate[T, U](self)
   }
 
   implicit class DatasetSyntax[T: TypedEncoder](self: Dataset[T]) {

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -21,9 +21,9 @@ sealed trait UntypedExpression[T] {
   */
 sealed class TypedColumn[T, U](expr: Expression)(
   implicit val uenc: TypedEncoder[U]
-) extends AbstractTypedColumn[T,U](expr) {
+) extends AbstractTypedColumn[T, U](expr) {
 
-  type TC[A] = TypedColumn[T,A]
+  type ThisType[A, B] = TypedColumn[A, B]
 
   def this(column: Column)(implicit uencoder: TypedEncoder[U]) {
     this(FramelessInternals.expr(column))
@@ -37,9 +37,9 @@ sealed class TypedColumn[T, U](expr: Expression)(
   */
 sealed class TypedAggregate[T, U](expr: Expression)(
   implicit val uenc: TypedEncoder[U]
-) extends AbstractTypedColumn[T,U](expr) {
+) extends AbstractTypedColumn[T, U](expr) {
 
-  type TC[A] = TypedAggregate[T, A]
+  type ThisType[A, B] = TypedAggregate[A, B]
 
   def this(column: Column)(implicit uencoder: TypedEncoder[U]) {
     this(FramelessInternals.expr(column))
@@ -59,32 +59,33 @@ sealed class TypedAggregate[T, U](expr: Expression)(
   * @tparam T type of dataset
   * @tparam U type of column
   */
-abstract class AbstractTypedColumn[T, U](val expr: Expression)(
-  implicit val uencoder: TypedEncoder[U]
-) extends UntypedExpression[T] { self =>
+abstract class AbstractTypedColumn[T, U]
+  (val expr: Expression)
+  (implicit val uencoder: TypedEncoder[U])
+    extends UntypedExpression[T] { self =>
 
-  type TC[A] <: AbstractTypedColumn[T, A]
+  type ThisType[A, B] <: AbstractTypedColumn[A, B]
 
   /** Fall back to an untyped Column
     */
   def untyped: Column = new Column(expr)
 
-  private def equalsTo(other: TC[U]): TC[Boolean] = typed {
+  private def equalsTo(other: ThisType[T, U]): ThisType[T, Boolean] = typed {
     if (uencoder.nullable && uencoder.catalystRepr.typeName != "struct") EqualNullSafe(self.expr, other.expr)
     else EqualTo(self.expr, other.expr)
   }
 
   /** Creates a typed column of either TypedColumn or TypedAggregate from an expression.
     */
-  protected def typed[U1: TypedEncoder](e: Expression): TC[U1] = typed(new Column(e))
+  protected def typed[U1: TypedEncoder](e: Expression): ThisType[T, U1] = typed(new Column(e))
 
   /** Creates a typed column of either TypedColumn or TypedAggregate.
     */
-  protected def typed[U1: TypedEncoder](c: Column): TC[U1]
+  protected def typed[U1: TypedEncoder](c: Column): ThisType[T, U1]
 
   /** Creates a typed column of either TypedColumn or TypedAggregate.
     */
-  protected def lit[U1: TypedEncoder](c: U1): TC[U1]
+  protected def lit[U1: TypedEncoder](c: U1): ThisType[T, U1]
 
   /** Equality test.
     * {{{
@@ -93,7 +94,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def ===(other: U): TC[Boolean] = equalsTo(lit(other))
+  def ===(other: U): ThisType[T, Boolean] = equalsTo(lit(other))
 
   /** Equality test.
     * {{{
@@ -102,7 +103,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def ===(other: TC[U]): TC[Boolean] = equalsTo(other)
+  def ===(other: ThisType[T, U]): ThisType[T, Boolean] = equalsTo(other)
 
   /** Inequality test.
     * {{{
@@ -111,7 +112,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def =!=(other: TC[U]): TC[Boolean] = typed(Not(equalsTo(other).expr))
+  def =!=(other: ThisType[T, U]): ThisType[T, Boolean] = typed(Not(equalsTo(other).expr))
 
   /** Inequality test.
     * {{{
@@ -120,20 +121,20 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def =!=(other: U): TC[Boolean] = typed(Not(equalsTo(lit(other)).expr))
+  def =!=(other: U): ThisType[T, Boolean] = typed(Not(equalsTo(lit(other)).expr))
 
   /** True if the current expression is an Option and it's None.
     *
     * apache/spark
     */
-  def isNone(implicit isOption: U <:< Option[_]): TC[Boolean] =
+  def isNone(implicit isOption: U <:< Option[_]): ThisType[T, Boolean] =
     equalsTo(lit[U](None.asInstanceOf[U]))
 
   /** True if the current expression is an Option and it's not None.
     *
     * apache/spark
     */
-  def isNotNone(implicit isOption: U <:< Option[_]): TC[Boolean] =
+  def isNotNone(implicit isOption: U <:< Option[_]): ThisType[T, Boolean] =
     typed(Not(equalsTo(lit(None.asInstanceOf[U])).expr))
 
   /** Convert an Optional column by providing a default value
@@ -141,7 +142,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *   df( df('opt).getOrElse(df('defaultValue)) )
     * }}}
     */
-  def getOrElse[Out](default: TC[Out])(implicit isOption: U =:= Option[Out]): TC[Out] =
+  def getOrElse[Out](default: ThisType[T, Out])(implicit isOption: U =:= Option[Out]): ThisType[T, Out] =
     typed(Coalesce(Seq(expr, default.expr)))(default.uencoder)
 
   /** Convert an Optional column by providing a default value
@@ -149,7 +150,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *   df( df('opt).getOrElse(defaultConstant) )
     * }}}
     */
-  def getOrElse[Out: TypedEncoder](default: Out)(implicit isOption: U =:= Option[Out]): TC[Out] =
+  def getOrElse[Out: TypedEncoder](default: Out)(implicit isOption: U =:= Option[Out]): ThisType[T, Out] =
     getOrElse(lit[Out](default))
 
   /** Sum of this expression and another expression.
@@ -160,7 +161,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def plus(other: TC[U])(implicit n: CatalystNumeric[U]): TC[U] =
+  def plus(other: ThisType[T, U])(implicit n: CatalystNumeric[U]): ThisType[T, U] =
     typed(self.untyped.plus(other.untyped))
 
   /** Sum of this expression and another expression.
@@ -171,7 +172,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def +(u: TC[U])(implicit n: CatalystNumeric[U]): TC[U] = plus(u)
+  def +(u: ThisType[T, U])(implicit n: CatalystNumeric[U]): ThisType[T, U] = plus(u)
 
   /** Sum of this expression (column) with a constant.
     * {{{
@@ -182,7 +183,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def +(u: U)(implicit n: CatalystNumeric[U]): TC[U] = typed(self.untyped.plus(u))
+  def +(u: U)(implicit n: CatalystNumeric[U]): ThisType[T, U] = typed(self.untyped.plus(u))
 
   /** Unary minus, i.e. negate the expression.
     * {{{
@@ -192,7 +193,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def unary_-(implicit n: CatalystNumeric[U]): TC[U] = typed(-self.untyped)
+  def unary_-(implicit n: CatalystNumeric[U]): ThisType[T, U] = typed(-self.untyped)
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -202,7 +203,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def minus(u: TC[U])(implicit n: CatalystNumeric[U]): TC[U] = typed(self.untyped.minus(u.untyped))
+  def minus(u: ThisType[T, U])(implicit n: CatalystNumeric[U]): ThisType[T, U] = typed(self.untyped.minus(u.untyped))
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -212,7 +213,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def -(u: TC[U])(implicit n: CatalystNumeric[U]): TC[U] = minus(u)
+  def -(u: ThisType[T, U])(implicit n: CatalystNumeric[U]): ThisType[T, U] = minus(u)
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -223,7 +224,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def -(u: U)(implicit n: CatalystNumeric[U]): TC[U] = typed(self.untyped.minus(u))
+  def -(u: U)(implicit n: CatalystNumeric[U]): ThisType[T, U] = typed(self.untyped.minus(u))
 
   /** Multiplication of this expression and another expression.
     * {{{
@@ -233,7 +234,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def multiply(u: TC[U])(implicit n: CatalystNumeric[U], ct: ClassTag[U]): TC[U] = typed {
+  def multiply(u: ThisType[T, U])(implicit n: CatalystNumeric[U], ct: ClassTag[U]): ThisType[T, U] = typed {
     if (ct.runtimeClass == BigDecimal(0).getClass) {
       // That's apparently the only way to get sound multiplication.
       // See https://issues.apache.org/jira/browse/SPARK-22036
@@ -252,7 +253,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def *(u: TC[U])(implicit n: CatalystNumeric[U], tt: ClassTag[U]): TC[U] = multiply(u)
+  def *(u: ThisType[T, U])(implicit n: CatalystNumeric[U], tt: ClassTag[U]): ThisType[T, U] = multiply(u)
 
   /** Multiplication of this expression a constant.
     * {{{
@@ -262,7 +263,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *
     * apache/spark
     */
-  def *(u: U)(implicit n: CatalystNumeric[U]): TC[U] = typed(self.untyped.multiply(u))
+  def *(u: U)(implicit n: CatalystNumeric[U]): ThisType[T, U] = typed(self.untyped.multiply(u))
 
   /**
     * Division this expression by another expression.
@@ -274,7 +275,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param other another column of the same type
     * apache/spark
     */
-  def divide[Out: TypedEncoder](other: TC[U])(implicit n: CatalystDivisible[U, Out]): TC[Out] =
+  def divide[Out: TypedEncoder](other: ThisType[T, U])(implicit n: CatalystDivisible[U, Out]): ThisType[T, Out] =
     typed(self.untyped.divide(other.untyped))
 
   /**
@@ -287,10 +288,10 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param other another column of the same type
     * apache/spark
     */
-  def /[Out](other: TC[U])
+  def /[Out](other: ThisType[T, U])
      (implicit
         n: CatalystDivisible[U, Out],
-        e: TypedEncoder[Out]): TC[Out] = divide(other)
+        e: TypedEncoder[Out]): ThisType[T, Out] = divide(other)
 
   /**
     * Division this expression by another expression.
@@ -302,7 +303,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def /(u: U)(implicit n: CatalystNumeric[U]): TC[Double] = typed(self.untyped.divide(u))
+  def /(u: U)(implicit n: CatalystNumeric[U]): ThisType[T, Double] = typed(self.untyped.divide(u))
 
   /**
     * Bitwise AND this expression and another expression.
@@ -313,7 +314,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseAND(u: U)(implicit n: CatalystBitwise[U]): TC[U] =
+  def bitwiseAND(u: U)(implicit n: CatalystBitwise[U]): ThisType[T, U] =
     typed(self.untyped.bitwiseAND(u))
 
   /**
@@ -325,7 +326,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseAND(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] =
+  def bitwiseAND(u: ThisType[T, U])(implicit n: CatalystBitwise[U]): ThisType[T, U] =
     typed(self.untyped.bitwiseAND(u.untyped))
 
   /**
@@ -337,7 +338,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def &(u: U)(implicit n: CatalystBitwise[U]): TC[U] = bitwiseAND(u)
+  def &(u: U)(implicit n: CatalystBitwise[U]): ThisType[T, U] = bitwiseAND(u)
 
   /**
     * Bitwise AND this expression and another expression.
@@ -348,7 +349,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def &(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] = bitwiseAND(u)
+  def &(u: ThisType[T, U])(implicit n: CatalystBitwise[U]): ThisType[T, U] = bitwiseAND(u)
 
   /**
     * Bitwise OR this expression and another expression.
@@ -359,7 +360,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseOR(u: U)(implicit n: CatalystBitwise[U]): TC[U] = typed(self.untyped.bitwiseOR(u))
+  def bitwiseOR(u: U)(implicit n: CatalystBitwise[U]): ThisType[T, U] = typed(self.untyped.bitwiseOR(u))
 
   /**
     * Bitwise OR this expression and another expression.
@@ -370,7 +371,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseOR(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] =
+  def bitwiseOR(u: ThisType[T, U])(implicit n: CatalystBitwise[U]): ThisType[T, U] =
     typed(self.untyped.bitwiseOR(u.untyped))
 
   /**
@@ -382,7 +383,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def |(u: U)(implicit n: CatalystBitwise[U]): TC[U] = bitwiseOR(u)
+  def |(u: U)(implicit n: CatalystBitwise[U]): ThisType[T, U] = bitwiseOR(u)
 
   /**
     * Bitwise OR this expression and another expression.
@@ -393,7 +394,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def |(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] = bitwiseOR(u)
+  def |(u: ThisType[T, U])(implicit n: CatalystBitwise[U]): ThisType[T, U] = bitwiseOR(u)
 
   /**
     * Bitwise XOR this expression and another expression.
@@ -404,7 +405,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseXOR(u: U)(implicit n: CatalystBitwise[U]): TC[U] =
+  def bitwiseXOR(u: U)(implicit n: CatalystBitwise[U]): ThisType[T, U] =
     typed(self.untyped.bitwiseXOR(u))
 
   /**
@@ -416,7 +417,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseXOR(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] =
+  def bitwiseXOR(u: ThisType[T, U])(implicit n: CatalystBitwise[U]): ThisType[T, U] =
     typed(self.untyped.bitwiseXOR(u.untyped))
 
   /**
@@ -428,7 +429,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def ^(u: U)(implicit n: CatalystBitwise[U]): TC[U] = bitwiseXOR(u)
+  def ^(u: U)(implicit n: CatalystBitwise[U]): ThisType[T, U] = bitwiseXOR(u)
 
   /**
     * Bitwise XOR this expression and another expression.
@@ -439,14 +440,14 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def ^(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] = bitwiseXOR(u)
+  def ^(u: ThisType[T, U])(implicit n: CatalystBitwise[U]): ThisType[T, U] = bitwiseXOR(u)
 
   /** Casts the column to a different type.
     * {{{
     *   df.select(df('a).cast[Int])
     * }}}
     */
-  def cast[A: TypedEncoder](implicit c: CatalystCast[U, A]): TC[A] =
+  def cast[A: TypedEncoder](implicit c: CatalystCast[U, A]): ThisType[T, A] =
     typed(self.untyped.cast(TypedEncoder[A].catalystRepr))
 
   /** Contains test.
@@ -454,7 +455,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *   df.filter ( df.col('a).contains("foo") )
     * }}}
     */
-  def contains(other: String)(implicit ev: U =:= String): TC[Boolean] =
+  def contains(other: String)(implicit ev: U =:= String): ThisType[T, Boolean] =
     typed(self.untyped.contains(other))
 
   /** Contains test.
@@ -462,7 +463,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *   df.filter ( df.col('a).contains(df.col('b) )
     * }}}
     */
-  def contains(other: TC[U])(implicit ev: U =:= String): TC[Boolean] =
+  def contains(other: ThisType[T, U])(implicit ev: U =:= String): ThisType[T, Boolean] =
     typed(self.untyped.contains(other.untyped))
 
   /** Boolean AND.
@@ -470,7 +471,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *   df.filter ( (df.col('a) === 1).and(df.col('b) > 5) )
     * }}}
     */
-  def and(other: TC[Boolean]): TC[Boolean] =
+  def and(other: ThisType[T, Boolean]): ThisType[T, Boolean] =
     typed(self.untyped.and(other.untyped))
 
   /** Boolean AND.
@@ -478,14 +479,14 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *   df.filter ( df.col('a) === 1 && df.col('b) > 5)
     * }}}
     */
-  def && (other: TC[Boolean]): TC[Boolean] = and(other)
+  def && (other: ThisType[T, Boolean]): ThisType[T, Boolean] = and(other)
 
   /** Boolean OR.
     * {{{
     *   df.filter ( (df.col('a) === 1).or(df.col('b) > 5) )
     * }}}
     */
-  def or(other: TC[Boolean]): TC[Boolean] =
+  def or(other: ThisType[T, Boolean]): ThisType[T, Boolean] =
     typed(self.untyped.or(other.untyped))
 
   /** Boolean OR.
@@ -493,7 +494,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     *   df.filter ( df.col('a) === 1 || df.col('b) > 5)
     * }}}
     */
-  def || (other: TC[Boolean]): TC[Boolean] = or(other)
+  def || (other: ThisType[T, Boolean]): ThisType[T, Boolean] = or(other)
 
   /**
     * Less than.
@@ -505,7 +506,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u another column of the same type
     * apache/spark
     */
-  def <(u: TC[U])(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+  def <(u: ThisType[T, U])(implicit canOrder: CatalystOrdered[U]): ThisType[T, Boolean] =
     typed(self.untyped < u.untyped)
 
   /**
@@ -518,7 +519,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u another column of the same type
     * apache/spark
     */
-  def <=(u: TC[U])(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+  def <=(u: ThisType[T, U])(implicit canOrder: CatalystOrdered[U]): ThisType[T, Boolean] =
     typed(self.untyped <= u.untyped)
 
   /**
@@ -531,7 +532,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u another column of the same type
     * apache/spark
     */
-  def >(u: TC[U])(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+  def >(u: ThisType[T, U])(implicit canOrder: CatalystOrdered[U]): ThisType[T, Boolean] =
     typed(self.untyped > u.untyped)
 
   /**
@@ -544,7 +545,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u another column of the same type
     * apache/spark
     */
-  def >=(u: TC[U])(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+  def >=(u: ThisType[T, U])(implicit canOrder: CatalystOrdered[U]): ThisType[T, Boolean] =
     typed(self.untyped >= u.untyped)
 
   /**
@@ -557,7 +558,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def <(u: U)(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+  def <(u: U)(implicit canOrder: CatalystOrdered[U]): ThisType[T, Boolean] =
     typed(self.untyped < lit(u)(self.uencoder).untyped)
 
   /**
@@ -570,7 +571,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u a constant of the same type
     * apache/spark
     */
-  def <=(u: U)(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+  def <=(u: U)(implicit canOrder: CatalystOrdered[U]): ThisType[T, Boolean] =
     typed(self.untyped <= lit(u)(self.uencoder).untyped)
 
   /**
@@ -583,7 +584,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u another column of the same type
     * apache/spark
     */
-  def >(u: U)(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+  def >(u: U)(implicit canOrder: CatalystOrdered[U]): ThisType[T, Boolean] =
     typed(self.untyped > lit(u)(self.uencoder).untyped)
 
   /**
@@ -596,7 +597,7 @@ abstract class AbstractTypedColumn[T, U](val expr: Expression)(
     * @param u another column of the same type
     * apache/spark
     */
-  def >=(u: U)(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+  def >=(u: U)(implicit canOrder: CatalystOrdered[U]): ThisType[T, Boolean] =
     typed(self.untyped >= lit(u)(self.uencoder).untyped)
 }
 

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -81,11 +81,11 @@ abstract class AbstractTypedColumn[T, U]
 
   /** Creates a typed column of either TypedColumn or TypedAggregate.
     */
-  protected def typed[U1: TypedEncoder](c: Column): ThisType[T, U1]
+ def typed[U1: TypedEncoder](c: Column): ThisType[T, U1]
 
   /** Creates a typed column of either TypedColumn or TypedAggregate.
     */
-  protected def lit[U1: TypedEncoder](c: U1): ThisType[T, U1]
+  def lit[U1: TypedEncoder](c: U1): ThisType[T, U1]
 
   /** Equality test.
     * {{{

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -81,7 +81,7 @@ abstract class AbstractTypedColumn[T, U]
 
   /** Creates a typed column of either TypedColumn or TypedAggregate.
     */
- def typed[U1: TypedEncoder](c: Column): ThisType[T, U1]
+  def typed[U1: TypedEncoder](c: Column): ThisType[T, U1]
 
   /** Creates a typed column of either TypedColumn or TypedAggregate.
     */

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -1,16 +1,15 @@
 package frameless
 
+import frameless.functions.{lit => flit, litAggr}
 import frameless.syntax._
-import frameless.functions._
-
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.{Column, FramelessInternals}
 import org.apache.spark.sql.types.DecimalType
-import shapeless.ops.record.Selector
+import org.apache.spark.sql.{Column, FramelessInternals}
 import shapeless._
+import shapeless.ops.record.Selector
 
-import scala.reflect.ClassTag
 import scala.annotation.implicitNotFound
+import scala.reflect.ClassTag
 
 sealed trait UntypedExpression[T] {
   def expr: Expression
@@ -19,6 +18,39 @@ sealed trait UntypedExpression[T] {
 }
 
 /** Expression used in `select`-like constructions.
+  */
+sealed class TypedColumn[T, U](expr: Expression)(
+  implicit val uenc: TypedEncoder[U]
+) extends AbstractTypedColumn[T,U](expr) {
+
+  type TC[A] = TypedColumn[T,A]
+
+  def this(column: Column)(implicit uencoder: TypedEncoder[U]) {
+    this(FramelessInternals.expr(column))
+  }
+
+  override def typed[U1: TypedEncoder](c: Column): TypedColumn[T, U1] = c.typedColumn
+  override def lit[U1: TypedEncoder](c: U1): TypedColumn[T,U1] = flit(c)
+}
+
+/** Expression used in `agg`-like constructions.
+  */
+sealed class TypedAggregate[T, U](expr: Expression)(
+  implicit val uenc: TypedEncoder[U]
+) extends AbstractTypedColumn[T,U](expr) {
+
+  type TC[A] = TypedAggregate[T, A]
+
+  def this(column: Column)(implicit uencoder: TypedEncoder[U]) {
+    this(FramelessInternals.expr(column))
+  }
+
+  override def typed[U1: TypedEncoder](c: Column): TypedAggregate[T,U1] = c.typedAggregate
+  override def lit[U1: TypedEncoder](c: U1): TypedAggregate[T,U1] = litAggr(c)
+}
+
+/** Generic representation of a typed column. A typed column can either be a [[TypedAggregate]] or
+  * a [[frameless.TypedColumn]].
   *
   * Documentation marked "apache/spark" is thanks to apache/spark Contributors
   * at https://github.com/apache/spark, licensed under Apache v2.0 available at
@@ -27,31 +59,32 @@ sealed trait UntypedExpression[T] {
   * @tparam T type of dataset
   * @tparam U type of column
   */
-sealed class TypedColumn[T, U](
-  val expr: Expression)(
-  implicit
-  val uencoder: TypedEncoder[U]
+abstract class AbstractTypedColumn[T, U](val expr: Expression)(
+  implicit val uencoder: TypedEncoder[U]
 ) extends UntypedExpression[T] { self =>
 
-  /** From an untyped Column to a [[TypedColumn]]
-    *
-    * @param column a spark.sql Column
-    * @param uencoder encoder of the resulting type U
-    */
-  def this(column: Column)(implicit uencoder: TypedEncoder[U]) {
-    this(FramelessInternals.expr(column))
-  }
+  type TC[A] <: AbstractTypedColumn[T, A]
 
   /** Fall back to an untyped Column
     */
   def untyped: Column = new Column(expr)
 
-  private def withExpr(newExpr: Expression): Column = new Column(newExpr)
-
-  private def equalsTo(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = withExpr {
+  private def equalsTo(other: TC[U]): TC[Boolean] = typed {
     if (uencoder.nullable && uencoder.catalystRepr.typeName != "struct") EqualNullSafe(self.expr, other.expr)
     else EqualTo(self.expr, other.expr)
-  }.typed
+  }
+
+  /** Creates a typed column of either TypedColumn or TypedAggregate from an expression.
+    */
+  protected def typed[U1: TypedEncoder](e: Expression): TC[U1] = typed(new Column(e))
+
+  /** Creates a typed column of either TypedColumn or TypedAggregate.
+    */
+  protected def typed[U1: TypedEncoder](c: Column): TC[U1]
+
+  /** Creates a typed column of either TypedColumn or TypedAggregate.
+    */
+  protected def lit[U1: TypedEncoder](c: U1): TC[U1]
 
   /** Equality test.
     * {{{
@@ -60,7 +93,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def ===(other: U): TypedColumn[T, Boolean] = equalsTo(lit(other))
+  def ===(other: U): TC[Boolean] = equalsTo(lit(other))
 
   /** Equality test.
     * {{{
@@ -69,7 +102,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def ===(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = equalsTo(other)
+  def ===(other: TC[U]): TC[Boolean] = equalsTo(other)
 
   /** Inequality test.
     * {{{
@@ -78,9 +111,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def =!=(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = withExpr {
-    Not(equalsTo(other).expr)
-  }.typed
+  def =!=(other: TC[U]): TC[Boolean] = typed(Not(equalsTo(other).expr))
 
   /** Inequality test.
     * {{{
@@ -89,41 +120,37 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def =!=(other: U): TypedColumn[T, Boolean] = withExpr {
-    Not(equalsTo(lit(other)).expr)
-  }.typed
+  def =!=(other: U): TC[Boolean] = typed(Not(equalsTo(lit(other)).expr))
 
   /** True if the current expression is an Option and it's None.
     *
     * apache/spark
     */
-  def isNone(implicit isOption: U <:< Option[_]): TypedColumn[T, Boolean] =
-    equalsTo(lit[U,T](None.asInstanceOf[U]))
+  def isNone(implicit isOption: U <:< Option[_]): TC[Boolean] =
+    equalsTo(lit[U](None.asInstanceOf[U]))
 
   /** True if the current expression is an Option and it's not None.
     *
     * apache/spark
     */
-  def isNotNone(implicit isOption: U <:< Option[_]): TypedColumn[T, Boolean] = withExpr {
-    Not(equalsTo(lit(None.asInstanceOf[U])).expr)
-  }.typed
+  def isNotNone(implicit isOption: U <:< Option[_]): TC[Boolean] =
+    typed(Not(equalsTo(lit(None.asInstanceOf[U])).expr))
 
   /** Convert an Optional column by providing a default value
     * {{{
     *   df( df('opt).getOrElse(df('defaultValue)) )
     * }}}
     */
-  def getOrElse[Out](default: TypedColumn[T, Out])(implicit isOption: U =:= Option[Out]): TypedColumn[T, Out] = withExpr {
-    Coalesce(Seq(expr, default.expr))
-  }.typed(default.uencoder)
+  def getOrElse[Out](default: TC[Out])(implicit isOption: U =:= Option[Out]): TC[Out] =
+    typed(Coalesce(Seq(expr, default.expr)))(default.uencoder)
 
   /** Convert an Optional column by providing a default value
     * {{{
     *   df( df('opt).getOrElse(defaultConstant) )
     * }}}
     */
-  def getOrElse[Out: TypedEncoder](default: Out)(implicit isOption: U =:= Option[Out]): TypedColumn[T, Out] =
-    getOrElse(lit[Out, T](default))
+  def getOrElse[Out: TypedEncoder](default: Out)(implicit isOption: U =:= Option[Out]): TC[Out] =
+    getOrElse(lit[Out](default))
 
   /** Sum of this expression and another expression.
     * {{{
@@ -133,8 +160,8 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def plus(other: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] =
-    self.untyped.plus(other.untyped).typed
+  def plus(other: TC[U])(implicit n: CatalystNumeric[U]): TC[U] =
+    typed(self.untyped.plus(other.untyped))
 
   /** Sum of this expression and another expression.
     * {{{
@@ -144,7 +171,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def +(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = plus(u)
+  def +(u: TC[U])(implicit n: CatalystNumeric[U]): TC[U] = plus(u)
 
   /** Sum of this expression (column) with a constant.
     * {{{
@@ -155,7 +182,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def +(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = self.untyped.plus(u).typed
+  def +(u: U)(implicit n: CatalystNumeric[U]): TC[U] = typed(self.untyped.plus(u))
 
   /** Unary minus, i.e. negate the expression.
     * {{{
@@ -165,7 +192,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def unary_-(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = (-self.untyped).typed
+  def unary_-(implicit n: CatalystNumeric[U]): TC[U] = typed(-self.untyped)
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -175,8 +202,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def minus(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] =
-    self.untyped.minus(u.untyped).typed
+  def minus(u: TC[U])(implicit n: CatalystNumeric[U]): TC[U] = typed(self.untyped.minus(u.untyped))
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -186,7 +212,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def -(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = minus(u)
+  def -(u: TC[U])(implicit n: CatalystNumeric[U]): TC[U] = minus(u)
 
   /** Subtraction. Subtract the other expression from this expression.
     * {{{
@@ -197,7 +223,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def -(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = self.untyped.minus(u).typed
+  def -(u: U)(implicit n: CatalystNumeric[U]): TC[U] = typed(self.untyped.minus(u))
 
   /** Multiplication of this expression and another expression.
     * {{{
@@ -207,14 +233,14 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def multiply(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U], ct: ClassTag[U]): TypedColumn[T, U] = {
+  def multiply(u: TC[U])(implicit n: CatalystNumeric[U], ct: ClassTag[U]): TC[U] = typed {
     if (ct.runtimeClass == BigDecimal(0).getClass) {
       // That's apparently the only way to get sound multiplication.
       // See https://issues.apache.org/jira/browse/SPARK-22036
       val dt = DecimalType(20, 14)
-      self.untyped.cast(dt).multiply(u.untyped.cast(dt)).typed
+      self.untyped.cast(dt).multiply(u.untyped.cast(dt))
     } else {
-      self.untyped.multiply(u.untyped).typed
+      self.untyped.multiply(u.untyped)
     }
   }
 
@@ -226,7 +252,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def *(u: TypedColumn[T, U])(implicit n: CatalystNumeric[U], tt: ClassTag[U]): TypedColumn[T, U] = multiply(u)
+  def *(u: TC[U])(implicit n: CatalystNumeric[U], tt: ClassTag[U]): TC[U] = multiply(u)
 
   /** Multiplication of this expression a constant.
     * {{{
@@ -236,7 +262,7 @@ sealed class TypedColumn[T, U](
     *
     * apache/spark
     */
-  def *(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, U] = self.untyped.multiply(u).typed
+  def *(u: U)(implicit n: CatalystNumeric[U]): TC[U] = typed(self.untyped.multiply(u))
 
   /**
     * Division this expression by another expression.
@@ -248,8 +274,8 @@ sealed class TypedColumn[T, U](
     * @param other another column of the same type
     * apache/spark
     */
-  def divide[Out: TypedEncoder](other: TypedColumn[T, U])(implicit n: CatalystDivisible[U, Out]): TypedColumn[T, Out] =
-    self.untyped.divide(other.untyped).typed
+  def divide[Out: TypedEncoder](other: TC[U])(implicit n: CatalystDivisible[U, Out]): TC[Out] =
+    typed(self.untyped.divide(other.untyped))
 
   /**
     * Division this expression by another expression.
@@ -261,10 +287,10 @@ sealed class TypedColumn[T, U](
     * @param other another column of the same type
     * apache/spark
     */
-  def /[Out](other: TypedColumn[T, U])
+  def /[Out](other: TC[U])
      (implicit
         n: CatalystDivisible[U, Out],
-        e: TypedEncoder[Out]): TypedColumn[T, Out] = divide(other)
+        e: TypedEncoder[Out]): TC[Out] = divide(other)
 
   /**
     * Division this expression by another expression.
@@ -276,7 +302,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def /(u: U)(implicit n: CatalystNumeric[U]): TypedColumn[T, Double] = self.untyped.divide(u).typed
+  def /(u: U)(implicit n: CatalystNumeric[U]): TC[Double] = typed(self.untyped.divide(u))
 
   /**
     * Bitwise AND this expression and another expression.
@@ -287,7 +313,8 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseAND(u: U)(implicit n: CatalystBitwise[U]): TypedColumn[T, U] = self.untyped.bitwiseAND(u).typed
+  def bitwiseAND(u: U)(implicit n: CatalystBitwise[U]): TC[U] =
+    typed(self.untyped.bitwiseAND(u))
 
   /**
     * Bitwise AND this expression and another expression.
@@ -298,8 +325,8 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseAND(u: TypedColumn[T, U])(implicit n: CatalystBitwise[U]): TypedColumn[T, U] =
-    self.untyped.bitwiseAND(u.untyped).typed
+  def bitwiseAND(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] =
+    typed(self.untyped.bitwiseAND(u.untyped))
 
   /**
     * Bitwise AND this expression and another expression (of same type).
@@ -310,7 +337,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def &(u: U)(implicit n: CatalystBitwise[U]): TypedColumn[T, U] = bitwiseAND(u)
+  def &(u: U)(implicit n: CatalystBitwise[U]): TC[U] = bitwiseAND(u)
 
   /**
     * Bitwise AND this expression and another expression.
@@ -321,7 +348,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def &(u: TypedColumn[T, U])(implicit n: CatalystBitwise[U]): TypedColumn[T, U] = bitwiseAND(u)
+  def &(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] = bitwiseAND(u)
 
   /**
     * Bitwise OR this expression and another expression.
@@ -332,7 +359,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseOR(u: U)(implicit n: CatalystBitwise[U]): TypedColumn[T, U] = self.untyped.bitwiseOR(u).typed
+  def bitwiseOR(u: U)(implicit n: CatalystBitwise[U]): TC[U] = typed(self.untyped.bitwiseOR(u))
 
   /**
     * Bitwise OR this expression and another expression.
@@ -343,8 +370,8 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseOR(u: TypedColumn[T, U])(implicit n: CatalystBitwise[U]): TypedColumn[T, U] =
-    self.untyped.bitwiseOR(u.untyped).typed
+  def bitwiseOR(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] =
+    typed(self.untyped.bitwiseOR(u.untyped))
 
   /**
     * Bitwise OR this expression and another expression (of same type).
@@ -355,7 +382,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def |(u: U)(implicit n: CatalystBitwise[U]): TypedColumn[T, U] = bitwiseOR(u)
+  def |(u: U)(implicit n: CatalystBitwise[U]): TC[U] = bitwiseOR(u)
 
   /**
     * Bitwise OR this expression and another expression.
@@ -366,7 +393,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def |(u: TypedColumn[T, U])(implicit n: CatalystBitwise[U]): TypedColumn[T, U] = bitwiseOR(u)
+  def |(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] = bitwiseOR(u)
 
   /**
     * Bitwise XOR this expression and another expression.
@@ -377,7 +404,8 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseXOR(u: U)(implicit n: CatalystBitwise[U]): TypedColumn[T, U] = self.untyped.bitwiseXOR(u).typed
+  def bitwiseXOR(u: U)(implicit n: CatalystBitwise[U]): TC[U] =
+    typed(self.untyped.bitwiseXOR(u))
 
   /**
     * Bitwise XOR this expression and another expression.
@@ -388,8 +416,8 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def bitwiseXOR(u: TypedColumn[T, U])(implicit n: CatalystBitwise[U]): TypedColumn[T, U] =
-    self.untyped.bitwiseXOR(u.untyped).typed
+  def bitwiseXOR(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] =
+    typed(self.untyped.bitwiseXOR(u.untyped))
 
   /**
     * Bitwise XOR this expression and another expression (of same type).
@@ -400,7 +428,7 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def ^(u: U)(implicit n: CatalystBitwise[U]): TypedColumn[T, U] = bitwiseXOR(u)
+  def ^(u: U)(implicit n: CatalystBitwise[U]): TC[U] = bitwiseXOR(u)
 
   /**
     * Bitwise XOR this expression and another expression.
@@ -411,79 +439,167 @@ sealed class TypedColumn[T, U](
     * @param u a constant of the same type
     * apache/spark
     */
-  def ^(u: TypedColumn[T, U])(implicit n: CatalystBitwise[U]): TypedColumn[T, U] = bitwiseXOR(u)
+  def ^(u: TC[U])(implicit n: CatalystBitwise[U]): TC[U] = bitwiseXOR(u)
 
   /** Casts the column to a different type.
     * {{{
     *   df.select(df('a).cast[Int])
     * }}}
     */
-  def cast[A: TypedEncoder](implicit c: CatalystCast[U, A]): TypedColumn[T, A] =
-    self.untyped.cast(TypedEncoder[A].catalystRepr).typed
+  def cast[A: TypedEncoder](implicit c: CatalystCast[U, A]): TC[A] =
+    typed(self.untyped.cast(TypedEncoder[A].catalystRepr))
 
   /** Contains test.
     * {{{
     *   df.filter ( df.col('a).contains("foo") )
     * }}}
     */
-  def contains(other: String)(implicit ev: U =:= String): TypedColumn[T, Boolean] =
-    self.untyped.contains(other).typed
+  def contains(other: String)(implicit ev: U =:= String): TC[Boolean] =
+    typed(self.untyped.contains(other))
 
   /** Contains test.
     * {{{
     *   df.filter ( df.col('a).contains(df.col('b) )
     * }}}
     */
-  def contains(other: TypedColumn[T, U])(implicit ev: U =:= String): TypedColumn[T, Boolean] =
-    self.untyped.contains(other.untyped).typed
+  def contains(other: TC[U])(implicit ev: U =:= String): TC[Boolean] =
+    typed(self.untyped.contains(other.untyped))
 
   /** Boolean AND.
     * {{{
     *   df.filter ( (df.col('a) === 1).and(df.col('b) > 5) )
     * }}}
     */
-  def and(other: TypedColumn[T, Boolean]): TypedColumn[T, Boolean] =
-    self.untyped.and(other.untyped).typed
+  def and(other: TC[Boolean]): TC[Boolean] =
+    typed(self.untyped.and(other.untyped))
 
   /** Boolean AND.
     * {{{
     *   df.filter ( df.col('a) === 1 && df.col('b) > 5)
     * }}}
     */
-  def && (other: TypedColumn[T, Boolean]): TypedColumn[T, Boolean] =
-    and(other)
+  def && (other: TC[Boolean]): TC[Boolean] = and(other)
 
   /** Boolean OR.
     * {{{
     *   df.filter ( (df.col('a) === 1).or(df.col('b) > 5) )
     * }}}
     */
-  def or(other: TypedColumn[T, Boolean]): TypedColumn[T, Boolean] =
-    self.untyped.or(other.untyped).typed
+  def or(other: TC[Boolean]): TC[Boolean] =
+    typed(self.untyped.or(other.untyped))
 
   /** Boolean OR.
     * {{{
     *   df.filter ( df.col('a) === 1 || df.col('b) > 5)
     * }}}
     */
-  def || (other: TypedColumn[T, Boolean]): TypedColumn[T, Boolean] =
-    or(other)
+  def || (other: TC[Boolean]): TC[Boolean] = or(other)
+
+  /**
+    * Less than.
+    * {{{
+    *   // The following selects people younger than the maxAge column.
+    *   df.select( df('age) < df('maxAge) )
+    * }}}
+    *
+    * @param u another column of the same type
+    * apache/spark
+    */
+  def <(u: TC[U])(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+    typed(self.untyped < u.untyped)
+
+  /**
+    * Less than or equal to.
+    * {{{
+    *   // The following selects people younger or equal than the maxAge column.
+    *   df.select( df('age) <= df('maxAge)
+    * }}}
+    *
+    * @param u another column of the same type
+    * apache/spark
+    */
+  def <=(u: TC[U])(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+    typed(self.untyped <= u.untyped)
+
+  /**
+    * Greater than.
+    * {{{
+    *   // The following selects people older than the maxAge column.
+    *   df.select( df('age) > df('maxAge) )
+    * }}}
+    *
+    * @param u another column of the same type
+    * apache/spark
+    */
+  def >(u: TC[U])(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+    typed(self.untyped > u.untyped)
+
+  /**
+    * Greater than or equal.
+    * {{{
+    *   // The following selects people older or equal than the maxAge column.
+    *   df.select( df('age) >= df('maxAge) )
+    * }}}
+    *
+    * @param u another column of the same type
+    * apache/spark
+    */
+  def >=(u: TC[U])(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+    typed(self.untyped >= u.untyped)
+
+  /**
+    * Less than.
+    * {{{
+    *   // The following selects people younger than 21.
+    *   df.select( df('age) < 21 )
+    * }}}
+    *
+    * @param u a constant of the same type
+    * apache/spark
+    */
+  def <(u: U)(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+    typed(self.untyped < lit(u)(self.uencoder).untyped)
+
+  /**
+    * Less than or equal to.
+    * {{{
+    *   // The following selects people younger than 22.
+    *   df.select( df('age) <= 2 )
+    * }}}
+    *
+    * @param u a constant of the same type
+    * apache/spark
+    */
+  def <=(u: U)(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+    typed(self.untyped <= lit(u)(self.uencoder).untyped)
+
+  /**
+    * Greater than.
+    * {{{
+    *   // The following selects people older than 21.
+    *   df.select( df('age) > 21 )
+    * }}}
+    *
+    * @param u another column of the same type
+    * apache/spark
+    */
+  def >(u: U)(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+    typed(self.untyped > lit(u)(self.uencoder).untyped)
+
+  /**
+    * Greater than or equal.
+    * {{{
+    *   // The following selects people older than 20.
+    *   df.select( df('age) >= 21 )
+    * }}}
+    *
+    * @param u another column of the same type
+    * apache/spark
+    */
+  def >=(u: U)(implicit canOrder: CatalystOrdered[U]): TC[Boolean] =
+    typed(self.untyped >= lit(u)(self.uencoder).untyped)
 }
 
-/** Expression used in `groupBy`-like constructions.
-  *
-  * @tparam T type of dataset
-  * @tparam U type of column for `groupBy`
-  */
-sealed class TypedAggregate[T, U](val expr: Expression)(
-  implicit
-  val uencoder: TypedEncoder[U]
-) extends UntypedExpression[T] {
-
-  def this(column: Column)(implicit e: TypedEncoder[U]) {
-    this(FramelessInternals.expr(column))
-  }
-}
 
 object TypedColumn {
   /**
@@ -515,17 +631,5 @@ object TypedColumn {
         i0: LabelledGeneric.Aux[T, H],
         i1: Selector.Aux[H, K, V]
       ): Exists[T, K, V] = new Exists[T, K, V] {}
-  }
-
-  implicit class OrderedTypedColumnSyntax[T, U: CatalystOrdered](col: TypedColumn[T, U]) {
-    def <(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (col.untyped < other.untyped).typed
-    def <=(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (col.untyped <= other.untyped).typed
-    def >(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (col.untyped > other.untyped).typed
-    def >=(other: TypedColumn[T, U]): TypedColumn[T, Boolean] = (col.untyped >= other.untyped).typed
-
-    def <(other: U): TypedColumn[T, Boolean] = (col.untyped < lit(other)(col.uencoder).untyped).typed
-    def <=(other: U): TypedColumn[T, Boolean] = (col.untyped <= lit(other)(col.uencoder).untyped).typed
-    def >(other: U): TypedColumn[T, Boolean] = (col.untyped > lit(other)(col.uencoder).untyped).typed
-    def >=(other: U): TypedColumn[T, Boolean] = (col.untyped >= lit(other)(col.uencoder).untyped).typed
   }
 }

--- a/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
@@ -7,15 +7,6 @@ import org.apache.spark.sql.{functions => untyped}
 import frameless.syntax._
 
 trait AggregateFunctions {
-
-  /** Creates a [[frameless.TypedColumn]] of literal value. If A is to be encoded using an Injection make
-    * sure the injection instance is in scope.
-    *
-    * apache/spark
-    */
-  def litAggr[A: TypedEncoder, T](value: A): TypedAggregate[T, A] =
-    frameless.functions.lit(value).untyped.typedAggregate
-
   /** Aggregate function: returns the number of items in a group.
     *
     * apache/spark

--- a/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
@@ -4,6 +4,7 @@ package functions
 import org.apache.spark.sql.FramelessInternals.expr
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.{functions => untyped}
+import frameless.syntax._
 
 trait AggregateFunctions {
 
@@ -12,37 +13,34 @@ trait AggregateFunctions {
     *
     * apache/spark
     */
-  def lit[A: TypedEncoder, T](value: A): TypedColumn[T, A] = frameless.functions.lit(value)
+  def litAggr[A: TypedEncoder, T](value: A): TypedAggregate[T, A] =
+    frameless.functions.lit(value).untyped.typedAggregate
 
   /** Aggregate function: returns the number of items in a group.
     *
     * apache/spark
     */
-  def count[T](): TypedAggregate[T, Long] = {
-    new TypedAggregate(untyped.count(untyped.lit(1)))
-  }
+  def count[T](): TypedAggregate[T, Long] =
+    untyped.count(untyped.lit(1)).typedAggregate
 
   /** Aggregate function: returns the number of items in a group for which the selected column is not null.
     *
     * apache/spark
     */
-  def count[T](column: TypedColumn[T, _]): TypedAggregate[T, Long] = {
-    new TypedAggregate[T, Long](untyped.count(column.untyped))
-  }
+  def count[T](column: TypedColumn[T, _]): TypedAggregate[T, Long] =
+    untyped.count(column.untyped).typedAggregate
 
   /** Aggregate function: returns the number of distinct items in a group.
     *
     * apache/spark
     */
-  def countDistinct[T](column: TypedColumn[T, _]): TypedAggregate[T, Long] = {
-    new TypedAggregate[T, Long](untyped.countDistinct(column.untyped))
-  }
+  def countDistinct[T](column: TypedColumn[T, _]): TypedAggregate[T, Long] =
+    untyped.countDistinct(column.untyped).typedAggregate
 
   /** Aggregate function: returns the approximate number of distinct items in a group.
     */
-  def approxCountDistinct[T](column: TypedColumn[T, _]): TypedAggregate[T, Long] = {
-    new TypedAggregate[T, Long](untyped.approx_count_distinct(column.untyped))
-  }
+  def approxCountDistinct[T](column: TypedColumn[T, _]): TypedAggregate[T, Long] =
+    untyped.approx_count_distinct(column.untyped).typedAggregate
 
   /** Aggregate function: returns the approximate number of distinct items in a group.
     *
@@ -50,25 +48,22 @@ trait AggregateFunctions {
     *
     * apache/spark
     */
-  def approxCountDistinct[T](column: TypedColumn[T, _], rsd: Double): TypedAggregate[T, Long] = {
-    new TypedAggregate[T, Long](untyped.approx_count_distinct(column.untyped, rsd))
-  }
+  def approxCountDistinct[T](column: TypedColumn[T, _], rsd: Double): TypedAggregate[T, Long] =
+    untyped.approx_count_distinct(column.untyped, rsd).typedAggregate
 
   /** Aggregate function: returns a list of objects with duplicates.
     *
     * apache/spark
     */
-  def collectList[T, A: TypedEncoder](column: TypedColumn[T, A]): TypedAggregate[T, Vector[A]] = {
-    new TypedAggregate[T, Vector[A]](untyped.collect_list(column.untyped))
-  }
+  def collectList[T, A: TypedEncoder](column: TypedColumn[T, A]): TypedAggregate[T, Vector[A]] =
+    untyped.collect_list(column.untyped).typedAggregate
 
   /** Aggregate function: returns a set of objects with duplicate elements eliminated.
     *
     * apache/spark
     */
-  def collectSet[T, A: TypedEncoder](column: TypedColumn[T, A]): TypedAggregate[T, Vector[A]] = {
-    new TypedAggregate[T, Vector[A]](untyped.collect_set(column.untyped))
-  }
+  def collectSet[T, A: TypedEncoder](column: TypedColumn[T, A]): TypedAggregate[T, Vector[A]] =
+    untyped.collect_set(column.untyped).typedAggregate
 
   /** Aggregate function: returns the sum of all values in the given column.
     *
@@ -114,7 +109,6 @@ trait AggregateFunctions {
     new TypedAggregate[T, Out](untyped.avg(column.untyped))
   }
 
-
   /** Aggregate function: returns the unbiased variance of the values in a group.
     *
     * @note In Spark variance always returns Double
@@ -122,9 +116,8 @@ trait AggregateFunctions {
     *
     * apache/spark
     */
-  def variance[A: CatalystVariance, T](column: TypedColumn[T, A]): TypedAggregate[T, Double] = {
-    new TypedAggregate[T, Double](untyped.variance(column.untyped))
-  }
+  def variance[A: CatalystVariance, T](column: TypedColumn[T, A]): TypedAggregate[T, Double] =
+    untyped.variance(column.untyped).typedAggregate
 
   /** Aggregate function: returns the sample standard deviation.
     *
@@ -133,9 +126,8 @@ trait AggregateFunctions {
     *
     * apache/spark
     */
-  def stddev[A: CatalystVariance, T](column: TypedColumn[T, A]): TypedAggregate[T, Double] = {
-    new TypedAggregate[T, Double](untyped.stddev(column.untyped))
-  }
+  def stddev[A: CatalystVariance, T](column: TypedColumn[T, A]): TypedAggregate[T, Double] =
+    untyped.stddev(column.untyped).typedAggregate
 
   /**
     * Aggregate function: returns the standard deviation of a column by population.
@@ -175,7 +167,7 @@ trait AggregateFunctions {
     */
   def max[A: CatalystOrdered, T](column: TypedColumn[T, A]): TypedAggregate[T, A] = {
     implicit val c = column.uencoder
-    new TypedAggregate[T, A](untyped.max(column.untyped))
+    untyped.max(column.untyped).typedAggregate
   }
 
   /** Aggregate function: returns the minimum value of the column in a group.
@@ -184,7 +176,7 @@ trait AggregateFunctions {
     */
   def min[A: CatalystOrdered, T](column: TypedColumn[T, A]): TypedAggregate[T, A] = {
     implicit val c = column.uencoder
-    new TypedAggregate[T, A](untyped.min(column.untyped))
+    untyped.min(column.untyped).typedAggregate
   }
 
   /** Aggregate function: returns the first value in a group.
@@ -196,7 +188,7 @@ trait AggregateFunctions {
     */
   def first[A, T](column: TypedColumn[T, A]): TypedAggregate[T, A] = {
     implicit val c = column.uencoder
-    new TypedAggregate[T, A](untyped.first(column.untyped))
+    untyped.first(column.untyped).typedAggregate(column.uencoder)
   }
 
   /**
@@ -209,7 +201,7 @@ trait AggregateFunctions {
     */
   def last[A, T](column: TypedColumn[T, A]): TypedAggregate[T, A] = {
     implicit val c = column.uencoder
-    new TypedAggregate[T, A](untyped.last(column.untyped))
+    untyped.last(column.untyped).typedAggregate
   }
 
   /**

--- a/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
@@ -175,35 +175,38 @@ trait NonAggregateFunctions {
     column.typed(untyped.base64(column.untyped))
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column.
+    * @note varargs make it harder to generalize so we overload the method for [[TypedColumn]] and [[TypedAggregate]]
     *
     * apache/spark
     */
-  def concat[T](c1: TypedColumn[T, String], xs: TypedColumn[T, String]*): TypedColumn[T, String] =
-    c1.typed(untyped.concat((c1 +: xs).map(_.untyped): _*))
-
-  /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column,
-    * using the given separator.
-    *
-    * apache/spark
-    */
-  def concatWs[T](sep: String, c1: TypedColumn[T, String], xs: TypedColumn[T, String]*): TypedColumn[T, String] =
-    c1.typed(untyped.concat_ws(sep, (c1 +: xs).map(_.untyped): _*))
+  def concat[T](columns: TypedColumn[T, String]*): TypedColumn[T, String] =
+    new TypedColumn(untyped.concat(columns.map(_.untyped): _*))
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column.
+    * @note varargs make it harder to generalize so we overload the method for [[TypedColumn]] and [[TypedAggregate]]
     *
     * apache/spark
     */
-  def concat[T](c1: TypedAggregate[T, String], xs: TypedAggregate[T, String]*): TypedAggregate[T, String] =
-    c1.typed(untyped.concat((c1 +: xs).map(_.untyped): _*))
-
+  def concat[T](columns: TypedAggregate[T, String]*): TypedAggregate[T, String] =
+    new TypedAggregate(untyped.concat(columns.map(_.untyped): _*))
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column,
     * using the given separator.
+    * @note varargs make it harder to generalize so we overload the method for [[TypedColumn]] and [[TypedAggregate]]
     *
     * apache/spark
     */
-  def concatWs[T](sep: String, c1: TypedAggregate[T, String], xs: TypedAggregate[T, String]*): TypedAggregate[T, String] =
-    c1.typed(untyped.concat_ws(sep, (c1 +: xs).map(_.untyped): _*))
+  def concatWs[T](sep: String, columns: TypedAggregate[T, String]*): TypedAggregate[T, String] =
+    new TypedAggregate(untyped.concat_ws(sep, columns.map(_.untyped): _*))
+
+  /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column,
+    * using the given separator.
+    * @note varargs make it harder to generalize so we overload the method for [[TypedColumn]] and [[TypedAggregate]]
+    *
+    * apache/spark
+    */
+  def concatWs[T](sep: String, columns: TypedColumn[T, String]*): TypedColumn[T, String] =
+    new TypedColumn(untyped.concat_ws(sep, columns.map(_.untyped): _*))
 
   /** Non-Aggregate function: Locates the position of the first occurrence of substring column
     * in given string

--- a/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
@@ -12,10 +12,11 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def abs[A, B, T](column: AbstractTypedColumn[T, A])
-     (implicit
-      evAbs: CatalystAbsolute[A, B],
-      enc:TypedEncoder[B]): column.ThisType[T, B] =
-    column.typed(untyped.abs(column.untyped))(enc)
+    (implicit
+      i0: CatalystAbsolute[A, B],
+      i1: TypedEncoder[B]
+    ): column.ThisType[T, B] =
+      column.typed(untyped.abs(column.untyped))(i1)
 
   /** Non-Aggregate function: returns the acos of a numeric column
     *
@@ -24,9 +25,8 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def acos[A, T](column: AbstractTypedColumn[T, A])
-    (implicit
-     evCanBeDouble: CatalystCast[A, Double]): column.ThisType[T, Double] =
-    column.typed(untyped.acos(column.cast[Double].untyped))
+    (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
+      column.typed(untyped.acos(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns true if value is contained with in the array in the specified column
     *
@@ -42,9 +42,8 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def atan[A, T](column: AbstractTypedColumn[T,A])
-     (implicit
-      evCanBeDouble: CatalystCast[A, Double]): column.ThisType[T, Double] =
-    column.typed(untyped.atan(column.cast[Double].untyped))
+    (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
+      column.typed(untyped.atan(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns the asin of a numeric column
     *
@@ -53,9 +52,8 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def asin[A, T](column: AbstractTypedColumn[T, A])
-     (implicit
-      evCanBeDouble: CatalystCast[A, Double]): column.ThisType[T, Double] =
-    column.typed(untyped.asin(column.cast[Double].untyped))
+    (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
+      column.typed(untyped.asin(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns the angle theta from the conversion of rectangular coordinates (x, y) to
     * polar coordinates (r, theta).
@@ -64,21 +62,42 @@ trait NonAggregateFunctions {
     *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
     * apache/spark
     */
-  def atan2[A, B, T](l: AbstractTypedColumn[T,A], r: AbstractTypedColumn[T, B])
+  def atan2[A, B, T](l: TypedColumn[T, A], r: TypedColumn[T, B])
     (implicit
-      evCanBeDoubleL: CatalystCast[A, Double],
-      evCanBeDoubleR: CatalystCast[B, Double]
-    ): r.ThisType[T, Double] =
-    r.typed(untyped.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
+      i0: CatalystCast[A, Double],
+      i1: CatalystCast[B, Double]
+    ): TypedColumn[T, Double] =
+      r.typed(untyped.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
 
-  def atan2[B, T](l: Double, r: AbstractTypedColumn[T, B])
-     (implicit
-      evCanBeDoubleR: CatalystCast[B, Double]): r.ThisType[T, Double] = atan2(r.lit(l), r)
+  /** Non-Aggregate function: returns the angle theta from the conversion of rectangular coordinates (x, y) to
+    * polar coordinates (r, theta).
+    *
+    * Spark will expect a Double value for this expression. See:
+    *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
+    * apache/spark
+    */
+  def atan2[A, B, T](l: TypedAggregate[T, A], r: TypedAggregate[T, B])
+    (implicit
+      i0: CatalystCast[A, Double],
+      i1: CatalystCast[B, Double]
+    ): TypedAggregate[T, Double] =
+      r.typed(untyped.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
 
-  def atan2[A, T](l: AbstractTypedColumn[T, A], r: Double)
-     (implicit
-      evCanBeDoubleL: CatalystCast[A, Double]): l.ThisType[T, Double] =
-    atan2(l, l.lit(r)).asInstanceOf[l.ThisType[T, Double]]
+  def atan2[B, T](l: Double, r: TypedColumn[T, B])
+    (implicit i0: CatalystCast[B, Double]): TypedColumn[T, Double] =
+      atan2(r.lit(l), r)
+
+  def atan2[A, T](l: TypedColumn[T, A], r: Double)
+    (implicit i0: CatalystCast[A, Double]): TypedColumn[T, Double] =
+      atan2(l, l.lit(r))
+
+  def atan2[B, T](l: Double, r: TypedAggregate[T, B])
+    (implicit i0: CatalystCast[B, Double]): TypedAggregate[T, Double] =
+      atan2(r.lit(l), r)
+
+  def atan2[A, T](l: TypedAggregate[T, A], r: Double)
+    (implicit i0: CatalystCast[A, Double]): TypedAggregate[T, Double] =
+      atan2(l, l.lit(r))
 
   /** Non-Aggregate function: Returns the string representation of the binary value of the given long
     * column. For example, bin("12") returns "1100".
@@ -128,9 +147,8 @@ trait NonAggregateFunctions {
     private[functions] def this(condition: AbstractTypedColumn[T, Boolean], value: AbstractTypedColumn[T, A]) =
       this(untyped.when(condition.untyped, value.untyped))
 
-    def when(condition: AbstractTypedColumn[T, Boolean], value: AbstractTypedColumn[T, A]): When[T, A] = new When[T, A](
-      untypedC.when(condition.untyped, value.untyped)
-    )
+    def when(condition: AbstractTypedColumn[T, Boolean], value: AbstractTypedColumn[T, A]): When[T, A] =
+      new When[T, A](untypedC.when(condition.untyped, value.untyped))
 
     def otherwise(value: AbstractTypedColumn[T, A]): value.ThisType[T, A] =
       value.typed(untypedC.otherwise(value.untyped))(value.uencoder)
@@ -160,9 +178,23 @@ trait NonAggregateFunctions {
     *
     * apache/spark
     */
-  def concat[T](c1: AbstractTypedColumn[T, String],
-                rest: AbstractTypedColumn[T, String]*): c1.ThisType[T, String] =
-    c1.typed(untyped.concat((c1 +: rest).map(_.untyped): _*))
+  def concat[T](c1: TypedColumn[T, String], xs: TypedColumn[T, String]*): TypedColumn[T, String] =
+    c1.typed(untyped.concat((c1 +: xs).map(_.untyped): _*))
+
+  /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column,
+    * using the given separator.
+    *
+    * apache/spark
+    */
+  def concatWs[T](sep: String, c1: TypedColumn[T, String], xs: TypedColumn[T, String]*): TypedColumn[T, String] =
+    c1.typed(untyped.concat_ws(sep, (c1 +: xs).map(_.untyped): _*))
+
+  /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column.
+    *
+    * apache/spark
+    */
+  def concat[T](c1: TypedAggregate[T, String], xs: TypedAggregate[T, String]*): TypedAggregate[T, String] =
+    c1.typed(untyped.concat((c1 +: xs).map(_.untyped): _*))
 
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column,
@@ -170,10 +202,8 @@ trait NonAggregateFunctions {
     *
     * apache/spark
     */
-  def concatWs[T](sep: String,
-                  c1: AbstractTypedColumn[T, String],
-                  rest: AbstractTypedColumn[T, String]*): c1.ThisType[T, String] =
-    c1.typed(untyped.concat_ws(sep, (c1 +: rest).map(_.untyped): _*))
+  def concatWs[T](sep: String, c1: TypedAggregate[T, String], xs: TypedAggregate[T, String]*): TypedAggregate[T, String] =
+    c1.typed(untyped.concat_ws(sep, (c1 +: xs).map(_.untyped): _*))
 
   /** Non-Aggregate function: Locates the position of the first occurrence of substring column
     * in given string
@@ -198,7 +228,14 @@ trait NonAggregateFunctions {
     *
     * apache/spark
     */
-  def levenshtein[T](l: AbstractTypedColumn[T, String], r: AbstractTypedColumn[T, String]): l.ThisType[T, Int] =
+  def levenshtein[T](l: TypedColumn[T, String], r: TypedColumn[T, String]): TypedColumn[T, Int] =
+    l.typed(untyped.levenshtein(l.untyped, r.untyped))
+
+  /** Non-Aggregate function: Computes the Levenshtein distance of the two given string columns.
+    *
+    * apache/spark
+    */
+  def levenshtein[T](l: TypedAggregate[T, String], r: TypedAggregate[T, String]): TypedAggregate[T, Int] =
     l.typed(untyped.levenshtein(l.untyped, r.untyped))
 
   /** Non-Aggregate function: Converts a string column to lower case.

--- a/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
@@ -11,10 +11,11 @@ trait NonAggregateFunctions {
     *
     * apache/spark
     */
-  def abs[A, B, T](column: TypedColumn[T, A])(implicit evAbs: CatalystAbsolute[A, B], enc:TypedEncoder[B]):TypedColumn[T, B] = {
-    implicit val c = column.uencoder
-    new TypedColumn[T, B](untyped.abs(column.untyped))
-  }
+  def abs[A, B, T](column: AbstractTypedColumn[T, A])
+     (implicit
+      evAbs: CatalystAbsolute[A, B],
+      enc:TypedEncoder[B]): column.ThisType[T, B] =
+    column.typed(untyped.abs(column.untyped))(enc)
 
   /** Non-Aggregate function: returns the acos of a numeric column
     *
@@ -22,20 +23,17 @@ trait NonAggregateFunctions {
     *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
     * apache/spark
     */
-  def acos[A, T](column: TypedColumn[T, A])
-    (implicit evCanBeDouble: CatalystCast[A, Double]): TypedColumn[T, Double] = {
-    implicit val c = column.uencoder
-    new TypedColumn[T, Double](untyped.acos(column.cast[Double].untyped))
-  }
+  def acos[A, T](column: AbstractTypedColumn[T, A])
+    (implicit
+     evCanBeDouble: CatalystCast[A, Double]): column.ThisType[T, Double] =
+    column.typed(untyped.acos(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns true if value is contained with in the array in the specified column
     *
     * apache/spark
     */
-  def arrayContains[C[_]: CatalystCollection, A, T](column: TypedColumn[T, C[A]], value: A): TypedColumn[T, Boolean] = {
-    implicit val c = column.uencoder
-    new TypedColumn[T, Boolean](untyped.array_contains(column.untyped, value))
-  }
+  def arrayContains[C[_]: CatalystCollection, A, T](column: AbstractTypedColumn[T, C[A]], value: A): column.ThisType[T, Boolean] =
+    column.typed(untyped.array_contains(column.untyped, value))
 
   /** Non-Aggregate function: returns the atan of a numeric column
     *
@@ -43,11 +41,10 @@ trait NonAggregateFunctions {
     *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
     * apache/spark
     */
-  def atan[A, T](column: TypedColumn[T,A])
-                (implicit evCanBeDouble: CatalystCast[A, Double]): TypedColumn[T, Double] = {
-    implicit val c = column.uencoder
-    new TypedColumn[T, Double](untyped.atan(column.cast[Double].untyped))
-  }
+  def atan[A, T](column: AbstractTypedColumn[T,A])
+     (implicit
+      evCanBeDouble: CatalystCast[A, Double]): column.ThisType[T, Double] =
+    column.typed(untyped.atan(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns the asin of a numeric column
     *
@@ -55,11 +52,10 @@ trait NonAggregateFunctions {
     *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
     * apache/spark
     */
-  def asin[A, T](column: TypedColumn[T, A])
-                (implicit evCanBeDouble: CatalystCast[A, Double]): TypedColumn[T, Double] = {
-    implicit val c = column.uencoder
-    new TypedColumn[T, Double](untyped.asin(column.cast[Double].untyped))
-  }
+  def asin[A, T](column: AbstractTypedColumn[T, A])
+     (implicit
+      evCanBeDouble: CatalystCast[A, Double]): column.ThisType[T, Double] =
+    column.typed(untyped.asin(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns the angle theta from the conversion of rectangular coordinates (x, y) to
     * polar coordinates (r, theta).
@@ -68,40 +64,36 @@ trait NonAggregateFunctions {
     *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
     * apache/spark
     */
-  def atan2[A, B, T](l: TypedColumn[T,A], r: TypedColumn[T, B])
+  def atan2[A, B, T](l: AbstractTypedColumn[T,A], r: AbstractTypedColumn[T, B])
     (implicit
       evCanBeDoubleL: CatalystCast[A, Double],
       evCanBeDoubleR: CatalystCast[B, Double]
-    ): TypedColumn[T, Double] = {
-      implicit val lUnencoder = l.uencoder
-      implicit val rUnencoder = r.uencoder
-      new TypedColumn[T, Double](untyped.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
-    }
+    ): r.ThisType[T, Double] =
+    r.typed(untyped.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
 
-  def atan2[B, T](l: Double, r: TypedColumn[T, B])(implicit evCanBeDoubleR: CatalystCast[B, Double]): TypedColumn[T, Double] =
-    atan2(lit(l): TypedColumn[T, Double], r)
+  def atan2[B, T](l: Double, r: AbstractTypedColumn[T, B])
+     (implicit
+      evCanBeDoubleR: CatalystCast[B, Double]): r.ThisType[T, Double] = atan2(r.lit(l), r)
 
-  def atan2[A, T](l: TypedColumn[T, A], r: Double)(implicit evCanBeDoubleL: CatalystCast[A, Double]): TypedColumn[T, Double] =
-    atan2(l, lit(r): TypedColumn[T, Double])
+  def atan2[A, T](l: AbstractTypedColumn[T, A], r: Double)
+     (implicit
+      evCanBeDoubleL: CatalystCast[A, Double]): l.ThisType[T, Double] =
+    atan2(l, l.lit(r)).asInstanceOf[l.ThisType[T, Double]]
 
   /** Non-Aggregate function: Returns the string representation of the binary value of the given long
     * column. For example, bin("12") returns "1100".
     *
     * apache/spark
     */
-  def bin[T](column: TypedColumn[T, Long]): TypedColumn[T, String] = {
-    implicit val c = column.uencoder
-    new TypedColumn[T, String](untyped.bin(column.untyped))
-  }
+  def bin[T](column: AbstractTypedColumn[T, Long]): column.ThisType[T, String] =
+    column.typed(untyped.bin(column.untyped))
 
   /** Non-Aggregate function: Computes bitwise NOT.
     *
     * apache/spark
     */
-  def bitwiseNOT[A: CatalystBitwise, T](column: TypedColumn[T, A]): TypedColumn[T, A] = {
-    implicit val c = column.uencoder
-    new TypedColumn[T, A](untyped.bitwiseNOT(column.untyped))
-  }
+  def bitwiseNOT[A: CatalystBitwise, T](column: AbstractTypedColumn[T, A]): column.ThisType[T, A] =
+    column.typed(untyped.bitwiseNOT(column.untyped))(column.uencoder)
 
   /** Non-Aggregate function: file name of the current Spark task. Empty string if row did not originate from
     * a file
@@ -129,19 +121,19 @@ trait NonAggregateFunctions {
     * }}}
     * apache/spark
     */
-  def when[T, A](condition: TypedColumn[T, Boolean], value: TypedColumn[T, A]): When[T, A] =
+  def when[T, A](condition: AbstractTypedColumn[T, Boolean], value: AbstractTypedColumn[T, A]): When[T, A] =
     new When[T, A](condition, value)
 
   class When[T, A] private (untypedC: Column) {
-    private[functions] def this(condition: TypedColumn[T, Boolean], value: TypedColumn[T, A]) =
+    private[functions] def this(condition: AbstractTypedColumn[T, Boolean], value: AbstractTypedColumn[T, A]) =
       this(untyped.when(condition.untyped, value.untyped))
 
-    def when(condition: TypedColumn[T, Boolean], value: TypedColumn[T, A]): When[T, A] = new When[T, A](
+    def when(condition: AbstractTypedColumn[T, Boolean], value: AbstractTypedColumn[T, A]): When[T, A] = new When[T, A](
       untypedC.when(condition.untyped, value.untyped)
     )
 
-    def otherwise(value: TypedColumn[T, A]): TypedColumn[T, A] =
-      new TypedColumn[T, A](untypedC.otherwise(value.untyped))(value.uencoder)
+    def otherwise(value: AbstractTypedColumn[T, A]): value.ThisType[T, A] =
+      value.typed(untypedC.otherwise(value.untyped))(value.uencoder)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////
@@ -153,35 +145,35 @@ trait NonAggregateFunctions {
     *
     * apache/spark
     */
-  def ascii[T](column: TypedColumn[T, String]): TypedColumn[T, Int] = {
-    new TypedColumn[T, Int](untyped.ascii(column.untyped))
-  }
+  def ascii[T](column: AbstractTypedColumn[T, String]): column.ThisType[T, Int] =
+    column.typed(untyped.ascii(column.untyped))
 
   /** Non-Aggregate function: Computes the BASE64 encoding of a binary column and returns it as a string column.
     * This is the reverse of unbase64.
     *
     * apache/spark
     */
-  def base64[T](column: TypedColumn[T, Array[Byte]]): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.base64(column.untyped))
-  }
+  def base64[T](column: AbstractTypedColumn[T, Array[Byte]]): column.ThisType[T, String] =
+    column.typed(untyped.base64(column.untyped))
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column.
     *
     * apache/spark
     */
-  def concat[T](columns: TypedColumn[T, String]*): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.concat(columns.map(_.untyped):_*))
-  }
+  def concat[T](c1: AbstractTypedColumn[T, String],
+                rest: AbstractTypedColumn[T, String]*): c1.ThisType[T, String] =
+    c1.typed(untyped.concat((c1 +: rest).map(_.untyped): _*))
+
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column,
     * using the given separator.
     *
     * apache/spark
     */
-  def concatWs[T](sep: String, columns: TypedColumn[T, String]*): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.concat_ws(sep, columns.map(_.untyped):_*))
-  }
+  def concatWs[T](sep: String,
+                  c1: AbstractTypedColumn[T, String],
+                  rest: AbstractTypedColumn[T, String]*): c1.ThisType[T, String] =
+    c1.typed(untyped.concat_ws(sep, (c1 +: rest).map(_.untyped): _*))
 
   /** Non-Aggregate function: Locates the position of the first occurrence of substring column
     * in given string
@@ -191,107 +183,99 @@ trait NonAggregateFunctions {
     *
     * apache/spark
     */
-  def instr[T](column: TypedColumn[T, String], substring: String): TypedColumn[T, Int] = {
-    new TypedColumn[T, Int](untyped.instr(column.untyped, substring))
-  }
+  def instr[T](str: AbstractTypedColumn[T, String], substring: String): str.ThisType[T, Int] =
+    str.typed(untyped.instr(str.untyped, substring))
 
   /** Non-Aggregate function: Computes the length of a given string.
     *
     * apache/spark
     */
   //TODO: Also for binary
-  def length[T](column: TypedColumn[T, String]): TypedColumn[T, Int] = {
-    new TypedColumn[T, Int](untyped.length(column.untyped))
-  }
+  def length[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, Int] =
+    str.typed(untyped.length(str.untyped))
 
   /** Non-Aggregate function: Computes the Levenshtein distance of the two given string columns.
     *
     * apache/spark
     */
-  def levenshtein[T](l: TypedColumn[T, String], r: TypedColumn[T, String]): TypedColumn[T, Int] = {
-    new TypedColumn[T, Int](untyped.levenshtein(l.untyped, r.untyped))
-  }
+  def levenshtein[T](l: AbstractTypedColumn[T, String], r: AbstractTypedColumn[T, String]): l.ThisType[T, Int] =
+    l.typed(untyped.levenshtein(l.untyped, r.untyped))
 
   /** Non-Aggregate function: Converts a string column to lower case.
     *
     * apache/spark
     */
-  def lower[T](e: TypedColumn[T, String]): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.lower(e.untyped))
-  }
+  def lower[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
+    str.typed(untyped.lower(str.untyped))
 
   /** Non-Aggregate function: Left-pad the string column with pad to a length of len. If the string column is longer
     * than len, the return value is shortened to len characters.
     *
     * apache/spark
     */
-  def lpad[T](str: TypedColumn[T, String], len: Int, pad: String): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.lpad(str.untyped, len, pad))
-  }
+  def lpad[T](str: AbstractTypedColumn[T, String],
+              len: Int,
+              pad: String): str.ThisType[T, String] =
+    str.typed(untyped.lpad(str.untyped, len, pad))
 
   /** Non-Aggregate function: Trim the spaces from left end for the specified string value.
     *
     * apache/spark
     */
-  def ltrim[T](str: TypedColumn[T, String]): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.ltrim(str.untyped))
-  }
+  def ltrim[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
+    str.typed(untyped.ltrim(str.untyped))
 
   /** Non-Aggregate function: Replace all substrings of the specified string value that match regexp with rep.
     *
     * apache/spark
     */
-  def regexpReplace[T](str: TypedColumn[T, String], pattern: Regex, replacement: String): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.regexp_replace(str.untyped, pattern.regex, replacement))
-  }
+  def regexpReplace[T](str: AbstractTypedColumn[T, String],
+                       pattern: Regex,
+                       replacement: String): str.ThisType[T, String] =
+    str.typed(untyped.regexp_replace(str.untyped, pattern.regex, replacement))
+
 
   /** Non-Aggregate function: Reverses the string column and returns it as a new string column.
     *
     * apache/spark
     */
-  def reverse[T](str: TypedColumn[T, String]): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.reverse(str.untyped))
-  }
+  def reverse[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
+    str.typed(untyped.reverse(str.untyped))
 
   /** Non-Aggregate function: Right-pad the string column with pad to a length of len.
     * If the string column is longer than len, the return value is shortened to len characters.
     *
     * apache/spark
     */
-  def rpad[T](str: TypedColumn[T, String], len: Int, pad: String): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.rpad(str.untyped, len, pad))
-  }
+  def rpad[T](str: AbstractTypedColumn[T, String], len: Int, pad: String): str.ThisType[T, String] =
+    str.typed(untyped.rpad(str.untyped, len, pad))
 
   /** Non-Aggregate function: Trim the spaces from right end for the specified string value.
     *
     * apache/spark
     */
-  def rtrim[T](e: TypedColumn[T, String]): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.rtrim(e.untyped))
-  }
+  def rtrim[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
+    str.typed(untyped.rtrim(str.untyped))
 
   /** Non-Aggregate function: Substring starts at `pos` and is of length `len`
     *
     * apache/spark
     */
   //TODO: Also for byte array
-  def substring[T](str: TypedColumn[T, String], pos: Int, len: Int): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.substring(str.untyped, pos, len))
-  }
+  def substring[T](str: AbstractTypedColumn[T, String], pos: Int, len: Int): str.ThisType[T, String] =
+    str.typed(untyped.substring(str.untyped, pos, len))
 
   /** Non-Aggregate function: Trim the spaces from both ends for the specified string column.
     *
     * apache/spark
     */
-  def trim[T](str: TypedColumn[T, String]): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.trim(str.untyped))
-  }
+  def trim[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
+    str.typed(untyped.trim(str.untyped))
 
   /** Non-Aggregate function: Converts a string column to upper case.
     *
     * apache/spark
     */
-  def upper[T](str: TypedColumn[T, String]): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.upper(str.untyped))
-  }
+  def upper[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
+    str.typed(untyped.upper(str.untyped))
 }

--- a/dataset/src/main/scala/frameless/functions/package.scala
+++ b/dataset/src/main/scala/frameless/functions/package.scala
@@ -7,6 +7,9 @@ package object functions extends Udf with UnaryFunctions {
   object aggregate extends AggregateFunctions
   object nonAggregate extends NonAggregateFunctions
 
+  def litAggr[A: TypedEncoder, T](value: A): TypedAggregate[T, A] =
+    new TypedAggregate[T,A](lit(value).expr)
+
   def lit[A: TypedEncoder, T](value: A): TypedColumn[T, A] = {
     val encoder = TypedEncoder[A]
 

--- a/dataset/src/main/scala/frameless/functions/package.scala
+++ b/dataset/src/main/scala/frameless/functions/package.scala
@@ -7,9 +7,20 @@ package object functions extends Udf with UnaryFunctions {
   object aggregate extends AggregateFunctions
   object nonAggregate extends NonAggregateFunctions
 
+  /** Creates a [[frameless.TypedAggregate]] of literal value. If A is to be encoded using an Injection make
+    * sure the injection instance is in scope.
+    *
+    * apache/spark
+    */
   def litAggr[A: TypedEncoder, T](value: A): TypedAggregate[T, A] =
     new TypedAggregate[T,A](lit(value).expr)
 
+
+  /** Creates a [[frameless.TypedColumn]] of literal value. If A is to be encoded using an Injection make
+    * sure the injection instance is in scope.
+    *
+    * apache/spark
+    */
   def lit[A: TypedEncoder, T](value: A): TypedColumn[T, A] = {
     val encoder = TypedEncoder[A]
 

--- a/dataset/src/test/scala/frameless/FilterTests.scala
+++ b/dataset/src/test/scala/frameless/FilterTests.scala
@@ -33,6 +33,27 @@ class FilterTests extends TypedDatasetSuite {
     check(forAll(prop[Int] _))
     check(forAll(prop[String] _))
     check(forAll(prop[Char] _))
+    check(forAll(prop[Boolean] _))
+    check(forAll(prop[SQLTimestamp] _))
+    //check(forAll(prop[Vector[SQLTimestamp]] _)) // Commenting out since this fails randomly due to frameless Issue #124
+  }
+
+  test("filter('a =!= 'b)") {
+    def prop[A: TypedEncoder](data: Vector[X2[A, A]]): Prop = {
+      val dataset = TypedDataset.create(data)
+      val A = dataset.col('a)
+      val B = dataset.col('b)
+
+      val dataset2 = dataset.filter(A =!= B).collect().run().toVector
+      val data2 = data.filter(x => x.a != x.b)
+
+      dataset2 ?= data2
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+    check(forAll(prop[Char] _))
+    check(forAll(prop[Boolean] _))
     check(forAll(prop[SQLTimestamp] _))
     //check(forAll(prop[Vector[SQLTimestamp]] _)) // Commenting out since this fails randomly due to frameless Issue #124
   }

--- a/dataset/src/test/scala/frameless/SchemaTests.scala
+++ b/dataset/src/test/scala/frameless/SchemaTests.scala
@@ -1,6 +1,7 @@
 package frameless
 
 import frameless.functions.aggregate._
+import frameless.functions._
 import org.scalacheck.Prop
 import org.scalacheck.Prop._
 import org.scalatest.Matchers

--- a/dataset/src/test/scala/frameless/functions/DoubleBehaviourUtils.scala
+++ b/dataset/src/test/scala/frameless/functions/DoubleBehaviourUtils.scala
@@ -1,11 +1,15 @@
-package frameless.functions
+package frameless
+package functions
 
 /**
-  * Some statistical functions in Spark can result in Double, Double.NaN or Null. This tends to break ?= of the property based testing.
-  * Use the nanNullHandler function here to alleviate this by mapping this NaN and Null to None. This will result in functioning comparison again.
+  * Some statistical functions in Spark can result in Double, Double.NaN or Null.
+  * This tends to break ?= of the property based testing. Use the nanNullHandler function
+  * here to alleviate this by mapping this NaN and Null to None. This will result in
+  * functioning comparison again.
   */
 object DoubleBehaviourUtils {
-  // Mapping with this function is needed because spark uses Double.NaN for some semantics in the correlation function. ?= for prop testing will use == underlying and will break because Double.NaN != Double.NaN
+  // Mapping with this function is needed because spark uses Double.NaN for some semantics in the
+  // correlation function. ?= for prop testing will use == underlying and will break because Double.NaN != Double.NaN
   private val nanHandler: Double => Option[Double] = value => if (!value.equals(Double.NaN)) Option(value) else None
   // Making sure that null => None and does not result in 0.0d because of row.getAs[Double]'s use of .asInstanceOf
   val nanNullHandler: Any => Option[Double] = {
@@ -13,5 +17,4 @@ object DoubleBehaviourUtils {
     case d: Double => nanHandler(d)
     case _ => ???
   }
-
 }


### PR DESCRIPTION
This fixes #148 as well. It essentially uses a base class for both TypedColumn and TypedAggregate that implements the vast majority of the methods once. Now, whatever you can do with a TypedColumn you can also do with TypedAggregate (like compare, multiply, cast, etc.). 

In its core, this implementation uses a type member to help with type inference. This ensures that aggregated types cannot be used where a simple column is expected and vis a versa. 