### PR TITLE
Encoders for Array and Map - continued

### DIFF
--- a/core/src/main/scala/frameless/CatalystNotNullable.scala
+++ b/core/src/main/scala/frameless/CatalystNotNullable.scala
@@ -1,0 +1,18 @@
+package frameless
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Cannot find evidence that type ${A} is nullable. Currently, only Option[A] is nullable.")
+trait CatalystNullable[A]
+
+object CatalystNullable {
+  implicit def optionIsNullable[A]: CatalystNullable[Option[A]] = new CatalystNullable[Option[A]] {}
+}
+
+@implicitNotFound("Cannot find evidence that type ${A} is not nullable.")
+trait NotCatalystNullable[A]
+
+object NotCatalystNullable {
+  implicit def everythingIsNotNullable[A]: NotCatalystNullable[A] = new NotCatalystNullable[A] {}
+  implicit def nullableIsNotNotNullable[A: CatalystNullable]: NotCatalystNullable[A] = new NotCatalystNullable[A] {}
+}

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.FramelessInternals.UserDefinedType
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.objects._
-import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import shapeless._
@@ -252,10 +252,40 @@ object TypedEncoder {
       WrapOption(underlying.fromCatalyst(path), underlying.jvmRepr)
   }
 
+  abstract class CollectionEncoder[F[_], A](implicit
+    underlying: TypedEncoder[A],
+    classTag: ClassTag[F[A]]
+  ) extends TypedEncoder[F[A]] {
+    protected def arrayData(path: Expression): Expression = Option(underlying.jvmRepr)
+      .filter(ScalaReflection.isNativeType)
+      .filter(_ == underlying.catalystRepr)
+      .collect {
+        case BooleanType => "toBooleanArray" -> ScalaReflection.dataTypeFor[Array[Boolean]]
+        case ByteType    => "toByteArray"    -> ScalaReflection.dataTypeFor[Array[Byte]]
+        case ShortType   => "toShortArray"   -> ScalaReflection.dataTypeFor[Array[Short]]
+        case IntegerType => "toIntArray"     -> ScalaReflection.dataTypeFor[Array[Int]]
+        case LongType    => "toLongArray"    -> ScalaReflection.dataTypeFor[Array[Long]]
+        case FloatType   => "toFloatArray"   -> ScalaReflection.dataTypeFor[Array[Float]]
+        case DoubleType  => "toDoubleArray"  -> ScalaReflection.dataTypeFor[Array[Double]]
+      }.map {
+        case (method, typ) => Invoke(path, method, typ)
+      }.getOrElse {
+        Invoke(
+          MapObjects(
+            underlying.fromCatalyst,
+            path,
+            underlying.catalystRepr
+          ),
+          "array",
+          ScalaReflection.dataTypeFor[Array[AnyRef]]
+        )
+      }
+  }
+
   implicit def vectorEncoder[A](
     implicit
     underlying: TypedEncoder[A]
-  ): TypedEncoder[Vector[A]] = new TypedEncoder[Vector[A]]() {
+  ): TypedEncoder[Vector[A]] = new CollectionEncoder[Vector, A]() {
     def nullable: Boolean = false
 
     def jvmRepr: DataType = FramelessInternals.objectTypeFor[Vector[A]](classTag)
@@ -263,21 +293,11 @@ object TypedEncoder {
     def catalystRepr: DataType = DataTypes.createArrayType(underlying.catalystRepr)
 
     def fromCatalyst(path: Expression): Expression = {
-      val arrayData = Invoke(
-        MapObjects(
-          underlying.fromCatalyst,
-          path,
-          underlying.catalystRepr
-        ),
-        "array",
-        ScalaReflection.dataTypeFor[Array[AnyRef]]
-      )
-
       StaticInvoke(
         TypedEncoderUtils.getClass,
         jvmRepr,
         "mkVector",
-        arrayData :: Nil
+        arrayData(path) :: Nil
       )
     }
 
@@ -293,6 +313,108 @@ object TypedEncoder {
         MapObjects(underlying.toCatalyst, path, underlying.jvmRepr)
       }
     }
+  }
+
+  implicit def listEncoder[A](
+    implicit
+    underlying: TypedEncoder[A]
+  ): TypedEncoder[List[A]] = new CollectionEncoder[List, A]() {
+    def nullable: Boolean = false
+
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[List[A]](classTag)
+
+    def catalystRepr: DataType = DataTypes.createArrayType(underlying.catalystRepr)
+
+    def fromCatalyst(path: Expression): Expression = {
+      StaticInvoke(
+        TypedEncoderUtils.getClass,
+        jvmRepr,
+        "mkList",
+        arrayData(path) :: Nil
+      )
+    }
+
+    def toCatalyst(path: Expression): Expression = {
+      // if source `path` is already native for Spark, no need to `map`
+      if (ScalaReflection.isNativeType(underlying.jvmRepr)) {
+        NewInstance(
+          classOf[GenericArrayData],
+          path :: Nil,
+          dataType = ArrayType(underlying.catalystRepr, underlying.nullable)
+        )
+      } else {
+        MapObjects(underlying.toCatalyst, path, underlying.jvmRepr)
+      }
+    }
+  }
+
+  implicit def arrayEncoder[A](
+    implicit
+    underlying: TypedEncoder[A]
+  ): TypedEncoder[Array[A]] = {
+    import underlying.classTag
+
+    new CollectionEncoder[Array, A]() {
+      def nullable: Boolean = false
+      def jvmRepr: DataType = FramelessInternals.objectTypeFor[Array[A]](classTag)
+      def catalystRepr: DataType = DataTypes.createArrayType(underlying.catalystRepr)
+
+      def fromCatalyst(path: Expression): Expression = arrayData(path)
+
+      def toCatalyst(path: Expression): Expression = {
+        // if source `path` is already native for Spark, no need to `map`
+        if (ScalaReflection.isNativeType(underlying.jvmRepr)) {
+          NewInstance(
+            classOf[GenericArrayData],
+            path :: Nil,
+            dataType = ArrayType(underlying.catalystRepr, underlying.nullable)
+          )
+        } else {
+          MapObjects(underlying.toCatalyst, path, underlying.jvmRepr)
+        }
+      }
+    }
+  }
+
+  implicit def mapEncoder[A: NotCatalystNullable, B](
+    implicit
+    encodeA: TypedEncoder[A],
+    encodeB: TypedEncoder[B]
+  ): TypedEncoder[Map[A, B]] = new TypedEncoder[Map[A, B]] {
+    def nullable: Boolean = false
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[Map[A, B]]
+    def catalystRepr: DataType = MapType(encodeA.catalystRepr, encodeB.catalystRepr, encodeB.nullable)
+
+    private def wrap(arrayData: Expression) = {
+      StaticInvoke(
+        scala.collection.mutable.WrappedArray.getClass,
+        FramelessInternals.objectTypeFor[Seq[_]],
+        "make",
+        arrayData :: Nil)
+    }
+
+    def fromCatalyst(path: Expression): Expression = {
+      val keyArrayType = ArrayType(encodeA.catalystRepr, containsNull = false)
+      val keyData = wrap(arrayEncoder[A].fromCatalyst(Invoke(path, "keyArray", keyArrayType)))
+
+      val valueArrayType = ArrayType(encodeB.catalystRepr, encodeB.nullable)
+      val valueData = wrap(arrayEncoder[B].fromCatalyst(Invoke(path, "valueArray", valueArrayType)))
+
+      StaticInvoke(
+        ArrayBasedMapData.getClass,
+        jvmRepr,
+        "toScalaMap",
+        keyData :: valueData :: Nil)
+    }
+
+    def toCatalyst(path: Expression): Expression = ExternalMapToCatalyst(
+      path,
+      encodeA.jvmRepr,
+      encodeA.toCatalyst,
+      encodeB.jvmRepr,
+      encodeB.toCatalyst,
+      encodeB.nullable)
+
   }
 
   /** Encodes things using injection if there is one defined */

--- a/dataset/src/main/scala/frameless/TypedEncoderUtils.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoderUtils.scala
@@ -3,4 +3,5 @@ package frameless
 /** Utils for Spark interop */
 object TypedEncoderUtils {
   def mkVector[A](xs: Array[A]): Vector[A] = Vector(xs: _*)
+  def mkList[A](xs: Array[A]): List[A] = List(xs: _*)
 }

--- a/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
@@ -47,12 +47,22 @@ object CatalystSizableCollection {
   implicit def sizableVector: CatalystSizableCollection[Vector] = new CatalystSizableCollection[Vector] {
     def sizeOp(col: Column): Column = sparkFunctions.size(col)
   }
+
+  implicit def sizableArray: CatalystSizableCollection[Array] = new CatalystSizableCollection[Array] {
+    def sizeOp(col: Column): Column = sparkFunctions.size(col)
+  }
+
+  implicit def sizableList: CatalystSizableCollection[List] = new CatalystSizableCollection[List] {
+    def sizeOp(col: Column): Column = sparkFunctions.size(col)
+  }
 }
 
 trait CatalystExplodableCollection[V[_]]
 
 object CatalystExplodableCollection {
   implicit def explodableVector: CatalystExplodableCollection[Vector] = new CatalystExplodableCollection[Vector] {}
+  implicit def explodableArray: CatalystExplodableCollection[Array] = new CatalystExplodableCollection[Array] {}
+  implicit def explodableList: CatalystExplodableCollection[List] = new CatalystExplodableCollection[List] {}
 }
 
 trait CatalystSortableCollection[V[_]] {
@@ -61,6 +71,14 @@ trait CatalystSortableCollection[V[_]] {
 
 object CatalystSortableCollection {
   implicit def sortableVector: CatalystSortableCollection[Vector] = new CatalystSortableCollection[Vector] {
+    def sortOp(col: Column, sortAscending: Boolean): Column = sparkFunctions.sort_array(col, sortAscending)
+  }
+
+  implicit def sortableArray: CatalystSortableCollection[Array] = new CatalystSortableCollection[Array] {
+    def sortOp(col: Column, sortAscending: Boolean): Column = sparkFunctions.sort_array(col, sortAscending)
+  }
+
+  implicit def sortableList: CatalystSortableCollection[List] = new CatalystSortableCollection[List] {
     def sortOp(col: Column, sortAscending: Boolean): Column = sparkFunctions.sort_array(col, sortAscending)
   }
 }

--- a/dataset/src/test/scala/frameless/CreateTests.scala
+++ b/dataset/src/test/scala/frameless/CreateTests.scala
@@ -1,8 +1,10 @@
 package frameless
 
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Prop}
 import org.scalacheck.Prop._
 import org.scalatest.Matchers
+import scala.reflect.ClassTag
+import shapeless.test.illTyped
 
 class CreateTests extends TypedDatasetSuite with Matchers {
 
@@ -26,6 +28,100 @@ class CreateTests extends TypedDatasetSuite with Matchers {
       Vector[Vector[X2[Vector[(Person, X1[Char])], Country]]],
       X3[Food, Country, String],
       Vector[(Food, Country)]] _))
+  }
+
+  test("array fields") {
+    def prop[T: Arbitrary: TypedEncoder: ClassTag] = forAll {
+      (d1: Array[T], d2: Array[Option[T]], d3: Array[X1[T]], d4: Array[X1[Option[T]]],
+        d5: X1[Array[T]]) =>
+        TypedDataset.create(Seq(d1)).collect().run().head.sameElements(d1) &&
+        TypedDataset.create(Seq(d2)).collect().run().head.sameElements(d2) &&
+        TypedDataset.create(Seq(d3)).collect().run().head.sameElements(d3) &&
+        TypedDataset.create(Seq(d4)).collect().run().head.sameElements(d4) &&
+        TypedDataset.create(Seq(d5)).collect().run().head.a.sameElements(d5.a)
+    }
+
+    check(prop[Boolean])
+    check(prop[Byte])
+    check(prop[Short])
+    check(prop[Int])
+    check(prop[Long])
+    check(prop[Float])
+    check(prop[Double])
+    check(prop[String])
+  }
+
+  test("vector fields") {
+    def prop[T: Arbitrary: TypedEncoder] = forAll {
+      (d1: Vector[T], d2: Vector[Option[T]], d3: Vector[X1[T]], d4: Vector[X1[Option[T]]],
+        d5: X1[Vector[T]]) =>
+      (TypedDataset.create(Seq(d1)).collect().run().head ?= d1) &&
+      (TypedDataset.create(Seq(d2)).collect().run().head ?= d2) &&
+      (TypedDataset.create(Seq(d3)).collect().run().head ?= d3) &&
+      (TypedDataset.create(Seq(d4)).collect().run().head ?= d4) &&
+      (TypedDataset.create(Seq(d5)).collect().run().head ?= d5)
+    }
+
+    check(prop[Boolean])
+    check(prop[Byte])
+    check(prop[Char])
+    check(prop[Short])
+    check(prop[Int])
+    check(prop[Long])
+    check(prop[Float])
+    check(prop[Double])
+    check(prop[String])
+  }
+
+  test("list fields") {
+    def prop[T: Arbitrary: TypedEncoder] = forAll {
+      (d1: List[T], d2: List[Option[T]], d3: List[X1[T]], d4: List[X1[Option[T]]],
+        d5: X1[List[T]]) =>
+      (TypedDataset.create(Seq(d1)).collect().run().head ?= d1) &&
+        (TypedDataset.create(Seq(d2)).collect().run().head ?= d2) &&
+        (TypedDataset.create(Seq(d3)).collect().run().head ?= d3) &&
+        (TypedDataset.create(Seq(d4)).collect().run().head ?= d4) &&
+        (TypedDataset.create(Seq(d5)).collect().run().head ?= d5)
+    }
+
+    check(prop[Boolean])
+    check(prop[Byte])
+    check(prop[Char])
+    check(prop[Short])
+    check(prop[Int])
+    check(prop[Long])
+    check(prop[Float])
+    check(prop[Double])
+    check(prop[String])
+  }
+
+  test("map fields (scala.Predef.Map / scala.collection.immutable.Map)") {
+    def prop[A: Arbitrary: TypedEncoder, B: Arbitrary: TypedEncoder] = forAll {
+      (d1: Map[A, B], d2: Map[B, A], d3: Map[A, Option[B]],
+        d4: Map[A, X1[B]], d5: Map[X1[A], B], d6: Map[X1[A], X1[B]]) =>
+
+      (TypedDataset.create(Seq(d1)).collect().run().head ?= d1) &&
+      (TypedDataset.create(Seq(d2)).collect().run().head ?= d2) &&
+      (TypedDataset.create(Seq(d3)).collect().run().head ?= d3) &&
+      (TypedDataset.create(Seq(d4)).collect().run().head ?= d4) &&
+      (TypedDataset.create(Seq(d5)).collect().run().head ?= d5) &&
+      (TypedDataset.create(Seq(d6)).collect().run().head ?= d6)
+    }
+
+    check(prop[String, String])
+    check(prop[String, Boolean])
+    check(prop[String, Byte])
+    check(prop[String, Char])
+    check(prop[String, Short])
+    check(prop[String, Int])
+    check(prop[String, Long])
+    check(prop[String, Float])
+    check(prop[String, Double])
+  }
+
+  test("maps with Option keys should not resolve the TypedEncoder") {
+    val data: Seq[Map[Option[Int], Int]] = Seq(Map(Some(5) -> 5))
+    illTyped("TypedDataset.create(data)", ".*could not find implicit value for parameter encoder.*")
   }
 
   test("not alligned columns should throw an exception") {

--- a/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
+++ b/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
@@ -1,14 +1,33 @@
 package frameless
 package functions
 
-import org.scalacheck.Prop
+import org.scalacheck.{ Arbitrary, Prop }
 import org.scalacheck.Prop._
+import scala.collection.SeqLike
 
 import scala.math.Ordering
 
 class UnaryFunctionsTest extends TypedDatasetSuite {
-  test("size on vector test") {
-    def prop[A: TypedEncoder](xs: List[X1[Vector[A]]]): Prop = {
+  test("size tests") {
+    def prop[F[X] <: Traversable[X] : CatalystSizableCollection, A](xs: List[X1[F[A]]])(implicit arb: Arbitrary[F[A]], enc: TypedEncoder[F[A]]): Prop = {
+      val tds = TypedDataset.create(xs)
+
+      val framelessResults = tds.select(size(tds('a))).collect().run().toVector
+      val scalaResults = xs.map(x => x.a.size).toVector
+
+      framelessResults ?= scalaResults
+    }
+
+    check(forAll(prop[Vector, Long] _))
+    check(forAll(prop[List, Long] _))
+    check(forAll(prop[Vector, Char] _))
+    check(forAll(prop[List, Char] _))
+    check(forAll(prop[Vector, X2[Int, Option[Long]]] _))
+    check(forAll(prop[List, X2[Int, Option[Long]]] _))
+  }
+
+  test("size on array test") {
+    def prop[A: TypedEncoder](xs: List[X1[Array[A]]]): Prop = {
       val tds = TypedDataset.create(xs)
 
       val framelessResults = tds.select(size(tds('a))).collect().run().toVector
@@ -18,12 +37,12 @@ class UnaryFunctionsTest extends TypedDatasetSuite {
     }
 
     check(forAll(prop[Long] _))
-    check(forAll(prop[Char] _))
+    check(forAll(prop[String] _))
     check(forAll(prop[X2[Int, Option[Long]]] _))
   }
 
-  test("sort on vector test: ascending order") {
-    def prop[A: TypedEncoder : Ordering](xs: List[X1[Vector[A]]]): Prop = {
+  test("sort in ascending order") {
+    def prop[F[X] <: SeqLike[X, F[X]] : CatalystSortableCollection, A: Ordering](xs: List[X1[F[A]]])(implicit enc: TypedEncoder[F[A]]): Prop = {
       val tds = TypedDataset.create(xs)
 
       val framelessResults = tds.select(sortAscending(tds('a))).collect().run().toVector
@@ -32,14 +51,18 @@ class UnaryFunctionsTest extends TypedDatasetSuite {
       framelessResults ?= scalaResults
     }
 
-    check(forAll(prop[Long] _))
-    check(forAll(prop[Int] _))
-    check(forAll(prop[Char] _))
-    check(forAll(prop[String] _))
+    check(forAll(prop[Vector, Long] _))
+    check(forAll(prop[Vector, Int] _))
+    check(forAll(prop[Vector, Char] _))
+    check(forAll(prop[Vector, String] _))
+    check(forAll(prop[List, Long] _))
+    check(forAll(prop[List, Int] _))
+    check(forAll(prop[List, Char] _))
+    check(forAll(prop[List, String] _))
   }
 
-  test("sort on vector test: descending order") {
-    def prop[A: TypedEncoder : Ordering](xs: List[X1[Vector[A]]]): Prop = {
+  test("sort in descending order") {
+    def prop[F[X] <: SeqLike[X, F[X]] : CatalystSortableCollection, A: Ordering](xs: List[X1[F[A]]])(implicit enc: TypedEncoder[F[A]]): Prop = {
       val tds = TypedDataset.create(xs)
 
       val framelessResults = tds.select(sortDescending(tds('a))).collect().run().toVector
@@ -48,14 +71,80 @@ class UnaryFunctionsTest extends TypedDatasetSuite {
       framelessResults ?= scalaResults
     }
 
+    check(forAll(prop[Vector, Long] _))
+    check(forAll(prop[Vector, Int] _))
+    check(forAll(prop[Vector, Char] _))
+    check(forAll(prop[Vector, String] _))
+    check(forAll(prop[List, Long] _))
+    check(forAll(prop[List, Int] _))
+    check(forAll(prop[List, Char] _))
+    check(forAll(prop[List, String] _))
+  }
+
+  test("sort on array test: ascending order") {
+    def prop[A: TypedEncoder : Ordering](xs: List[X1[Array[A]]]): Prop = {
+      val tds = TypedDataset.create(xs)
+
+      val framelessResults = tds.select(sortAscending(tds('a))).collect().run().toVector
+      val scalaResults = xs.map(x => x.a.sorted).toVector
+
+      Prop {
+        framelessResults
+          .zip(scalaResults)
+          .forall {
+            case (a, b) => a sameElements b
+          }
+      }
+    }
+
     check(forAll(prop[Long] _))
     check(forAll(prop[Int] _))
-    check(forAll(prop[Char] _))
+    check(forAll(prop[String] _))
+  }
+
+  test("sort on array test: descending order") {
+    def prop[A: TypedEncoder : Ordering](xs: List[X1[Array[A]]]): Prop = {
+      val tds = TypedDataset.create(xs)
+
+      val framelessResults = tds.select(sortDescending(tds('a))).collect().run().toVector
+      val scalaResults = xs.map(x => x.a.sorted.reverse).toVector
+
+      Prop {
+        framelessResults
+          .zip(scalaResults)
+          .forall {
+            case (a, b) => a sameElements b
+          }
+      }
+    }
+
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Int] _))
     check(forAll(prop[String] _))
   }
 
   test("explode on vectors") {
-    def prop[A: TypedEncoder](xs: List[X1[Vector[A]]]): Prop = {
+    def prop[F[X] <: Traversable[X] : CatalystExplodableCollection, A: TypedEncoder](xs: List[X1[F[A]]])(implicit arb: Arbitrary[F[A]], enc: TypedEncoder[F[A]]): Prop = {
+      val tds = TypedDataset.create(xs)
+
+      val framelessResults = tds.select(explode(tds('a))).collect().run().toSet
+      val scalaResults = xs.flatMap(_.a).toSet
+
+      framelessResults ?= scalaResults
+    }
+
+    check(forAll(prop[Vector, Long] _))
+    check(forAll(prop[Vector, Int] _))
+    check(forAll(prop[Vector, Char] _))
+    check(forAll(prop[Vector, String] _))
+    check(forAll(prop[List, Long] _))
+    check(forAll(prop[List, Int] _))
+    check(forAll(prop[List, Char] _))
+    check(forAll(prop[List, String] _))
+  }
+
+  test("explode on arrays") {
+    def prop[A: TypedEncoder](xs: List[X1[Array[A]]]): Prop = {
       val tds = TypedDataset.create(xs)
 
       val framelessResults = tds.select(explode(tds('a))).collect().run().toSet
@@ -66,7 +155,6 @@ class UnaryFunctionsTest extends TypedDatasetSuite {
 
     check(forAll(prop[Long] _))
     check(forAll(prop[Int] _))
-    check(forAll(prop[Char] _))
     check(forAll(prop[String] _))
   }
 }


### PR DESCRIPTION
Picking up where @jeremyrsmith left, this is rebased and has most of @kanterov's comments addressed.

Would be good to re-review this.

Caveats:
- `Array[Char]` doesn't work; explodes in codegen on this line: https://github.com/apache/spark/blob/v2.1.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala#L551, fixed in master but not in 2.2
- I had to revert the use of `FramelessInternals.objectTypeFor[Array[A]]` back to `ScalaReflection.dataTypeFor[Array[AnyRef]]` in `CollectionEncoder#arrayData` as that broke `Vector[Char]`