### PR TITLE
add frameless-ml project with public UDT for Vector and Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It consists of the following modules:
 
 * `dataset` for more strongly typed `Dataset`s  (supports Spark 2.0.x)
 * `cats` for using Spark with [cats](https://github.com/typelevel/cats) (supports Cats 0.9.x)
-
+* `ml` for a more strongly typed use of Spark ML based on `dataset`
 
 The Frameless project and contributors support the
 [Typelevel](http://typelevel.org/) [Code of Conduct](http://typelevel.org/conduct.html) and want all its
@@ -24,6 +24,7 @@ associated channels (e.g. GitHub, Gitter) to be a safe and friendly environment 
 * [Injection: Creating Custom Encoders](http://typelevel.org/frameless/Injection.html)
 * [Job\[A\]](http://typelevel.org/frameless/Job.html)
 * [Using Cats with RDDs](http://typelevel.org/frameless/Cats.html)
+* [TypedDataset support for Spark ML](http://typelevel.org/frameless/TypedML.html)
 * [Proof of Concept: TypedDataFrame](http://typelevel.org/frameless/TypedDataFrame.html)
 
 ## Why?

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val shapeless = "2.3.2"
 val scalacheck = "1.13.5"
 
 lazy val root = Project("frameless", file("." + "frameless")).in(file("."))
-  .aggregate(core, cats, dataset, docs)
+  .aggregate(core, cats, dataset, ml, docs)
   .settings(framelessSettings: _*)
   .settings(noPublishSettings: _*)
 
@@ -35,6 +35,22 @@ lazy val dataset = project
     "org.apache.spark" %% "spark-sql"  % sparkVersion % "provided"
   ))
   .dependsOn(core % "test->test;compile->compile")
+
+lazy val ml = project
+  .settings(name := "frameless-ml")
+  .settings(framelessSettings: _*)
+  .settings(warnUnusedImport: _*)
+  .settings(framelessTypedDatasetREPL: _*)
+  .settings(publishSettings: _*)
+  .settings(libraryDependencies ++= Seq(
+    "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
+    "org.apache.spark" %% "spark-sql"  % sparkVersion % "provided",
+    "org.apache.spark" %% "spark-mllib"  % sparkVersion % "provided"
+  ))
+  .dependsOn(
+    core % "test->test;compile->compile",
+    dataset % "test->test;compile->compile"
+  )
 
 lazy val docs = project
   .settings(framelessSettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -59,9 +59,10 @@ lazy val docs = project
   .settings(crossTarget := file(".") / "docs" / "target")
   .settings(libraryDependencies ++= Seq(
     "org.apache.spark" %% "spark-core" % sparkVersion,
-    "org.apache.spark" %% "spark-sql"  % sparkVersion
+    "org.apache.spark" %% "spark-sql"  % sparkVersion,
+    "org.apache.spark" %% "spark-mllib"  % sparkVersion
   ))
-  .dependsOn(dataset, cats)
+  .dependsOn(dataset, cats, ml)
 
 lazy val framelessSettings = Seq(
   organization := "org.typelevel",

--- a/docs/src/main/tut/SUMMARY.md
+++ b/docs/src/main/tut/SUMMARY.md
@@ -4,4 +4,5 @@
 - [Injection: Creating Custom Encoders](Injection.md)
 - [Job\[A\]](Job.md)
 - [Using Cats with RDDs](Cats.md)
+- [Using Spark ML with TypedDataset](TypedML.md)
 - [Proof of Concept: TypedDataFrame](TypedDataFrame.md)

--- a/docs/src/main/tut/TypedML.md
+++ b/docs/src/main/tut/TypedML.md
@@ -1,0 +1,42 @@
+# TypedDataset support for Spark ML
+
+The goal of the `frameless-ml` package is to be able to use Spark ML with `TypedDataset` and 
+to eventually provide a more strongly typed ML API for Spark. Currently, this module is at its very beginning and only 
+provides `TypedEncoder` instances for Spark ML's linear algebra data types.
+
+```tut:invisible
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SparkSession
+
+val conf = new SparkConf().setMaster("local[*]").setAppName("frameless repl").set("spark.ui.enabled", "false")
+val spark = SparkSession.builder().config(conf).appName("REPL").getOrCreate()
+implicit val sqlContext = spark.sqlContext
+spark.sparkContext.setLogLevel("WARN")
+
+import spark.implicits._
+```
+ 
+## Using Vector and Matrix with TypedDataset
+
+`frameless-ml` provides `TypedEncoder` instances for `org.apache.spark.ml.linalg.Vector` 
+and `org.apache.spark.ml.linalg.Matrix`:
+
+```tut:book
+import frameless.ml._
+import frameless.TypedDataset
+import org.apache.spark.ml.linalg._
+
+val vector = Vectors.dense(1, 2, 3)
+val vectorDs = TypedDataset.create(Seq(vector))
+
+val matrix = Matrices.dense(2, 1, Array(1, 2))
+val matrixDs = TypedDataset.create(Seq(matrix))
+```
+
+Under the hood, Vector and Matrix are encoded using `org.apache.spark.ml.linalg.VectorUDT` 
+and `org.apache.spark.ml.linalg.MatrixUDT`. This is possible thanks to the implicit derivation 
+from `org.apache.spark.sql.types.UserDefinedType[A]` to `TypedEncoder[A]` defined in `TypedEncoder` companion object.
+
+```tut:invisible
+spark.stop()
+```

--- a/docs/src/main/tut/TypedML.md
+++ b/docs/src/main/tut/TypedML.md
@@ -27,10 +27,10 @@ import frameless.TypedDataset
 import org.apache.spark.ml.linalg._
 
 val vector = Vectors.dense(1, 2, 3)
-val vectorDs = TypedDataset.create(Seq(vector))
+val vectorDs = TypedDataset.create(Seq("label" -> vector))
 
 val matrix = Matrices.dense(2, 1, Array(1, 2))
-val matrixDs = TypedDataset.create(Seq(matrix))
+val matrixDs = TypedDataset.create(Seq("label" -> matrix))
 ```
 
 Under the hood, Vector and Matrix are encoded using `org.apache.spark.ml.linalg.VectorUDT` 

--- a/docs/src/main/tut/TypedML.md
+++ b/docs/src/main/tut/TypedML.md
@@ -1,6 +1,6 @@
 # TypedDataset support for Spark ML
 
-The goal of the `frameless-ml` package is to be able to use Spark ML with `TypedDataset` and 
+The goal of the `frameless-ml` module is to be able to use Spark ML with `TypedDataset` and
 to eventually provide a more strongly typed ML API for Spark. Currently, this module is at its very beginning and only 
 provides `TypedEncoder` instances for Spark ML's linear algebra data types.
 

--- a/ml/src/main/scala/frameless/ml/package.scala
+++ b/ml/src/main/scala/frameless/ml/package.scala
@@ -1,0 +1,13 @@
+package frameless
+
+import org.apache.spark.sql.FramelessInternals.UserDefinedType
+import org.apache.spark.ml.FramelessInternals
+import org.apache.spark.ml.linalg.{Matrix, Vector}
+
+package object ml {
+
+  implicit val mlVectorUdt: UserDefinedType[Vector] = FramelessInternals.vectorUdt
+
+  implicit val mlMatrixUdt: UserDefinedType[Matrix] = FramelessInternals.matrixUdt
+
+}

--- a/ml/src/main/scala/org/apache/spark/ml/FramelessInternals.scala
+++ b/ml/src/main/scala/org/apache/spark/ml/FramelessInternals.scala
@@ -1,0 +1,13 @@
+package org.apache.spark.ml
+
+import org.apache.spark.ml.linalg.{MatrixUDT, VectorUDT}
+
+object FramelessInternals {
+
+  // because org.apache.spark.ml.linalg.VectorUDT is private[spark]
+  val vectorUdt = new VectorUDT
+
+  // because org.apache.spark.ml.linalg.MatrixUDT is private[spark]
+  val matrixUdt = new MatrixUDT
+
+}

--- a/ml/src/test/scala/frameless/ml/FramelessMlSuite.scala
+++ b/ml/src/test/scala/frameless/ml/FramelessMlSuite.scala
@@ -1,25 +1,9 @@
 package frameless
 package ml
 
-import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.scalactic.anyvals.PosZInt
 import org.scalatest.FunSuite
 import org.scalatest.prop.Checkers
-
-trait SparkTesting {
-  val appID: String = new java.util.Date().toString + math.floor(math.random * 10E4).toLong.toString
-
-  val conf: SparkConf = new SparkConf()
-    .setMaster("local[*]")
-    .setAppName("test")
-    .set("spark.ui.enabled", "false")
-    .set("spark.app.id", appID)
-
-  implicit def session: SparkSession = SparkSession.builder().config(conf).getOrCreate()
-  implicit def sc: SparkContext = session.sparkContext
-  implicit def sqlContext: SQLContext = session.sqlContext
-}
 
 class FramelessMlSuite extends FunSuite with Checkers with SparkTesting {
   // Limit size of generated collections and number of checks because Travis

--- a/ml/src/test/scala/frameless/ml/FramelessMlSuite.scala
+++ b/ml/src/test/scala/frameless/ml/FramelessMlSuite.scala
@@ -1,4 +1,5 @@
-package frameless.ml
+package frameless
+package ml
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.{SQLContext, SparkSession}
@@ -20,7 +21,7 @@ trait SparkTesting {
   implicit def sqlContext: SQLContext = session.sqlContext
 }
 
-class TypedDatasetSuite extends FunSuite with Checkers with SparkTesting {
+class FramelessMlSuite extends FunSuite with Checkers with SparkTesting {
   // Limit size of generated collections and number of checks because Travis
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(sizeRange = PosZInt(10), minSize = PosZInt(10))

--- a/ml/src/test/scala/frameless/ml/FramelessMlSuite.scala
+++ b/ml/src/test/scala/frameless/ml/FramelessMlSuite.scala
@@ -2,10 +2,10 @@ package frameless
 package ml
 
 import org.scalactic.anyvals.PosZInt
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.scalatest.prop.Checkers
 
-class FramelessMlSuite extends FunSuite with Checkers with SparkTesting {
+class FramelessMlSuite extends FunSuite with Checkers with BeforeAndAfterAll with SparkTesting {
   // Limit size of generated collections and number of checks because Travis
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(sizeRange = PosZInt(10), minSize = PosZInt(10))

--- a/ml/src/test/scala/frameless/ml/Generators.scala
+++ b/ml/src/test/scala/frameless/ml/Generators.scala
@@ -1,0 +1,25 @@
+package frameless.ml
+
+import frameless.arbDouble
+import org.apache.spark.ml.linalg.{Matrices, Matrix, Vector, Vectors}
+import org.scalacheck.{Arbitrary, Gen}
+
+object Generators {
+
+  implicit val arbVector: Arbitrary[Vector] = Arbitrary {
+    val genDenseVector = Gen.listOf(arbDouble.arbitrary).map(doubles => Vectors.dense(doubles.toArray))
+    val genSparseVector = genDenseVector.map(_.toSparse)
+
+    Gen.oneOf(genDenseVector, genSparseVector)
+  }
+
+  implicit val arbMatrix: Arbitrary[Matrix] = Arbitrary {
+    Gen.sized { nbRows =>
+      Gen.sized { nbCols =>
+        Gen.listOfN(nbRows * nbCols, arbDouble.arbitrary)
+          .map(values => Matrices.dense(nbRows, nbCols, values.toArray))
+      }
+    }
+  }
+
+}

--- a/ml/src/test/scala/frameless/ml/Generators.scala
+++ b/ml/src/test/scala/frameless/ml/Generators.scala
@@ -1,7 +1,6 @@
 package frameless
 package ml
 
-import frameless.arbDouble
 import org.apache.spark.ml.linalg.{Matrices, Matrix, Vector, Vectors}
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -15,11 +14,15 @@ object Generators {
   }
 
   implicit val arbMatrix: Arbitrary[Matrix] = Arbitrary {
-    Gen.sized { nbRows =>
-      Gen.sized { nbCols =>
-        Gen.listOfN(nbRows * nbCols, arbDouble.arbitrary)
-          .map(values => Matrices.dense(nbRows, nbCols, values.toArray))
-      }
+    Gen.sized { size =>
+      for {
+        nbRows <- Gen.oneOf(0, size)
+        nbCols <- Gen.oneOf(0, size)
+        matrix <- {
+          Gen.listOfN(nbRows * nbCols, arbDouble.arbitrary)
+            .map(values => Matrices.dense(nbRows, nbCols, values.toArray))
+        }
+      } yield matrix
     }
   }
 

--- a/ml/src/test/scala/frameless/ml/Generators.scala
+++ b/ml/src/test/scala/frameless/ml/Generators.scala
@@ -1,4 +1,5 @@
-package frameless.ml
+package frameless
+package ml
 
 import frameless.arbDouble
 import org.apache.spark.ml.linalg.{Matrices, Matrix, Vector, Vectors}

--- a/ml/src/test/scala/frameless/ml/TypedDatasetSuite.scala
+++ b/ml/src/test/scala/frameless/ml/TypedDatasetSuite.scala
@@ -1,0 +1,27 @@
+package frameless.ml
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{SQLContext, SparkSession}
+import org.scalactic.anyvals.PosZInt
+import org.scalatest.FunSuite
+import org.scalatest.prop.Checkers
+
+trait SparkTesting {
+  val appID: String = new java.util.Date().toString + math.floor(math.random * 10E4).toLong.toString
+
+  val conf: SparkConf = new SparkConf()
+    .setMaster("local[*]")
+    .setAppName("test")
+    .set("spark.ui.enabled", "false")
+    .set("spark.app.id", appID)
+
+  implicit def session: SparkSession = SparkSession.builder().config(conf).getOrCreate()
+  implicit def sc: SparkContext = session.sparkContext
+  implicit def sqlContext: SQLContext = session.sqlContext
+}
+
+class TypedDatasetSuite extends FunSuite with Checkers with SparkTesting {
+  // Limit size of generated collections and number of checks because Travis
+  implicit override val generatorDrivenConfig =
+    PropertyCheckConfiguration(sizeRange = PosZInt(10), minSize = PosZInt(10))
+}

--- a/ml/src/test/scala/frameless/ml/TypedEncoderInstancesTests.scala
+++ b/ml/src/test/scala/frameless/ml/TypedEncoderInstancesTests.scala
@@ -1,0 +1,57 @@
+package frameless.ml
+
+import frameless.TypedDataset
+import org.scalacheck.Prop._
+import org.apache.spark.ml.linalg._
+import org.apache.spark.ml.regression.DecisionTreeRegressor
+import Generators._
+
+import scala.util.Random
+
+class TypedEncoderInstancesTests extends TypedDatasetSuite {
+
+  test("Vector encoding is injective using collect()") {
+    val prop = forAll { vector: Vector =>
+      TypedDataset.create(Seq(vector)).collect().run() ?= Seq(vector)
+    }
+    check(prop)
+  }
+
+  test("Matrix encoding is injective using collect()") {
+    val prop = forAll { vector: Matrix =>
+      TypedDataset.create(Seq(vector)).collect().run() ?= Seq(vector)
+    }
+    check(prop)
+  }
+
+  test("Vector is encoded as VectorUDT and thus can be run in a Spark ML model") {
+    case class Input(features: Vector, label: Double)
+
+    val prop = forAll { trainingData: Matrix =>
+      // Spark 2.1.x decision tree implementation has a bug with a dataset with constant label,
+      // so we simulate two different labels
+      // See https://issues.apache.org/jira/browse/SPARK-18036
+      val inputs = trainingData.rowIter.toVector.zipWithIndex.map {
+        case (vector, i) => Input(vector, (i % 2).toDouble)
+      }
+
+      val inputsDS = TypedDataset.create(inputs)
+
+      val model = new DecisionTreeRegressor()
+      val trainedModel = model.fit(inputsDS.dataset)
+
+      val randomInput = inputs(Random.nextInt(inputs.length))
+      val randomInputDS = TypedDataset.create(Seq(randomInput))
+
+      val prediction = trainedModel.transform(randomInputDS.dataset)
+        .select("prediction")
+        .head
+        .getAs[Double](0)
+
+      (prediction ?= 0D) || (prediction ?= 1D)
+    }
+
+    check(prop, MinSize(2))
+  }
+
+}

--- a/ml/src/test/scala/frameless/ml/TypedEncoderInstancesTests.scala
+++ b/ml/src/test/scala/frameless/ml/TypedEncoderInstancesTests.scala
@@ -19,8 +19,8 @@ class TypedEncoderInstancesTests extends FramelessMlSuite {
   }
 
   test("Matrix encoding is injective using collect()") {
-    val prop = forAll { vector: Matrix =>
-      TypedDataset.create(Seq(vector)).collect().run() ?= Seq(vector)
+    val prop = forAll { matrix: Matrix =>
+      TypedDataset.create(Seq(matrix)).collect().run() ?= Seq(matrix)
     }
     check(prop)
   }
@@ -39,6 +39,8 @@ class TypedEncoderInstancesTests extends FramelessMlSuite {
       val inputsDS = TypedDataset.create(inputs)
 
       val model = new DecisionTreeRegressor()
+
+      // this line would throw a runtime exception if Vector was not encoded as VectorUDT
       val trainedModel = model.fit(inputsDS.dataset)
 
       val randomInput = inputs(Random.nextInt(inputs.length))

--- a/ml/src/test/scala/frameless/ml/TypedEncoderInstancesTests.scala
+++ b/ml/src/test/scala/frameless/ml/TypedEncoderInstancesTests.scala
@@ -1,26 +1,24 @@
 package frameless
 package ml
 
-import frameless.TypedDataset
 import org.scalacheck.Prop._
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.regression.DecisionTreeRegressor
 import Generators._
-
 import scala.util.Random
 
 class TypedEncoderInstancesTests extends FramelessMlSuite {
 
   test("Vector encoding is injective using collect()") {
     val prop = forAll { vector: Vector =>
-      TypedDataset.create(Seq(vector)).collect().run() ?= Seq(vector)
+      TypedDataset.create(Seq(vector)).collect().run() == Seq(vector)
     }
     check(prop)
   }
 
   test("Matrix encoding is injective using collect()") {
     val prop = forAll { matrix: Matrix =>
-      TypedDataset.create(Seq(matrix)).collect().run() ?= Seq(matrix)
+      TypedDataset.create(Seq(matrix)).collect().run() == Seq(matrix)
     }
     check(prop)
   }
@@ -29,29 +27,31 @@ class TypedEncoderInstancesTests extends FramelessMlSuite {
     case class Input(features: Vector, label: Double)
 
     val prop = forAll { trainingData: Matrix =>
-      // Spark 2.1.x decision tree implementation has a bug with a dataset with constant label,
-      // so we simulate two different labels
-      // See https://issues.apache.org/jira/browse/SPARK-18036
-      val inputs = trainingData.rowIter.toVector.zipWithIndex.map {
-        case (vector, i) => Input(vector, (i % 2).toDouble)
+      (trainingData.numRows >= 2 && trainingData.numCols >= 1) ==> {
+        // Spark 2.1.x decision tree implementation has a bug with a dataset with constant label,
+        // so we simulate two different labels
+        // See https://issues.apache.org/jira/browse/SPARK-18036
+        val inputs = trainingData.rowIter.toVector.zipWithIndex.map {
+          case (vector, i) => Input(vector, (i % 2).toDouble)
+        }
+
+        val inputsDS = TypedDataset.create(inputs)
+
+        val model = new DecisionTreeRegressor()
+
+        // this line would throw a runtime exception if Vector was not encoded as VectorUDT
+        val trainedModel = model.fit(inputsDS.dataset)
+
+        val randomInput = inputs(Random.nextInt(inputs.length))
+        val randomInputDS = TypedDataset.create(Seq(randomInput))
+
+        val prediction = trainedModel.transform(randomInputDS.dataset)
+          .select("prediction")
+          .head
+          .getAs[Double](0)
+
+        (prediction == 0D) || (prediction == 1D)
       }
-
-      val inputsDS = TypedDataset.create(inputs)
-
-      val model = new DecisionTreeRegressor()
-
-      // this line would throw a runtime exception if Vector was not encoded as VectorUDT
-      val trainedModel = model.fit(inputsDS.dataset)
-
-      val randomInput = inputs(Random.nextInt(inputs.length))
-      val randomInputDS = TypedDataset.create(Seq(randomInput))
-
-      val prediction = trainedModel.transform(randomInputDS.dataset)
-        .select("prediction")
-        .head
-        .getAs[Double](0)
-
-      (prediction ?= 0D) || (prediction ?= 1D)
     }
 
     check(prop, MinSize(2))

--- a/ml/src/test/scala/frameless/ml/TypedEncoderInstancesTests.scala
+++ b/ml/src/test/scala/frameless/ml/TypedEncoderInstancesTests.scala
@@ -1,4 +1,5 @@
-package frameless.ml
+package frameless
+package ml
 
 import frameless.TypedDataset
 import org.scalacheck.Prop._
@@ -8,7 +9,7 @@ import Generators._
 
 import scala.util.Random
 
-class TypedEncoderInstancesTests extends TypedDatasetSuite {
+class TypedEncoderInstancesTests extends FramelessMlSuite {
 
   test("Vector encoding is injective using collect()") {
     val prop = forAll { vector: Vector =>


### PR DESCRIPTION
Following https://github.com/typelevel/frameless/pull/166, this PR adds a "frameless-ml" project to provide public UDT instances for Spark ML linear algebra data structures (Vector and Matrix). 

Thanks to https://github.com/typelevel/frameless/pull/166, the resulting typed encoders will encode vectors/matrices using Spark ML's VectorUDT and MatrixUDT, meaning that we can use a TypedDataset directly to fit a Spark ML Model without encoding re-conversion.

This new "frameless-ml" project can then be the start of more work towards a better-typed ML API in Spark.

Note: I did not update README.md as I think we want to do that once we publish the frameless-ml package (during the Frameless 0.4 release I imagine).