### PR TITLE
Add support for withColumn on TypedDataset.

### DIFF
--- a/dataset/src/test/scala/frameless/WithColumnTest.scala
+++ b/dataset/src/test/scala/frameless/WithColumnTest.scala
@@ -1,0 +1,25 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+
+class WithColumnTest extends TypedDatasetSuite {
+  test("append five columns") {
+    def prop[A: TypedEncoder](value: A): Prop = {
+      val d = TypedDataset.create(X1(value) :: Nil)
+      val d1 = d.withColumn(d('a))
+      val d2 = d1.withColumn(d1('_1))
+      val d3 = d2.withColumn(d2('_2))
+      val d4 = d3.withColumn(d3('_3))
+      val d5 = d4.withColumn(d4('_4))
+
+      (value, value, value, value, value, value) ?= d5.collect().run().head
+    }
+
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[String] _)
+    check(prop[SQLDate] _)
+    check(prop[Option[X1[Boolean]]] _)
+  }
+}


### PR DESCRIPTION
`withColumn` is a very commonly used operation on a Dataframe. This PR brings this functionality in Frameless. Currently if you want to add a column you need to write a large select statement that brings every column of the target dataset and then add the new one at the end. That's really cumpersom and error prone. This PR makes this as easy as `d.withColumn(d('a) * 10)`. 