### PR TITLE
Feature/164 missing column methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val core = project
   .settings(warnUnusedImport: _*)
   .settings(publishSettings: _*)
 
+
 lazy val cats = project
   .settings(name := "frameless-cats")
   .settings(framelessSettings: _*)

--- a/core/src/main/scala/frameless/CatalystAbsolute.scala
+++ b/core/src/main/scala/frameless/CatalystAbsolute.scala
@@ -1,0 +1,19 @@
+package frameless
+
+import scala.annotation.implicitNotFound
+
+/** Spark does not return always the same type on abs as the input was
+  */
+@implicitNotFound("Cannot compute absolute on type ${In}.")
+trait CatalystAbsolute[In, Out]
+
+object CatalystAbsolute {
+  private[this] val theInstance = new CatalystAbsolute[Any, Any] {}
+  private[this] def of[In, Out]: CatalystAbsolute[In, Out] = theInstance.asInstanceOf[CatalystAbsolute[In, Out]]
+
+  implicit val framelessAbsoluteBigDecimal: CatalystAbsolute[BigDecimal, java.math.BigDecimal]  = of[BigDecimal, java.math.BigDecimal]
+  implicit val framelessAbsoluteDouble    : CatalystAbsolute[Double, Double]                    = of[Double, Double]
+  implicit val framelessAbsoluteInt       : CatalystAbsolute[Int, Int]                          = of[Int, Int]
+  implicit val framelessAbsoluteLong      : CatalystAbsolute[Long, Long]                        = of[Long, Long]
+  implicit val framelessAbsoluteShort     : CatalystAbsolute[Short, Short]                      = of[Short, Short]
+}

--- a/core/src/main/scala/frameless/CatalystCast.scala
+++ b/core/src/main/scala/frameless/CatalystCast.scala
@@ -38,8 +38,9 @@ object CatalystCast {
   // implicit object stringToLong extends CatalystCast[String, Option[Long]]
   // implicit object stringToSqlDate extends CatalystCast[String, Option[SQLDate]]
 
+
   // needs verification:
-  // implicit object sqlTimestampToSqlDate extends CatalystCast[SQLTimestamp, SQLDate]
+  //implicit object sqlTimestampToSqlDate extends CatalystCast[SQLTimestamp, SQLDate]
 
   // needs verification:
   // implicit object sqlTimestampToDecimal extends CatalystCast[SQLTimestamp, BigDecimal]

--- a/core/src/main/scala/frameless/CatalystCollection.scala
+++ b/core/src/main/scala/frameless/CatalystCollection.scala
@@ -1,0 +1,16 @@
+package frameless
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Cannot do collection operations on columns of type ${C}.")
+trait CatalystCollection[C[_]]
+
+object CatalystCollection {
+  private[this] val theInstance = new CatalystCollection[Any] {}
+  private[this] def of[A[_]]: CatalystCollection[A] = theInstance.asInstanceOf[CatalystCollection[A]]
+
+  implicit val arrayObject : CatalystCollection[Array]  = of[Array]
+  implicit val seqObject   : CatalystCollection[Seq]    = of[Seq]
+  implicit val listObject  : CatalystCollection[List]   = of[List]
+  implicit val vectorObject: CatalystCollection[Vector] = of[Vector]
+}

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -158,6 +158,19 @@ object TypedEncoder {
       Invoke(path, "toBigDecimal", jvmRepr)
   }
 
+  implicit val javaBigDecimalEncoder: TypedEncoder[java.math.BigDecimal] = new TypedEncoder[java.math.BigDecimal] {
+    def nullable: Boolean = false
+
+    def jvmRepr: DataType = ScalaReflection.dataTypeFor[java.math.BigDecimal]
+    def catalystRepr: DataType = DecimalType.SYSTEM_DEFAULT
+
+    def toCatalyst(path: Expression): Expression =
+      StaticInvoke(Decimal.getClass, DecimalType.SYSTEM_DEFAULT, "apply", path :: Nil)
+
+    def fromCatalyst(path: Expression): Expression =
+      Invoke(path, "toJavaBigDecimal", jvmRepr)
+  }
+
   implicit val sqlDate: TypedEncoder[SQLDate] = new TypedEncoder[SQLDate] {
     def nullable: Boolean = false
 

--- a/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
@@ -1,0 +1,124 @@
+package frameless
+package functions
+
+import frameless._
+import org.apache.spark.sql.{functions => untyped}
+
+trait NonAggregateFunctions {
+  /** Non-Aggregate function: returns the absolute value of a numeric column
+    *
+    * apache/spark
+    */
+  def abs[A, B, T](column: TypedColumn[T, A])(implicit evAbs: CatalystAbsolute[A, B], enc:TypedEncoder[B]):TypedColumn[T, B] = {
+    implicit val c = column.uencoder
+    new TypedColumn[T, B](untyped.abs(column.untyped))
+  }
+
+  /** Non-Aggregate function: returns the acos of a numeric column
+    *
+    * Spark will expect a Double value for this expression. See:
+    *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
+    * apache/spark
+    */
+  def acos[A, T](column: TypedColumn[T, A])
+    (implicit evCanBeDouble: CatalystCast[A, Double]): TypedColumn[T, Double] = {
+    implicit val c = column.uencoder
+    new TypedColumn[T, Double](untyped.acos(column.cast[Double].untyped))
+  }
+
+
+
+  /** Non-Aggregate function: returns true if value is contained with in the array in the specified column
+    *
+    * apache/spark
+    */
+  def arrayContains[C[_]: CatalystCollection, A, T](column: TypedColumn[T, C[A]], value: A): TypedColumn[T, Boolean] = {
+    implicit val c = column.uencoder
+    new TypedColumn[T, Boolean](untyped.array_contains(column.untyped, value))
+  }
+
+  /** Non-Aggregate function: takes the first letter of a string column and returns the ascii int value in a new column
+    *
+    * apache/spark
+    */
+  def ascii[T](column: TypedColumn[T, String]): TypedColumn[T, Int] = {
+    implicit val c = column.uencoder
+    new TypedColumn[T, Int](untyped.ascii(column.untyped))
+  }
+
+  /** Non-Aggregate function: returns the atan of a numeric column
+    *
+    * Spark will expect a Double value for this expression. See:
+    *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
+    * apache/spark
+    */
+  def atan[A, T](column: TypedColumn[T,A])
+                (implicit evCanBeDouble: CatalystCast[A, Double]): TypedColumn[T, Double] = {
+    implicit val c = column.uencoder
+    new TypedColumn[T, Double](untyped.atan(column.cast[Double].untyped))
+  }
+
+  /** Non-Aggregate function: returns the asin of a numeric column
+    *
+    * Spark will expect a Double value for this expression. See:
+    *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
+    * apache/spark
+    */
+  def asin[A, T](column: TypedColumn[T, A])
+                (implicit evCanBeDouble: CatalystCast[A, Double]): TypedColumn[T, Double] = {
+    implicit val c = column.uencoder
+    new TypedColumn[T, Double](untyped.asin(column.cast[Double].untyped))
+  }
+
+  /** Non-Aggregate function: returns the angle theta from the conversion of rectangular coordinates (x, y) to
+    * polar coordinates (r, theta).
+    *
+    * Spark will expect a Double value for this expression. See:
+    *   [[https://github.com/apache/spark/blob/4a3c09601ba69f7d49d1946bb6f20f5cfe453031/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L67]]
+    * apache/spark
+    */
+  def atan2[A, B, T](l: TypedColumn[T,A], r: TypedColumn[T, B])
+    (implicit
+      evCanBeDoubleL: CatalystCast[A, Double],
+      evCanBeDoubleR: CatalystCast[B, Double]
+    ): TypedColumn[T, Double] = {
+      implicit val lUnencoder = l.uencoder
+      implicit val rUnencoder = r.uencoder
+      new TypedColumn[T, Double](untyped.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
+    }
+
+  def atan2[B, T](l: Double, r: TypedColumn[T, B])(implicit evCanBeDoubleR: CatalystCast[B, Double]): TypedColumn[T, Double] =
+    atan2(lit(l): TypedColumn[T, Double], r)
+
+  def atan2[A, T](l: TypedColumn[T, A], r: Double)(implicit evCanBeDoubleL: CatalystCast[A, Double]): TypedColumn[T, Double] =
+    atan2(l, lit(r): TypedColumn[T, Double])
+
+  /** Non-Aggregate function: Computes the BASE64 encoding of a binary column and returns it as a string column.
+    * This is the reverse of unbase64.
+    *
+    * apache/spark
+    */
+  def base64[T](column: TypedColumn[T, Array[Byte]]): TypedColumn[T, String] = {
+    implicit val c = column.uencoder
+    new TypedColumn[T, String](untyped.base64(column.untyped))
+  }
+
+  /** Non-Aggregate function: Returns the string representation of the binary value of the given long
+    * column. For example, bin("12") returns "1100".
+    *
+    * apache/spark
+    */
+  def bin[T](column: TypedColumn[T, Long]): TypedColumn[T, String] = {
+    implicit val c = column.uencoder
+    new TypedColumn[T, String](untyped.bin(column.untyped))
+  }
+
+  /** Non-Aggregate function: Computes bitwise NOT.
+    *
+    * apache/spark
+    */
+  def bitwiseNOT[A: CatalystBitwise, T](column: TypedColumn[T, A]): TypedColumn[T, A] = {
+    implicit val c = column.uencoder
+    new TypedColumn[T, A](untyped.bitwiseNOT(column.untyped))
+  }
+}

--- a/dataset/src/main/scala/frameless/functions/package.scala
+++ b/dataset/src/main/scala/frameless/functions/package.scala
@@ -5,6 +5,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal
 
 package object functions extends Udf with UnaryFunctions {
   object aggregate extends AggregateFunctions
+  object nonAggregate extends NonAggregateFunctions
 
   def lit[A: TypedEncoder, T](value: A): TypedColumn[T, A] = {
     val encoder = TypedEncoder[A]

--- a/dataset/src/test/scala/frameless/functions/NonAggregateFunctionsTests.scala
+++ b/dataset/src/test/scala/frameless/functions/NonAggregateFunctionsTests.scala
@@ -1,0 +1,489 @@
+package frameless
+package functions
+import frameless.functions.nonAggregate._
+import org.apache.spark.sql.Encoder
+import org.scalacheck.Gen
+import org.scalacheck.Prop._
+
+class NonAggregateFunctionsTests extends TypedDatasetSuite {
+
+  test("abs big decimal") {
+    val spark = session
+    import spark.implicits._
+
+    def prop[A: TypedEncoder: Encoder, B: TypedEncoder: Encoder]
+      (values: List[X1[A]])
+      (
+        implicit catalystAbsolute: CatalystAbsolute[A, B],
+        encX1:Encoder[X1[A]]
+      )= {
+        val cDS = session.createDataset(values)
+        val resCompare = cDS
+          .select(org.apache.spark.sql.functions.abs(cDS("a")))
+          .map(_.getAs[B](0))
+          .collect().toList
+
+
+        val typedDS = TypedDataset.create(values)
+        val col = typedDS('a)
+        val res = typedDS
+          .select(
+            abs(col)
+          )
+          .collect()
+          .run()
+          .toList
+
+        res ?= resCompare
+      }
+
+    check(forAll(prop[BigDecimal, java.math.BigDecimal] _))
+  }
+
+  test("abs") {
+    val spark = session
+    import spark.implicits._
+
+    def prop[A: TypedEncoder : Encoder]
+      (values: List[X1[A]])
+      (
+        implicit catalystAbsolute: CatalystAbsolute[A, A],
+        encX1:Encoder[X1[A]]
+      )= {
+        val cDS = session.createDataset(values)
+        val resCompare = cDS
+          .select(org.apache.spark.sql.functions.abs(cDS("a")))
+          .map(_.getAs[A](0))
+          .collect().toList
+
+
+        val typedDS = TypedDataset.create(values)
+        val res = typedDS
+          .select(abs(typedDS('a)))
+          .collect()
+          .run()
+          .toList
+
+        res ?= resCompare
+      }
+
+      check(forAll(prop[Int] _))
+      check(forAll(prop[Long] _))
+      check(forAll(prop[Short] _))
+      check(forAll(prop[Double] _))
+    }
+
+
+
+  test("acos") {
+    val spark = session
+    import spark.implicits._
+
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder]
+    (values: List[X1[A]])
+    (implicit encX1:Encoder[X1[A]])
+    = {
+      val cDS = session.createDataset(values)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.acos(cDS("a")))
+        .map(_.getAs[Double](0))
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect().toList
+
+
+      val typedDS = TypedDataset.create(values)
+      val res = typedDS
+        .select(acos(typedDS('a)))
+        .deserialized
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Short] _))
+    check(forAll(prop[BigDecimal] _))
+    check(forAll(prop[Byte] _))
+    check(forAll(prop[Double] _))
+  }
+
+
+   /*
+    * Currently not all Collection types play nice with the Encoders.
+    * This test needs to be readressed and Set readded to the Collection Typeclass once these issues are resolved.
+    *
+    * [[https://issues.apache.org/jira/browse/SPARK-18891]]
+    * [[https://issues.apache.org/jira/browse/SPARK-21204]]
+    */
+  test("arrayContains"){
+
+
+    val spark = session
+    import spark.implicits._
+
+    val listLength = 10
+    val idxs = Stream.continually(Range(0, listLength)).flatten.toIterator
+
+    abstract class Nth[A, C[A]:CatalystCollection] {
+
+      def nth(c:C[A], idx:Int):A
+    }
+
+    implicit def deriveListNth[A] : Nth[A, List] = new Nth[A, List] {
+      override def nth(c: List[A], idx: Int): A = c(idx)
+    }
+
+    implicit def deriveSeqNth[A] : Nth[A, Seq] = new Nth[A, Seq] {
+      override def nth(c: Seq[A], idx: Int): A = c(idx)
+    }
+
+    implicit def deriveVectorNth[A] : Nth[A, Vector] = new Nth[A, Vector] {
+      override def nth(c: Vector[A], idx: Int): A = c(idx)
+    }
+
+    implicit def deriveArrayNth[A] : Nth[A, Array] = new Nth[A, Array] {
+      override def nth(c: Array[A], idx: Int): A = c(idx)
+    }
+
+
+    def prop[C[_] : CatalystCollection]
+      (
+        values: C[Int],
+        shouldBeIn:Boolean)
+      (
+        implicit nth:Nth[Int, C],
+        encEv: Encoder[C[Int]],
+        tEncEv: TypedEncoder[C[Int]]
+      ) = {
+
+      val contained = if (shouldBeIn) nth.nth(values, idxs.next) else -1
+
+      val cDS = session.createDataset(List(values))
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.array_contains(cDS("value"), contained))
+        .map(_.getAs[Boolean](0))
+        .collect().toList
+
+
+      val typedDS = TypedDataset.create(List(X1(values)))
+      val res = typedDS
+        .select(arrayContains(typedDS('a), contained))
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+
+    check(
+      forAll(
+        Gen.listOfN(listLength, Gen.choose(0,100)),
+        Gen.oneOf(true,false)
+      )
+      (prop[List])
+    )
+
+    /*check( Looks like there is no Typed Encoder for Seq type yet
+      forAll(
+        Gen.listOfN(listLength, Gen.choose(0,100)),
+        Gen.oneOf(true,false)
+      )
+      (prop[Seq])
+    )*/
+
+    check(
+      forAll(
+        Gen.listOfN(listLength, Gen.choose(0,100)).map(_.toVector),
+        Gen.oneOf(true,false)
+      )
+      (prop[Vector])
+    )
+
+    check(
+      forAll(
+        Gen.listOfN(listLength, Gen.choose(0,100)).map(_.toArray),
+        Gen.oneOf(true,false)
+      )
+      (prop[Array])
+    )
+  }
+
+  test("ascii"){
+    val spark = session
+    import spark.implicits._
+
+    def prop(values:List[X1[String]])(implicit x1Enc:Encoder[X1[String]]) = {
+      val cDS = session.createDataset(values)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.ascii(cDS("a")))
+        .map(_.getAs[Int](0))
+        .collect().toList
+
+      val typedDS = TypedDataset.create(values)
+      val res = typedDS
+        .select(ascii(typedDS('a)))
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+    check(forAll(prop _))
+  }
+
+
+  test("atan") {
+    val spark = session
+    import spark.implicits._
+
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])(implicit encX1:Encoder[X1[A]]) = {
+      val cDS = session.createDataset(values)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.atan(cDS("a")))
+        .map(_.getAs[Double](0))
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect().toList
+
+
+      val typedDS = TypedDataset.create(values)
+      val res = typedDS
+        .select(atan(typedDS('a)))
+        .deserialized
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Short] _))
+    check(forAll(prop[BigDecimal] _))
+    check(forAll(prop[Byte] _))
+    check(forAll(prop[Double] _))
+  }
+
+  test("asin") {
+    val spark = session
+    import spark.implicits._
+
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])(implicit encX1:Encoder[X1[A]]) = {
+      val cDS = session.createDataset(values)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.asin(cDS("a")))
+        .map(_.getAs[Double](0))
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect().toList
+
+
+      val typedDS = TypedDataset.create(values)
+      val res = typedDS
+        .select(asin(typedDS('a)))
+        .deserialized
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Short] _))
+    check(forAll(prop[BigDecimal] _))
+    check(forAll(prop[Byte] _))
+    check(forAll(prop[Double] _))
+  }
+
+  test("atan2") {
+    val spark = session
+    import spark.implicits._
+
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder, B: CatalystNumeric : TypedEncoder : Encoder](values: List[X2[A, B]])
+            (implicit encEv: Encoder[X2[A,B]]) = {
+      val cDS = session.createDataset(values)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.atan2(cDS("a"), cDS("b")))
+        .map(_.getAs[Double](0))
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect().toList
+
+
+      val typedDS = TypedDataset.create(values)
+      val res = typedDS
+        .select(atan2(typedDS('a), typedDS('b)))
+        .deserialized
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+
+    check(forAll(prop[Int, Long] _))
+    check(forAll(prop[Long, Int] _))
+    check(forAll(prop[Short, Byte] _))
+    check(forAll(prop[BigDecimal, Double] _))
+    check(forAll(prop[Byte, Int] _))
+    check(forAll(prop[Double, Double] _))
+  }
+
+  test("atan2LitLeft") {
+    val spark = session
+    import spark.implicits._
+
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](value: List[X1[A]], lit:Double)(implicit encX1:Encoder[X1[A]]) = {
+      val cDS = session.createDataset(value)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.atan2(lit, cDS("a")))
+        .map(_.getAs[Double](0))
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect().toList
+
+
+      val typedDS = TypedDataset.create(value)
+      val res = typedDS
+        .select(atan2(lit, typedDS('a)))
+        .deserialized
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Short] _))
+    check(forAll(prop[BigDecimal] _))
+    check(forAll(prop[Byte] _))
+    check(forAll(prop[Double] _))
+  }
+
+  test("atan2LitRight") {
+    val spark = session
+    import spark.implicits._
+
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](value: List[X1[A]], lit:Double)(implicit encX1:Encoder[X1[A]]) = {
+      val cDS = session.createDataset(value)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.atan2(cDS("a"), lit))
+        .map(_.getAs[Double](0))
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect().toList
+
+
+      val typedDS = TypedDataset.create(value)
+      val res = typedDS
+        .select(atan2(typedDS('a), lit))
+        .deserialized
+        .map(DoubleBehaviourUtils.nanNullHandler)
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Short] _))
+    check(forAll(prop[BigDecimal] _))
+    check(forAll(prop[Byte] _))
+    check(forAll(prop[Double] _))
+  }
+
+  test("base64") {
+    val spark = session
+    import spark.implicits._
+
+    def prop(values:List[X1[Array[Byte]]])(implicit encX1:Encoder[X1[Array[Byte]]]) = {
+      val cDS = session.createDataset(values)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.base64(cDS("a")))
+        .map(_.getAs[String](0))
+        .collect().toList
+
+      val typedDS = TypedDataset.create(values)
+      val res = typedDS
+        .select(base64(typedDS('a)))
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+    check(forAll(prop _))
+  }
+
+  test("bin"){
+    val spark = session
+    import spark.implicits._
+
+    def prop(values:List[X1[Long]])(implicit encX1:Encoder[X1[Long]]) = {
+      val cDS = session.createDataset(values)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.bin(cDS("a")))
+        .map(_.getAs[String](0))
+        .collect().toList
+
+      val typedDS = TypedDataset.create(values)
+      val res = typedDS
+        .select(bin(typedDS('a)))
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+    check(forAll(prop _))
+  }
+
+
+  test("bitwiseNOT"){
+    val spark = session
+    import spark.implicits._
+
+    def prop[A: CatalystBitwise : TypedEncoder : Encoder](values:List[X1[A]])(implicit encX1:Encoder[X1[A]]) = {
+      val cDS = session.createDataset(values)
+      val resCompare = cDS
+        .select(org.apache.spark.sql.functions.bitwiseNOT(cDS("a")))
+        .map(_.getAs[A](0))
+        .collect().toList
+
+      val typedDS = TypedDataset.create(values)
+      val res = typedDS
+        .select(bitwiseNOT(typedDS('a)))
+        .collect()
+        .run()
+        .toList
+
+      res ?= resCompare
+    }
+
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Short] _))
+    check(forAll(prop[Byte] _))
+    check(forAll(prop[Int] _))
+  }
+
+}


### PR DESCRIPTION
I didn't want to end up with a huge pull request after implementing many more column functions, so I thought I'd make a smaller intermittent one.

There's some points that I could use some feedback to though:

- CatalystCollection is mainly tuned for Types that work with the array_contains column function. I'm not sure this will generalize well

- TypedEncoderBinaryType is placed oddly. The reason it exists is that currently `Array[Byte]` will be represented as array<tinyint> instead of the correct binarytype. However i couldn't get the implicit resolution to pick it over the generic Array[T] implementation in TypedEncoder when placed in the same file.

- Seq has no TypedEncoder yet so I couldn't fully test array_contains.