### PR TITLE
Add a typed `col` function for creating column references

### DIFF
--- a/dataset/src/main/scala/frameless/functions/package.scala
+++ b/dataset/src/main/scala/frameless/functions/package.scala
@@ -2,6 +2,8 @@ package frameless
 
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.functions.{ col => sparkCol }
+import shapeless.Witness
 
 package object functions extends Udf with UnaryFunctions {
   object aggregate extends AggregateFunctions
@@ -16,5 +18,13 @@ package object functions extends Udf with UnaryFunctions {
       val expr = FramelessLit(value, encoder)
       new TypedColumn(expr)
     }
+  }
+
+  def col[T, A](column: Witness.Lt[Symbol])(
+    implicit
+    exists: TypedColumn.Exists[T, column.T, A],
+    encoder: TypedEncoder[A]): TypedColumn[T, A] = {
+    val untypedExpr = sparkCol(column.value.name).as[A](TypedExpressionEncoder[A])
+    new TypedColumn[T, A](untypedExpr)
   }
 }

--- a/dataset/src/test/scala/frameless/SelectTests.scala
+++ b/dataset/src/test/scala/frameless/SelectTests.scala
@@ -18,9 +18,10 @@ class SelectTests extends TypedDatasetSuite {
       val A = dataset.col[A]('a)
 
       val dataset2 = dataset.select(A).collect().run().toVector
+      val symDataset2 = dataset.select(functions.col('a)).collect().run().toVector
       val data2 = data.map { case X4(a, _, _, _) => a }
 
-      dataset2 ?= data2
+      (dataset2 ?= data2) && (symDataset2 ?= data2)
     }
 
     check(forAll(prop[Int, Int, Int, Int] _))


### PR DESCRIPTION
Resolves #186.

Would be a good idea to wait for #110 before merging this to avoid conflict on `SelectTests.scala`.