### PR TITLE
Fix BigDecimal multiplication

### DIFF
--- a/dataset/src/test/scala/frameless/NumericTests.scala
+++ b/dataset/src/test/scala/frameless/NumericTests.scala
@@ -41,14 +41,12 @@ class NumericTests extends TypedDatasetSuite {
   test("multiply") {
     def prop[A: TypedEncoder: CatalystNumeric: Numeric](a: A, b: A): Prop = {
       val df = TypedDataset.create(X2(a, b) :: Nil)
-      val sum = implicitly[Numeric[A]].times(a, b)
+      val result = implicitly[Numeric[A]].times(a, b)
       val got = df.select(df.col('a) * df.col('b)).collect().run()
 
-      got ?= (sum :: Nil)
+      got ?= (result :: Nil)
     }
 
-    // FIXME doesn't work ¯\_(ツ)_/¯
-    // check(prop[BigDecimal] _)
     check(prop[Byte] _)
     check(prop[Double] _)
     check(prop[Int] _)
@@ -84,6 +82,21 @@ class NumericTests extends TypedDatasetSuite {
         val got = df.select(df.col('a) / df.col('b)).collect().run()
         approximatelyEqual(got.head, div)
       }
+    }
+
+    check(prop _)
+  }
+
+  test("multiply BigDecimal") {
+    def prop(a: BigDecimal, b: BigDecimal): Prop = {
+      val df = TypedDataset.create(X2(a, b) :: Nil)
+      val result = BigDecimal(a.doubleValue * b.doubleValue)
+      val got = df.select(df.col('a) * df.col('b)).collect().run()
+
+      if (got == null :: Nil)
+        proved // https://issues.apache.org/jira/browse/SPARK-22036
+      else
+        approximatelyEqual(got.head, result)
     }
 
     check(prop _)

--- a/dataset/src/test/scala/frameless/NumericTests.scala
+++ b/dataset/src/test/scala/frameless/NumericTests.scala
@@ -2,6 +2,7 @@ package frameless
 
 import org.scalacheck.Prop
 import org.scalacheck.Prop._
+import scala.reflect.ClassTag
 
 class NumericTests extends TypedDatasetSuite {
   test("plus") {
@@ -39,7 +40,7 @@ class NumericTests extends TypedDatasetSuite {
   }
 
   test("multiply") {
-    def prop[A: TypedEncoder: CatalystNumeric: Numeric](a: A, b: A): Prop = {
+    def prop[A: TypedEncoder : CatalystNumeric : Numeric : ClassTag](a: A, b: A): Prop = {
       val df = TypedDataset.create(X2(a, b) :: Nil)
       val result = implicitly[Numeric[A]].times(a, b)
       val got = df.select(df.col('a) * df.col('b)).collect().run()
@@ -92,11 +93,7 @@ class NumericTests extends TypedDatasetSuite {
       val df = TypedDataset.create(X2(a, b) :: Nil)
       val result = BigDecimal(a.doubleValue * b.doubleValue)
       val got = df.select(df.col('a) * df.col('b)).collect().run()
-
-      if (got == null :: Nil)
-        proved // https://issues.apache.org/jira/browse/SPARK-22036
-      else
-        approximatelyEqual(got.head, result)
+      approximatelyEqual(got.head, result)
     }
 
     check(prop _)


### PR DESCRIPTION
This PR fixes BigDecimal multiplication. We had a long time pending issue with that, I think the test is commented from day one?

Investigating the issue I discovered that the multiplication of two BigDecimal sometimes returns `null`. That seems like a bug to me: https://issues.apache.org/jira/browse/SPARK-22036.

The discussion on Spark's issue tracker lead to a workaround that I implemented in the last commit. That of course not a satisfactory solution as it makes `BigDecimal` less precise than `Double`... I did that as a temporary workaround, assuming it would be fixed upstream. If this it turns out to be "working as indented" the alternative would be to have `(a: BigDecimal) * b` return `Option[BigDecimal]` instead.