### PR TITLE
Add TypedTransformer and TypedEstimator, towards a type-safe Spark ML API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It consists of the following modules:
 
 * `dataset` for more strongly typed `Dataset`s  (supports Spark 2.2.x)
 * `cats` for using Spark with [cats](https://github.com/typelevel/cats) (supports Cats 1.0.0-MF)
-* `ml` for a more strongly typed use of Spark ML based on `dataset`
+* `ml` for a more strongly typed Spark ML API based on `dataset`
 
 The Frameless project and contributors support the
 [Typelevel](http://typelevel.org/) [Code of Conduct](http://typelevel.org/conduct.html) and want all its
@@ -24,7 +24,7 @@ associated channels (e.g. GitHub, Gitter) to be a safe and friendly environment 
 * [Injection: Creating Custom Encoders](http://typelevel.org/frameless/Injection.html)
 * [Job\[A\]](http://typelevel.org/frameless/Job.html)
 * [Using Cats with RDDs](http://typelevel.org/frameless/Cats.html)
-* [TypedDataset support for Spark ML](http://typelevel.org/frameless/TypedML.html)
+* [Typed Spark ML](http://typelevel.org/frameless/TypedML.html)
 * [Proof of Concept: TypedDataFrame](http://typelevel.org/frameless/TypedDataFrame.html)
 
 ## Why?

--- a/dataset/src/test/scala/frameless/XN.scala
+++ b/dataset/src/test/scala/frameless/XN.scala
@@ -64,3 +64,16 @@ object X5 {
   implicit def ordering[A: Ordering, B: Ordering, C: Ordering, D: Ordering, E: Ordering]: Ordering[X5[A, B, C, D, E]] =
     Ordering.Tuple5[A, B, C, D, E].on(x => (x.a, x.b, x.c, x.d, x.e))
 }
+
+case class X6[A, B, C, D, E, F](a: A, b: B, c: C, d: D, e: E, f: F)
+
+object X6 {
+  implicit def arbitrary[A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Arbitrary, E: Arbitrary, F: Arbitrary]: Arbitrary[X6[A, B, C, D, E, F]] =
+    Arbitrary(Arbitrary.arbTuple6[A, B, C, D, E, F].arbitrary.map((X6.apply[A, B, C, D, E, F] _).tupled))
+
+  implicit def cogen[A, B, C, D, E, F](implicit A: Cogen[A], B: Cogen[B], C: Cogen[C], D: Cogen[D], E: Cogen[E], F: Cogen[F]): Cogen[X6[A, B, C, D, E, F]] =
+    Cogen.tuple6(A, B, C, D, E, F).contramap(x => (x.a, x.b, x.c, x.d, x.e, x.f))
+
+  implicit def ordering[A: Ordering, B: Ordering, C: Ordering, D: Ordering, E: Ordering, F: Ordering]: Ordering[X6[A, B, C, D, E, F]] =
+    Ordering.Tuple6[A, B, C, D, E, F].on(x => (x.a, x.b, x.c, x.d, x.e, x.f))
+}

--- a/docs/src/main/tut/TypedML.md
+++ b/docs/src/main/tut/TypedML.md
@@ -1,6 +1,6 @@
 # Typed Spark ML
 
-`frameless-ml` module provides a strongly typed Spark ML API leveraging `TypedDataset`s. It introduces `TypedTransformer`s
+The `frameless-ml` module provides a strongly typed Spark ML API leveraging `TypedDataset`s. It introduces `TypedTransformer`s
 and `TypedEstimator`s, the type-safe equivalents of Spark ML's `Transformer` and `Estimator`. 
 
 A `TypedEstimator` fits models to data, i.e trains a ML model based on an input `TypedDataset`. 
@@ -229,14 +229,14 @@ prediction == Seq("foo")
 
 * `TypedRandomForestClassifier`
 * `TypedRandomForestRegressor`
-* ... your contribution here ... :)
+* ... [your contribution here](https://github.com/typelevel/frameless/issues/215) ... :)
 
 ## List of currently implemented `TypedTransformer`s
 
 * `TypedIndexToString`
 * `TypedStringIndexer`
 * `TypedVectorAssembler`
-* ... your contribution here ... :)
+* ... [your contribution here](https://github.com/typelevel/frameless/issues/215) ... :)
  
 ## Using Vector and Matrix with `TypedDataset`
 

--- a/docs/src/main/tut/TypedML.md
+++ b/docs/src/main/tut/TypedML.md
@@ -1,8 +1,22 @@
-# TypedDataset support for Spark ML
+# Typed Spark ML
 
-The goal of the `frameless-ml` module is to be able to use Spark ML with `TypedDataset` and
-to eventually provide a more strongly typed ML API for Spark. Currently, this module is at its very beginning and only 
-provides `TypedEncoder` instances for Spark ML's linear algebra data types.
+`frameless-ml` module provides a strongly typed Spark ML API leveraging `TypedDataset`s. It introduces `TypedTransformer`s
+and `TypedEstimator`s, the type-safe equivalents of Spark ML's `Transformer` and `Estimator`. 
+
+A `TypedEstimator` fits models to data, i.e trains a ML model based on an input `TypedDataset`. 
+A `TypedTransformer` transforms one `TypedDataset` into another, usually by appending column(s) to it.
+
+By calling the `fit` method of a `TypedEstimator`, the `TypedEstimator` will train a ML model using the `TypedDataset` 
+passed as input (representing the training data) and will return a `TypedTransformer` that represents the trained model. 
+This `TypedTransformer`can then be used to make predictions on an input `TypedDataset` (representing the test data) 
+using the `transform` method that will return a new `TypedDataset` with appended prediction column(s).
+
+Both `TypedEstimator` and `TypedTransformer` check at compile-time the correctness of their inputs field names and types,
+contrary to Spark ML API which only deals with DataFrames (the data structure with the lowest level of type-safety in Spark).
+
+`frameless-ml` adds type-safety to Spark ML API but stays very close to it in terms of abstractions and code flow, so 
+please check [Spark ML documentation](https://spark.apache.org/docs/2.2.0/ml-pipeline.html) for more details 
+on `Transformer`s and `Estimator`s.
 
 ```tut:invisible
 import org.apache.spark.{SparkConf, SparkContext}
@@ -15,17 +29,226 @@ spark.sparkContext.setLogLevel("WARN")
 
 import spark.implicits._
 ```
+
+## Example 1: predict a continuous value using a `TypedRandomForestRegressor`
+
+In this example, we want to predict `field3` of type Double from `field1` and `field2` using 
+a `TypedRandomForestRegressor`.
+
+### Training
+
+As with Spark ML API, we use a `TypedVectorAssembler` (the type-safe equivalent of `VectorAssembler`) to compute feature vectors:
+
+```tut:silent
+import frameless._
+import frameless.syntax._
+import frameless.ml._
+import frameless.ml.feature._
+import frameless.ml.regression._
+import org.apache.spark.ml.linalg.Vector
+```
+
+```tut:book
+case class Data(field1: Double, field2: Int, field3: Double)
+
+val trainingData = TypedDataset.create(
+  Seq.fill(10)(Data(0D, 10, 0D))
+)
+
+case class Features(field1: Double, field2: Int)
+val assembler = TypedVectorAssembler[Features]
+
+case class DataWithFeatures(field1: Double, field2: Int, field3: Double, features: Vector)
+val trainingDataWithFeatures = assembler.transform(trainingData).as[DataWithFeatures]
+```
+
+Then, we train the model:
+
+```tut:book
+case class RFInputs(field3: Double, features: Vector)
+val rf = TypedRandomForestRegressor[RFInputs]
+
+val model = rf.fit(trainingDataWithFeatures).run()
+```
+
+As an example of added type-safety, `TypedRandomForestRegressor[RFInputs]` will compile only if the given `RFInputs` case class 
+contains only one field of type Double (the label) and one field of type Vector (the features):
+
+```tut:silent
+case class WrongRFInputs(labelOfWrongType: String, features: Vector)
+```
+
+```tut:book:fail
+TypedRandomForestRegressor[WrongRFInputs]
+```
+
+The subsequent `rf.fit(trainingDataWithFeatures)` call will compile only if `trainingDataWithFeatures` contains the same fields 
+(names and types) as RFInputs.
+
+```tut:book
+val wrongTrainingDataWithFeatures = TypedDataset.create(Seq(Data(0D, 1, 0D))) // features are missing
+```
+
+```tut:book:fail
+rf.fit(wrongTrainingDataWithFeatures) 
+```
+
+For new-comers to frameless, please note that `typedDataset.as[...]` is a type-safe cast, 
+see [TypedDataset: Feature Overview](https://typelevel.org/frameless/FeatureOverview.html):
+
+```tut:silent
+case class WrongTrainingDataWithFeatures(
+  field1: Double, 
+  field2: String, // field 2 has wrong type 
+  field3: Double, 
+  features: Vector
+) 
+```
+
+```tut:book:fail
+assembler.transform(trainingData).as[WrongTrainingDataWithFeatures]
+```
+
+### Prediction
+
+We now want to predict `field3` for `testData` using the previously trained model. Please note that, like Spark ML API,
+`testData` has a default value for `field3` (`0D` in our case) that will be ignored at prediction time. We reuse 
+our `assembler` to compute the feature vector of `testData`.
+
+```tut:book
+val testData = TypedDataset.create(Seq(Data(0D, 10, 0D)))
+val testDataWithFeatures = assembler.transform(testData).as[DataWithFeatures]
+
+case class PredictionResult(
+  field1: Double, 
+  field2: Int, 
+  field3: Double, 
+  features: Vector, 
+  predictedField3: Double
+)
+val results = model.transform(testDataWithFeatures).as[PredictionResult]
+
+val predictions = results.select(results.col('predictedField3)).collect.run()
+
+predictions == Seq(0D)
+```
+
+## Example 2: predict a categorical value using a `TypedRandomForestClassifier`
+
+In this example, we want to predict `field3` of type String from `field1` and `field2` using a `TypedRandomForestClassifier`. 
+
+### Training
+
+As with Spark ML API, we use a `TypedVectorAssembler` to compute feature vectors and a `TypedStringIndexer` 
+to index `field3` values in order to be able to pass them to a `TypedRandomForestClassifier` 
+(which only accepts indexed Double values as label):
+
+```tut:silent
+import frameless.ml.classification._
+```
+
+```tut:book
+case class Data(field1: Double, field2: Int, field3: String)
+
+val trainingDataDs = TypedDataset.create(
+  Seq.fill(10)(Data(0D, 10, "foo"))
+)
+
+case class Features(field1: Double, field2: Int)
+val vectorAssembler = TypedVectorAssembler[Features]
+
+case class DataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector)
+val dataWithFeatures = vectorAssembler.transform(trainingDataDs).as[DataWithFeatures]
+
+case class StringIndexerInput(field3: String)
+val indexer = TypedStringIndexer[StringIndexerInput]
+val indexerModel = indexer.fit(dataWithFeatures).run()
+
+case class IndexedDataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector, indexedField3: Double)
+val indexedData = indexerModel.transform(dataWithFeatures).as[IndexedDataWithFeatures]
+```
+
+Then, we train the model:
+
+```tut:book
+case class RFInputs(indexedField3: Double, features: Vector)
+val rf = TypedRandomForestClassifier[RFInputs]
+
+val model = rf.fit(indexedData).run()
+```
+
+### Prediction
+
+We now want to predict `field3` for `testData` using the previously trained model. Please note that, like Spark ML API,
+`testData` has a default value for `field3` (empty String in our case) that will be ignored at prediction time. We reuse 
+our `vectorAssembler` to compute the feature vector of `testData` and our `indexerModel` to index `field3`.
+
+```tut:book
+val testData = TypedDataset.create(Seq(
+  Data(0D, 10, "")
+))
+val testDataWithFeatures = vectorAssembler.transform(testData).as[DataWithFeatures]
+val indexedTestData = indexerModel.transform(testDataWithFeatures).as[IndexedDataWithFeatures]
+
+case class PredictionInputs(features: Vector, indexedField3: Double)
+val testInput = indexedTestData.project[PredictionInputs]
+
+case class PredictionResultIndexed(
+  features: Vector,
+  indexedField3: Double,
+  rawPrediction: Vector,
+  probability: Vector,
+  predictedField3Indexed: Double
+)
+val predictionDs = model.transform(testInput).as[PredictionResultIndexed]
+```
+
+Then, we use a `TypedIndexToString` to get back a String value from `predictedField3`. `TypedIndexToString` takes
+as input the label array computed by our previous `indexerModel`:
+
+```tut:book
+case class IndexToStringInput(predictedField3Indexed: Double)
+val indexToString = TypedIndexToString[IndexToStringInput](indexerModel.transformer.labels)
+
+case class PredictionResult(
+  features: Vector,
+  indexedField3: Double,
+  rawPrediction: Vector,
+  probability: Vector,
+  predictedField3Indexed: Double,
+  predictedField3: String
+)
+val stringPredictionDs = indexToString.transform(predictionDs).as[PredictionResult]
+
+val prediction = stringPredictionDs.select(stringPredictionDs.col('predictedField3)).collect.run()
+
+prediction == Seq("foo")
+```
+
+## List of currently implemented `TypedEstimator`s
+
+* `TypedRandomForestClassifier`
+* `TypedRandomForestRegressor`
+* ... your contribution here ... :)
+
+## List of currently implemented `TypedTransformer`s
+
+* `TypedIndexToString`
+* `TypedStringIndexer`
+* `TypedVectorAssembler`
+* ... your contribution here ... :)
  
-## Using Vector and Matrix with TypedDataset
+## Using Vector and Matrix with `TypedDataset`
 
 `frameless-ml` provides `TypedEncoder` instances for `org.apache.spark.ml.linalg.Vector` 
 and `org.apache.spark.ml.linalg.Matrix`:
 
-```tut:book
+```tut:silent
 import frameless.ml._
-import frameless.TypedDataset
 import org.apache.spark.ml.linalg._
+```
 
+```tut:book
 val vector = Vectors.dense(1, 2, 3)
 val vectorDs = TypedDataset.create(Seq("label" -> vector))
 

--- a/ml/src/main/scala/frameless/ml/TypedEstimator.scala
+++ b/ml/src/main/scala/frameless/ml/TypedEstimator.scala
@@ -5,8 +5,7 @@ import frameless.ops.SmartProject
 import org.apache.spark.ml.{Estimator, Model}
 
 /**
-  * A TypedEstimator `fit` method takes as input a TypedDataset containing `Inputs` and
-  * return an AppendTransformer with `Inputs` as inputs and `Outputs` as outputs
+  * A TypedEstimator fits models to data.
   */
 trait TypedEstimator[Inputs, Outputs, M <: Model[M]] {
   val estimator: Estimator[M]

--- a/ml/src/main/scala/frameless/ml/TypedEstimator.scala
+++ b/ml/src/main/scala/frameless/ml/TypedEstimator.scala
@@ -8,14 +8,21 @@ import org.apache.spark.ml.{Estimator, Model}
   * A TypedEstimator `fit` method takes as input a TypedDataset containing `Inputs`and
   * return an AppendTransformer with `Inputs` as inputs and `Outputs` as outputs
   */
-abstract class TypedEstimator[Inputs, Outputs, M <: Model[M]] private[ml] {
+trait TypedEstimator[Inputs, Outputs, M <: Model[M]] {
   val estimator: Estimator[M]
 
-  def fit[T](ds: TypedDataset[T])(implicit smartProject: SmartProject[T, Inputs]): AppendTransformer[Inputs, Outputs, M] = {
-    val inputDs = smartProject.apply(ds)
-    val model = estimator.fit(inputDs.dataset)
-    new AppendTransformer[Inputs, Outputs, M] {
-      val transformer: M = model
+  def fit[T, F[_]](ds: TypedDataset[T])(
+    implicit
+    smartProject: SmartProject[T, Inputs],
+    F: SparkDelay[F]
+  ): F[AppendTransformer[Inputs, Outputs, M]] = {
+    implicit val sparkSession = ds.dataset.sparkSession
+    F.delay {
+      val inputDs = smartProject.apply(ds)
+      val model = estimator.fit(inputDs.dataset)
+      new AppendTransformer[Inputs, Outputs, M] {
+        val transformer: M = model
+      }
     }
   }
 }

--- a/ml/src/main/scala/frameless/ml/TypedEstimator.scala
+++ b/ml/src/main/scala/frameless/ml/TypedEstimator.scala
@@ -1,0 +1,21 @@
+package frameless
+package ml
+
+import frameless.ops.SmartProject
+import org.apache.spark.ml.{Estimator, Model}
+
+/**
+  * A TypedEstimator `fit` method takes as input a TypedDataset containing `Inputs`and
+  * return an AppendTransformer with `Inputs` as inputs and `Outputs` as outputs
+  */
+abstract class TypedEstimator[Inputs, Outputs, M <: Model[M]] private[ml] {
+  val estimator: Estimator[M]
+
+  def fit[T](ds: TypedDataset[T])(implicit smartProject: SmartProject[T, Inputs]): AppendTransformer[Inputs, Outputs, M] = {
+    val inputDs = smartProject.apply(ds)
+    val model = estimator.fit(inputDs.dataset)
+    new AppendTransformer[Inputs, Outputs, M] {
+      val transformer: M = model
+    }
+  }
+}

--- a/ml/src/main/scala/frameless/ml/TypedEstimator.scala
+++ b/ml/src/main/scala/frameless/ml/TypedEstimator.scala
@@ -5,7 +5,7 @@ import frameless.ops.SmartProject
 import org.apache.spark.ml.{Estimator, Model}
 
 /**
-  * A TypedEstimator `fit` method takes as input a TypedDataset containing `Inputs`and
+  * A TypedEstimator `fit` method takes as input a TypedDataset containing `Inputs` and
   * return an AppendTransformer with `Inputs` as inputs and `Outputs` as outputs
   */
 trait TypedEstimator[Inputs, Outputs, M <: Model[M]] {

--- a/ml/src/main/scala/frameless/ml/TypedTransformer.scala
+++ b/ml/src/main/scala/frameless/ml/TypedTransformer.scala
@@ -6,6 +6,9 @@ import org.apache.spark.ml.Transformer
 import shapeless.{Generic, HList}
 import shapeless.ops.hlist.{Prepend, Tupler}
 
+/**
+  * A TypedTransformer transforms one TypedDataset into another.
+  */
 sealed trait TypedTransformer
 
 /**

--- a/ml/src/main/scala/frameless/ml/TypedTransformer.scala
+++ b/ml/src/main/scala/frameless/ml/TypedTransformer.scala
@@ -1,0 +1,37 @@
+package frameless
+package ml
+
+import frameless.ops.SmartProject
+import org.apache.spark.ml.Transformer
+import shapeless.{Generic, HList}
+import shapeless.ops.hlist.{Prepend, Tupler}
+
+sealed trait TypedTransformer
+
+/**
+  * An AppendTransformer `transform` method takes as input a TypedDataset containing `Inputs` and
+  * return a TypedDataset with `Outputs` columns appended to the input TypedDataset.
+  */
+abstract class AppendTransformer[Inputs, Outputs, InnerTransformer <: Transformer] private[ml] extends TypedTransformer {
+  val transformer: InnerTransformer
+
+  def transform[T, TVals <: HList, OutputsVals <: HList, OutVals <: HList, Out](ds: TypedDataset[T])(
+    implicit smartProject: SmartProject[T, Inputs],
+    tGen: Generic.Aux[T, TVals],
+    outputsGen: Generic.Aux[Outputs, OutputsVals],
+    prepend: Prepend.Aux[TVals, OutputsVals, OutVals],
+    tupler: Tupler.Aux[OutVals, Out],
+    outEncoder: TypedEncoder[Out]
+  ): TypedDataset[Out] = {
+    val transformed = transformer.transform(ds.dataset).as[Out](TypedExpressionEncoder[Out])
+    TypedDataset.create[Out](transformed)
+  }
+
+}
+
+object AppendTransformer {
+  // Random name to a temp column added by a TypedTransformer (the proper name will be given by the Tuple-based encoder)
+  private[ml] val tempColumnName = "I1X3T9CU1OP0128JYIO76TYZZA3AXHQ18RMI"
+  private[ml] val tempColumnName2 = "I1X3T9CU1OP0128JYIO76TYZZA3AXHQ18RMJ"
+  private[ml] val tempColumnName3 = "I1X3T9CU1OP0128JYIO76TYZZA3AXHQ18RMK"
+}

--- a/ml/src/main/scala/frameless/ml/TypedTransformer.scala
+++ b/ml/src/main/scala/frameless/ml/TypedTransformer.scala
@@ -22,14 +22,10 @@ trait AppendTransformer[Inputs, Outputs, InnerTransformer <: Transformer] extend
     i2: Generic.Aux[Outputs, OutputsVals],
     i3: Prepend.Aux[TVals, OutputsVals, OutVals],
     i4: Tupler.Aux[OutVals, Out],
-    i5: TypedEncoder[Out],
-    F: SparkDelay[F]
-  ): F[TypedDataset[Out]] = {
-    implicit val sparkSession = ds.dataset.sparkSession
-    F.delay {
-      val transformed = transformer.transform(ds.dataset).as[Out](TypedExpressionEncoder[Out])
-      TypedDataset.create[Out](transformed)
-    }
+    i5: TypedEncoder[Out]
+  ): TypedDataset[Out] = {
+    val transformed = transformer.transform(ds.dataset).as[Out](TypedExpressionEncoder[Out])
+    TypedDataset.create[Out](transformed)
   }
 
 }

--- a/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
+++ b/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
@@ -62,7 +62,7 @@ object TypedRandomForestClassifier {
     }
   }
 
-  def create[Inputs]()(implicit inputsChecker: TreesInputsChecker[Inputs]): TypedRandomForestClassifier[Inputs] = {
+  def apply[Inputs](implicit inputsChecker: TreesInputsChecker[Inputs]): TypedRandomForestClassifier[Inputs] = {
     new TypedRandomForestClassifier(new RandomForestClassifier(), inputsChecker.labelCol, inputsChecker.featuresCol)
   }
 }

--- a/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
+++ b/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
@@ -3,12 +3,9 @@ package ml
 package classification
 
 import frameless.ml.classification.TypedRandomForestClassifier.FeatureSubsetStrategy
-import frameless.ml.internals.SelectorByValue
+import frameless.ml.internals.TreesInputsChecker
 import org.apache.spark.ml.classification.{RandomForestClassificationModel, RandomForestClassifier}
 import org.apache.spark.ml.linalg.Vector
-import shapeless.ops.hlist.Length
-import shapeless.{HList, LabelledGeneric, Nat, Witness}
-import scala.annotation.implicitNotFound
 
 final class TypedRandomForestClassifier[Inputs] private[ml](
   rf: RandomForestClassifier,
@@ -65,39 +62,8 @@ object TypedRandomForestClassifier {
     }
   }
 
-  def create[Inputs]()
-                    (implicit inputsChecker: TypedRandomForestClassifierInputsChecker[Inputs])
-  : TypedRandomForestClassifier[Inputs] = {
+  def create[Inputs]()(implicit inputsChecker: TreesInputsChecker[Inputs]): TypedRandomForestClassifier[Inputs] = {
     new TypedRandomForestClassifier(new RandomForestClassifier(), inputsChecker.labelCol, inputsChecker.featuresCol)
   }
 }
 
-@implicitNotFound(
-  msg = "Cannot prove that ${Inputs} is a valid input type for TypedRandomForestClassifier. " +
-    "Input type must only contain a field of type Double (label) and a field of type Vector (features)."
-)
-private[ml] trait TypedRandomForestClassifierInputsChecker[Inputs] {
-  val labelCol: String
-  val featuresCol: String
-}
-
-private[ml] object TypedRandomForestClassifierInputsChecker {
-  implicit def checkInputs[
-  Inputs,
-  InputsRec <: HList,
-  LabelK <: Symbol,
-  FeaturesK <: Symbol](
-    implicit
-    inputsGen: LabelledGeneric.Aux[Inputs, InputsRec],
-    sizeCheck: Length.Aux[InputsRec, Nat._2],
-    labelSelect: SelectorByValue.Aux[InputsRec, Double, LabelK],
-    labelW: Witness.Aux[LabelK],
-    featuresSelect: SelectorByValue.Aux[InputsRec, Vector, FeaturesK],
-    featuresW: Witness.Aux[FeaturesK]
-  ): TypedRandomForestClassifierInputsChecker[Inputs] = {
-    new TypedRandomForestClassifierInputsChecker[Inputs] {
-      val labelCol: String = labelW.value.name
-      val featuresCol: String = featuresW.value.name
-    }
-  }
-}

--- a/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
+++ b/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
@@ -2,8 +2,8 @@ package frameless
 package ml
 package classification
 
-import frameless.ml.classification.TypedRandomForestClassifier.FeatureSubsetStrategy
 import frameless.ml.internals.TreesInputsChecker
+import frameless.ml.params.trees.FeatureSubsetStrategy
 import org.apache.spark.ml.classification.{RandomForestClassificationModel, RandomForestClassifier}
 import org.apache.spark.ml.linalg.Vector
 
@@ -37,30 +37,6 @@ final class TypedRandomForestClassifier[Inputs] private[ml](
 
 object TypedRandomForestClassifier {
   case class Outputs(rawPrediction: Vector, probability: Vector, prediction: Double)
-
-  sealed trait FeatureSubsetStrategy {
-    val sparkValue: String
-  }
-  object FeatureSubsetStrategy {
-    case object Auto extends FeatureSubsetStrategy {
-      val sparkValue = "auto"
-    }
-    case object All extends FeatureSubsetStrategy {
-      val sparkValue = "all"
-    }
-    case object OneThird extends FeatureSubsetStrategy {
-      val sparkValue = "onethird"
-    }
-    case object Sqrt extends FeatureSubsetStrategy {
-      val sparkValue = "sqrt"
-    }
-    case object Log2 extends FeatureSubsetStrategy {
-      val sparkValue = "log2"
-    }
-    case class StrictlyPositiveDouble(value: Double) extends FeatureSubsetStrategy {
-      val sparkValue = value.toString
-    }
-  }
 
   def apply[Inputs](implicit inputsChecker: TreesInputsChecker[Inputs]): TypedRandomForestClassifier[Inputs] = {
     new TypedRandomForestClassifier(new RandomForestClassifier(), inputsChecker.labelCol, inputsChecker.featuresCol)

--- a/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
+++ b/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
@@ -1,0 +1,103 @@
+package frameless
+package ml
+package classification
+
+import frameless.ml.classification.TypedRandomForestClassifier.FeatureSubsetStrategy
+import frameless.ml.internals.SelectorByValue
+import org.apache.spark.ml.classification.{RandomForestClassificationModel, RandomForestClassifier}
+import org.apache.spark.ml.linalg.Vector
+import shapeless.ops.hlist.Length
+import shapeless.{HList, LabelledGeneric, Nat, Witness}
+import scala.annotation.implicitNotFound
+
+final class TypedRandomForestClassifier[Inputs] private[ml](
+  rf: RandomForestClassifier,
+  labelCol: String,
+  featuresCol: String
+) extends TypedEstimator[Inputs, TypedRandomForestClassifier.Outputs, RandomForestClassificationModel] {
+
+  val estimator: RandomForestClassifier =
+    rf
+      .setLabelCol(labelCol)
+      .setFeaturesCol(featuresCol)
+      .setPredictionCol(AppendTransformer.tempColumnName)
+      .setRawPredictionCol(AppendTransformer.tempColumnName2)
+      .setProbabilityCol(AppendTransformer.tempColumnName3)
+
+  def setNumTrees(value: Int): TypedRandomForestClassifier[Inputs] = copy(rf.setNumTrees(value))
+  def setMaxDepth(value: Int): TypedRandomForestClassifier[Inputs] = copy(rf.setMaxDepth(value))
+  def setMinInfoGain(value: Double): TypedRandomForestClassifier[Inputs] = copy(rf.setMinInfoGain(value))
+  def setMinInstancesPerNode(value: Int): TypedRandomForestClassifier[Inputs] = copy(rf.setMinInstancesPerNode(value))
+  def setMaxMemoryInMB(value: Int): TypedRandomForestClassifier[Inputs] = copy(rf.setMaxMemoryInMB(value))
+  def setSubsamplingRate(value: Double): TypedRandomForestClassifier[Inputs] = copy(rf.setSubsamplingRate(value))
+  def setFeatureSubsetStrategy(value: FeatureSubsetStrategy): TypedRandomForestClassifier[Inputs] =
+    copy(rf.setFeatureSubsetStrategy(value.sparkValue))
+  def setMaxBins(value: Int): TypedRandomForestClassifier[Inputs] = copy(rf.setMaxBins(value))
+
+  private def copy(newRf: RandomForestClassifier): TypedRandomForestClassifier[Inputs] =
+    new TypedRandomForestClassifier[Inputs](newRf, labelCol, featuresCol)
+}
+
+object TypedRandomForestClassifier {
+  case class Outputs(rawPrediction: Vector, probability: Vector, prediction: Double)
+
+  sealed trait FeatureSubsetStrategy {
+    val sparkValue: String
+  }
+  object FeatureSubsetStrategy {
+    case object Auto extends FeatureSubsetStrategy {
+      val sparkValue = "auto"
+    }
+    case object All extends FeatureSubsetStrategy {
+      val sparkValue = "all"
+    }
+    case object OneThird extends FeatureSubsetStrategy {
+      val sparkValue = "onethird"
+    }
+    case object Sqrt extends FeatureSubsetStrategy {
+      val sparkValue = "sqrt"
+    }
+    case object Log2 extends FeatureSubsetStrategy {
+      val sparkValue = "log2"
+    }
+    case class StrictlyPositiveDouble(value: Double) extends FeatureSubsetStrategy {
+      val sparkValue = value.toString
+    }
+  }
+
+  def create[Inputs]()
+                    (implicit inputsChecker: TypedRandomForestClassifierInputsChecker[Inputs])
+  : TypedRandomForestClassifier[Inputs] = {
+    new TypedRandomForestClassifier(new RandomForestClassifier(), inputsChecker.labelCol, inputsChecker.featuresCol)
+  }
+}
+
+@implicitNotFound(
+  msg = "Cannot prove that ${Inputs} is a valid input type for TypedRandomForestClassifier. " +
+    "Input type must only contain a field of type Double (label) and a field of type Vector (features)."
+)
+private[ml] trait TypedRandomForestClassifierInputsChecker[Inputs] {
+  val labelCol: String
+  val featuresCol: String
+}
+
+private[ml] object TypedRandomForestClassifierInputsChecker {
+  implicit def checkInputs[
+  Inputs,
+  InputsRec <: HList,
+  LabelK <: Symbol,
+  FeaturesK <: Symbol](
+    implicit
+    inputsGen: LabelledGeneric.Aux[Inputs, InputsRec],
+    sizeCheck: Length.Aux[InputsRec, Nat._2],
+    labelSelect: SelectorByValue.Aux[InputsRec, Double, LabelK],
+    labelW: Witness.Aux[LabelK],
+    featuresSelect: SelectorByValue.Aux[InputsRec, Vector, FeaturesK],
+    featuresW: Witness.Aux[FeaturesK]
+  ): TypedRandomForestClassifierInputsChecker[Inputs] = {
+    new TypedRandomForestClassifierInputsChecker[Inputs] {
+      val labelCol: String = labelW.value.name
+      val featuresCol: String = featuresW.value.name
+    }
+  }
+}

--- a/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
+++ b/ml/src/main/scala/frameless/ml/classification/TypedRandomForestClassifier.scala
@@ -7,6 +7,12 @@ import frameless.ml.params.trees.FeatureSubsetStrategy
 import org.apache.spark.ml.classification.{RandomForestClassificationModel, RandomForestClassifier}
 import org.apache.spark.ml.linalg.Vector
 
+/**
+  * <a href="http://en.wikipedia.org/wiki/Random_forest">Random Forest</a> learning algorithm for
+  * classification.
+  * It supports both binary and multiclass labels, as well as both continuous and categorical
+  * features.
+  */
 final class TypedRandomForestClassifier[Inputs] private[ml](
   rf: RandomForestClassifier,
   labelCol: String,

--- a/ml/src/main/scala/frameless/ml/feature/TypedIndexToString.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedIndexToString.scala
@@ -2,12 +2,8 @@ package frameless
 package ml
 package feature
 
-import frameless.ml.internals.SelectorByValue
+import frameless.ml.internals.UnaryInputsChecker
 import org.apache.spark.ml.feature.IndexToString
-import shapeless.{HList, LabelledGeneric, Witness}
-import scala.annotation.implicitNotFound
-import shapeless._
-import shapeless.ops.hlist.Length
 
 final class TypedIndexToString[Inputs] private[ml](indexToString: IndexToString, inputCol: String)
   extends AppendTransformer[Inputs, TypedIndexToString.Outputs, IndexToString] {
@@ -23,30 +19,7 @@ object TypedIndexToString {
   case class Outputs(originalOutput: String)
 
   def create[Inputs](labels: Array[String])
-                    (implicit inputsChecker: TypedIndexToStringInputsChecker[Inputs]): TypedIndexToString[Inputs] = {
+                    (implicit inputsChecker: UnaryInputsChecker[Inputs, Double]): TypedIndexToString[Inputs] = {
     new TypedIndexToString[Inputs](new IndexToString().setLabels(labels), inputsChecker.inputCol)
-  }
-}
-
-@implicitNotFound(
-  msg = "Cannot prove that ${Inputs} is a valid input type for TypedIndexToString. " +
-    "Input type must only contain a field of type Double (index)"
-)
-private[ml] trait TypedIndexToStringInputsChecker[Inputs] {
-  val inputCol: String
-}
-
-private[ml] object TypedIndexToStringInputsChecker {
-  implicit def checkInputs[
-  Inputs,
-  InputsRec <: HList,
-  InputK <: Symbol](
-   implicit
-   inputsGen: LabelledGeneric.Aux[Inputs, InputsRec],
-   sizeCheck: Length.Aux[InputsRec, Nat._1],
-   labelSelect: SelectorByValue.Aux[InputsRec, Double, InputK],
-   inputW: Witness.Aux[InputK]
-  ): TypedIndexToStringInputsChecker[Inputs] = new TypedIndexToStringInputsChecker[Inputs] {
-    val inputCol: String = inputW.value.name
   }
 }

--- a/ml/src/main/scala/frameless/ml/feature/TypedIndexToString.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedIndexToString.scala
@@ -18,7 +18,7 @@ final class TypedIndexToString[Inputs] private[ml](indexToString: IndexToString,
 object TypedIndexToString {
   case class Outputs(originalOutput: String)
 
-  def create[Inputs](labels: Array[String])
+  def apply[Inputs](labels: Array[String])
                     (implicit inputsChecker: UnaryInputsChecker[Inputs, Double]): TypedIndexToString[Inputs] = {
     new TypedIndexToString[Inputs](new IndexToString().setLabels(labels), inputsChecker.inputCol)
   }

--- a/ml/src/main/scala/frameless/ml/feature/TypedIndexToString.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedIndexToString.scala
@@ -5,6 +5,13 @@ package feature
 import frameless.ml.internals.UnaryInputsChecker
 import org.apache.spark.ml.feature.IndexToString
 
+/**
+  * A `TypedTransformer` that maps a column of indices back to a new column of corresponding
+  * string values.
+  * The index-string mapping must be supplied when creating the `TypedIndexToString`.
+  *
+  * @see `TypedStringIndexer` for converting strings into indices
+  */
 final class TypedIndexToString[Inputs] private[ml](indexToString: IndexToString, inputCol: String)
   extends AppendTransformer[Inputs, TypedIndexToString.Outputs, IndexToString] {
 

--- a/ml/src/main/scala/frameless/ml/feature/TypedIndexToString.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedIndexToString.scala
@@ -1,0 +1,52 @@
+package frameless
+package ml
+package feature
+
+import frameless.ml.internals.SelectorByValue
+import org.apache.spark.ml.feature.IndexToString
+import shapeless.{HList, LabelledGeneric, Witness}
+import scala.annotation.implicitNotFound
+import shapeless._
+import shapeless.ops.hlist.Length
+
+final class TypedIndexToString[Inputs] private[ml](indexToString: IndexToString, inputCol: String)
+  extends AppendTransformer[Inputs, TypedIndexToString.Outputs, IndexToString] {
+
+  val transformer: IndexToString =
+    indexToString
+      .setInputCol(inputCol)
+      .setOutputCol(AppendTransformer.tempColumnName)
+
+}
+
+object TypedIndexToString {
+  case class Outputs(originalOutput: String)
+
+  def create[Inputs](labels: Array[String])
+                    (implicit inputsChecker: TypedIndexToStringInputsChecker[Inputs]): TypedIndexToString[Inputs] = {
+    new TypedIndexToString[Inputs](new IndexToString().setLabels(labels), inputsChecker.inputCol)
+  }
+}
+
+@implicitNotFound(
+  msg = "Cannot prove that ${Inputs} is a valid input type for TypedIndexToString. " +
+    "Input type must only contain a field of type Double (index)"
+)
+private[ml] trait TypedIndexToStringInputsChecker[Inputs] {
+  val inputCol: String
+}
+
+private[ml] object TypedIndexToStringInputsChecker {
+  implicit def checkInputs[
+  Inputs,
+  InputsRec <: HList,
+  InputK <: Symbol](
+   implicit
+   inputsGen: LabelledGeneric.Aux[Inputs, InputsRec],
+   sizeCheck: Length.Aux[InputsRec, Nat._1],
+   labelSelect: SelectorByValue.Aux[InputsRec, Double, InputK],
+   inputW: Witness.Aux[InputK]
+  ): TypedIndexToStringInputsChecker[Inputs] = new TypedIndexToStringInputsChecker[Inputs] {
+    val inputCol: String = inputW.value.name
+  }
+}

--- a/ml/src/main/scala/frameless/ml/feature/TypedStringIndexer.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedStringIndexer.scala
@@ -1,0 +1,70 @@
+package frameless
+package ml
+package feature
+
+import frameless.ml.feature.TypedStringIndexer.HandleInvalid
+import frameless.ml.internals.SelectorByValue
+import org.apache.spark.ml.feature.{StringIndexer, StringIndexerModel}
+import shapeless.ops.hlist.Length
+import shapeless.{HList, LabelledGeneric, Nat, Witness}
+import scala.annotation.implicitNotFound
+
+final class TypedStringIndexer[Inputs] private[ml](stringIndexer: StringIndexer, inputCol: String)
+  extends TypedEstimator[Inputs, TypedStringIndexer.Outputs, StringIndexerModel] {
+
+  val estimator: StringIndexer = stringIndexer
+    .setInputCol(inputCol)
+    .setOutputCol(AppendTransformer.tempColumnName)
+
+  def setHandleInvalid(value: HandleInvalid): TypedStringIndexer[Inputs] = copy(stringIndexer.setHandleInvalid(value.sparkValue))
+
+  private def copy(newStringIndexer: StringIndexer): TypedStringIndexer[Inputs] =
+    new TypedStringIndexer[Inputs](newStringIndexer, inputCol)
+}
+
+object TypedStringIndexer {
+  case class Outputs(indexedOutput: Double)
+
+  sealed trait HandleInvalid {
+    val sparkValue: String
+  }
+  object HandleInvalid {
+    case object Error extends HandleInvalid {
+      val sparkValue = "error"
+    }
+    case object Skip extends HandleInvalid {
+      val sparkValue = "skip"
+    }
+    case object Keep extends HandleInvalid {
+      val sparkValue = "keep"
+    }
+  }
+
+  def create[Inputs]()
+                    (implicit inputsChecker: TypedStringIndexerInputsChecker[Inputs]): TypedStringIndexer[Inputs] = {
+    new TypedStringIndexer[Inputs](new StringIndexer(), inputsChecker.inputCol)
+  }
+}
+
+@implicitNotFound(
+  msg = "Cannot prove that ${Inputs} is a valid input type for TypedStringIndexer. " +
+    "Input type must only contain a field of type String (string to index)"
+)
+private[ml] trait TypedStringIndexerInputsChecker[Inputs] {
+  val inputCol: String
+}
+
+private[ml] object TypedStringIndexerInputsChecker {
+  implicit def checkInputs[
+  Inputs,
+  InputsRec <: HList,
+  InputK <: Symbol](
+    implicit
+    inputsGen: LabelledGeneric.Aux[Inputs, InputsRec],
+    sizeCheck: Length.Aux[InputsRec, Nat._1],
+    labelSelect: SelectorByValue.Aux[InputsRec, String, InputK],
+    inputW: Witness.Aux[InputK]
+  ): TypedStringIndexerInputsChecker[Inputs] = new TypedStringIndexerInputsChecker[Inputs] {
+    val inputCol: String = inputW.value.name
+  }
+}

--- a/ml/src/main/scala/frameless/ml/feature/TypedStringIndexer.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedStringIndexer.scala
@@ -6,6 +6,13 @@ import frameless.ml.feature.TypedStringIndexer.HandleInvalid
 import frameless.ml.internals.UnaryInputsChecker
 import org.apache.spark.ml.feature.{StringIndexer, StringIndexerModel}
 
+/**
+  * A label indexer that maps a string column of labels to an ML column of label indices.
+  * The indices are in [0, numLabels), ordered by label frequencies.
+  * So the most frequent label gets index 0.
+  *
+  * @see `TypedIndexToString` for the inverse transformation
+  */
 final class TypedStringIndexer[Inputs] private[ml](stringIndexer: StringIndexer, inputCol: String)
   extends TypedEstimator[Inputs, TypedStringIndexer.Outputs, StringIndexerModel] {
 

--- a/ml/src/main/scala/frameless/ml/feature/TypedStringIndexer.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedStringIndexer.scala
@@ -37,8 +37,7 @@ object TypedStringIndexer {
     }
   }
 
-  def create[Inputs]()
-                    (implicit inputsChecker: UnaryInputsChecker[Inputs, String]): TypedStringIndexer[Inputs] = {
+  def apply[Inputs](implicit inputsChecker: UnaryInputsChecker[Inputs, String]): TypedStringIndexer[Inputs] = {
     new TypedStringIndexer[Inputs](new StringIndexer(), inputsChecker.inputCol)
   }
 }

--- a/ml/src/main/scala/frameless/ml/feature/TypedStringIndexer.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedStringIndexer.scala
@@ -22,19 +22,11 @@ final class TypedStringIndexer[Inputs] private[ml](stringIndexer: StringIndexer,
 object TypedStringIndexer {
   case class Outputs(indexedOutput: Double)
 
-  sealed trait HandleInvalid {
-    val sparkValue: String
-  }
+  sealed abstract class HandleInvalid(val sparkValue: String)
   object HandleInvalid {
-    case object Error extends HandleInvalid {
-      val sparkValue = "error"
-    }
-    case object Skip extends HandleInvalid {
-      val sparkValue = "skip"
-    }
-    case object Keep extends HandleInvalid {
-      val sparkValue = "keep"
-    }
+    case object Error extends HandleInvalid("error")
+    case object Skip extends HandleInvalid("skip")
+    case object Keep extends HandleInvalid("keep")
   }
 
   def apply[Inputs](implicit inputsChecker: UnaryInputsChecker[Inputs, String]): TypedStringIndexer[Inputs] = {

--- a/ml/src/main/scala/frameless/ml/feature/TypedVectorAssembler.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedVectorAssembler.scala
@@ -28,8 +28,7 @@ object TypedVectorAssembler {
 }
 
 @implicitNotFound(
-  msg = "Cannot prove that ${Inputs} is a valid input type for TypedVectorAssembler. " +
-    "Input type must only contain numeric or boolean types."
+  msg = "Cannot prove that ${Inputs} is a valid input type. Input type must only contain fields of numeric or boolean types."
 )
 private[ml] trait TypedVectorAssemblerInputsChecker[Inputs] {
   val inputCols: Seq[String]

--- a/ml/src/main/scala/frameless/ml/feature/TypedVectorAssembler.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedVectorAssembler.scala
@@ -22,7 +22,7 @@ final class TypedVectorAssembler[Inputs] private[ml](vectorAssembler: VectorAsse
 object TypedVectorAssembler {
   case class Output(vector: Vector)
 
-  def create[Inputs]()(implicit inputsChecker: TypedVectorAssemblerInputsChecker[Inputs]): TypedVectorAssembler[Inputs] = {
+  def apply[Inputs](implicit inputsChecker: TypedVectorAssemblerInputsChecker[Inputs]): TypedVectorAssembler[Inputs] = {
     new TypedVectorAssembler(new VectorAssembler(), inputsChecker.inputCols.toArray)
   }
 }

--- a/ml/src/main/scala/frameless/ml/feature/TypedVectorAssembler.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedVectorAssembler.scala
@@ -10,6 +10,9 @@ import shapeless.ops.record.{Keys, Values}
 import shapeless._
 import scala.annotation.implicitNotFound
 
+/**
+  * A feature transformer that merges multiple columns into a vector column.
+  */
 final class TypedVectorAssembler[Inputs] private[ml](vectorAssembler: VectorAssembler, inputCols: Array[String])
   extends AppendTransformer[Inputs, TypedVectorAssembler.Output, VectorAssembler] {
 

--- a/ml/src/main/scala/frameless/ml/feature/TypedVectorAssembler.scala
+++ b/ml/src/main/scala/frameless/ml/feature/TypedVectorAssembler.scala
@@ -1,0 +1,67 @@
+package frameless
+package ml
+package feature
+
+import org.apache.spark.ml.feature.VectorAssembler
+import org.apache.spark.ml.linalg.Vector
+import shapeless.{HList, HNil, LabelledGeneric}
+import shapeless.ops.hlist.ToTraversable
+import shapeless.ops.record.{Keys, Values}
+import shapeless._
+import scala.annotation.implicitNotFound
+
+final class TypedVectorAssembler[Inputs] private[ml](vectorAssembler: VectorAssembler, inputCols: Array[String])
+  extends AppendTransformer[Inputs, TypedVectorAssembler.Output, VectorAssembler] {
+
+  val transformer: VectorAssembler = vectorAssembler
+    .setInputCols(inputCols)
+    .setOutputCol(AppendTransformer.tempColumnName)
+
+}
+
+object TypedVectorAssembler {
+  case class Output(vector: Vector)
+
+  def create[Inputs]()(implicit inputsChecker: TypedVectorAssemblerInputsChecker[Inputs]): TypedVectorAssembler[Inputs] = {
+    new TypedVectorAssembler(new VectorAssembler(), inputsChecker.inputCols.toArray)
+  }
+}
+
+@implicitNotFound(
+  msg = "Cannot prove that ${Inputs} is a valid input type for TypedVectorAssembler. " +
+    "Input type must only contain numeric or boolean types."
+)
+private[ml] trait TypedVectorAssemblerInputsChecker[Inputs] {
+  val inputCols: Seq[String]
+}
+
+private[ml] object TypedVectorAssemblerInputsChecker {
+  implicit def checkInputs[Inputs, InputsRec <: HList, InputsKeys <: HList, InputsVals <: HList](
+    implicit
+    inputsGen: LabelledGeneric.Aux[Inputs, InputsRec],
+    inputsKeys: Keys.Aux[InputsRec, InputsKeys],
+    inputsKeysTraverse: ToTraversable.Aux[InputsKeys, Seq, Symbol],
+    inputsValues: Values.Aux[InputsRec, InputsVals],
+    inputsTypeCheck: TypedVectorAssemblerInputsValueChecker[InputsVals]
+  ): TypedVectorAssemblerInputsChecker[Inputs] = new TypedVectorAssemblerInputsChecker[Inputs] {
+    val inputCols: Seq[String] = inputsKeys.apply.to[Seq].map(_.name)
+  }
+}
+
+private[ml] trait TypedVectorAssemblerInputsValueChecker[InputsVals]
+
+private[ml] object TypedVectorAssemblerInputsValueChecker {
+  implicit def hnilCheckInputsValue: TypedVectorAssemblerInputsValueChecker[HNil] =
+    new TypedVectorAssemblerInputsValueChecker[HNil] {}
+
+  implicit def hlistCheckInputsValueNumeric[H, T <: HList](
+    implicit ch: CatalystNumeric[H],
+    tt: TypedVectorAssemblerInputsValueChecker[T]
+  ): TypedVectorAssemblerInputsValueChecker[H :: T] = new TypedVectorAssemblerInputsValueChecker[H :: T] {}
+
+  implicit def hlistCheckInputsValueBoolean[T <: HList](
+    implicit tt: TypedVectorAssemblerInputsValueChecker[T]
+  ): TypedVectorAssemblerInputsValueChecker[Boolean :: T] = new TypedVectorAssemblerInputsValueChecker[Boolean :: T] {}
+}
+
+

--- a/ml/src/main/scala/frameless/ml/internals/SelectorByValue.scala
+++ b/ml/src/main/scala/frameless/ml/internals/SelectorByValue.scala
@@ -1,0 +1,29 @@
+package frameless
+package ml
+package internals
+
+import shapeless.labelled.FieldType
+import shapeless.{::, DepFn1, HList, Witness}
+
+/**
+  * Typeclass supporting record selection by value type (returning the first key whose value is of type `Value`)
+  */
+trait SelectorByValue[L <: HList, Value] extends DepFn1[L] with Serializable { type Out <: Symbol }
+
+object SelectorByValue {
+  type Aux[L <: HList, Value, Out0 <: Symbol] = SelectorByValue[L, Value] { type Out = Out0 }
+
+  implicit def select[K <: Symbol, T <: HList, Value](implicit wk: Witness.Aux[K]): Aux[FieldType[K, Value] :: T, Value, K] = {
+    new SelectorByValue[FieldType[K, Value] :: T, Value] {
+      type Out = K
+      def apply(l: FieldType[K, Value] :: T): Out = wk.value
+    }
+  }
+
+  implicit def recurse[H, T <: HList, Value](implicit st: SelectorByValue[T, Value]): Aux[H :: T, Value, st.Out] = {
+    new SelectorByValue[H :: T, Value] {
+      type Out = st.Out
+      def apply(l: H :: T): Out = st(l.tail)
+    }
+  }
+}

--- a/ml/src/main/scala/frameless/ml/internals/TreesInputsChecker.scala
+++ b/ml/src/main/scala/frameless/ml/internals/TreesInputsChecker.scala
@@ -11,8 +11,8 @@ import scala.annotation.implicitNotFound
   */
 @implicitNotFound(
   msg = "Cannot prove that ${Inputs} is a valid input type. " +
-    "Input type must only contain a field of type Double (label) and a field of type " +
-    "org.apache.spark.ml.linalg.Vector (features)."
+    "Input type must only contain a field of type Double (the label) and a field of type " +
+    "org.apache.spark.ml.linalg.Vector (the features)."
 )
 trait TreesInputsChecker[Inputs] {
   val featuresCol: String

--- a/ml/src/main/scala/frameless/ml/internals/TreesInputsChecker.scala
+++ b/ml/src/main/scala/frameless/ml/internals/TreesInputsChecker.scala
@@ -1,0 +1,43 @@
+package frameless.ml.internals
+
+import shapeless.ops.hlist.Length
+import shapeless.{HList, LabelledGeneric, Nat, Witness}
+import org.apache.spark.ml.linalg._
+
+import scala.annotation.implicitNotFound
+
+/**
+  * Can be used for all tree-based ML algorithm (decision tree, random forest, gradient-boosted trees)
+  */
+@implicitNotFound(
+  msg = "Cannot prove that ${Inputs} is a valid input type." +
+    "Input type must only contain a field of type Double (label) and a field of type " +
+    "org.apache.spark.ml.linalg.Vector (features)."
+)
+trait TreesInputsChecker[Inputs] {
+  val featuresCol: String
+  val labelCol: String
+}
+
+object TreesInputsChecker {
+
+  implicit def checkTreesInputs[
+  Inputs,
+  InputsRec <: HList,
+  LabelK <: Symbol,
+  FeaturesK <: Symbol](
+    implicit
+    i0: LabelledGeneric.Aux[Inputs, InputsRec],
+    i1: Length.Aux[InputsRec, Nat._2],
+    i2: SelectorByValue.Aux[InputsRec, Double, LabelK],
+    i3: Witness.Aux[LabelK],
+    i4: SelectorByValue.Aux[InputsRec, Vector, FeaturesK],
+    i5: Witness.Aux[FeaturesK]
+  ): TreesInputsChecker[Inputs] = {
+    new TreesInputsChecker[Inputs] {
+      val labelCol: String = implicitly[Witness.Aux[LabelK]].value.name
+      val featuresCol: String = implicitly[Witness.Aux[FeaturesK]].value.name
+    }
+  }
+
+}

--- a/ml/src/main/scala/frameless/ml/internals/TreesInputsChecker.scala
+++ b/ml/src/main/scala/frameless/ml/internals/TreesInputsChecker.scala
@@ -10,7 +10,7 @@ import scala.annotation.implicitNotFound
   * Can be used for all tree-based ML algorithm (decision tree, random forest, gradient-boosted trees)
   */
 @implicitNotFound(
-  msg = "Cannot prove that ${Inputs} is a valid input type." +
+  msg = "Cannot prove that ${Inputs} is a valid input type. " +
     "Input type must only contain a field of type Double (label) and a field of type " +
     "org.apache.spark.ml.linalg.Vector (features)."
 )

--- a/ml/src/main/scala/frameless/ml/internals/UnaryInputsChecker.scala
+++ b/ml/src/main/scala/frameless/ml/internals/UnaryInputsChecker.scala
@@ -1,0 +1,31 @@
+package frameless.ml.internals
+
+import shapeless.ops.hlist.Length
+import shapeless.{HList, LabelledGeneric, Nat, Witness}
+
+import scala.annotation.implicitNotFound
+
+/**
+  * Can be used for all unary transformers (i.e almost all of them)
+  */
+@implicitNotFound(
+  msg = "Cannot prove that ${Inputs} is a valid input type. Input type must have only one field of type ${Expected}"
+)
+trait UnaryInputsChecker[Inputs, Expected] {
+  val inputCol: String
+}
+
+object UnaryInputsChecker {
+
+  implicit def checkUnaryInputs[Inputs, Expected, InputsRec <: HList, InputK <: Symbol](
+    implicit
+    i0: LabelledGeneric.Aux[Inputs, InputsRec],
+    i1: Length.Aux[InputsRec, Nat._1],
+    i2: SelectorByValue.Aux[InputsRec, Expected, InputK],
+    i3: Witness.Aux[InputK]
+  ): UnaryInputsChecker[Inputs, Expected] = new UnaryInputsChecker[Inputs, Expected] {
+    val inputCol: String = implicitly[Witness.Aux[InputK]].value.name
+  }
+
+}
+

--- a/ml/src/main/scala/frameless/ml/params/trees/FeatureSubsetStrategy.scala
+++ b/ml/src/main/scala/frameless/ml/params/trees/FeatureSubsetStrategy.scala
@@ -3,6 +3,30 @@ package ml
 package params
 package trees
 
+/**
+  * The number of features to consider for splits at each tree node.
+  * Supported options:
+  *  - Auto: Choose automatically for task:
+  *            If numTrees == 1, set to All
+  *            If numTrees > 1 (forest), set to Sqrt for classification and
+  *              to OneThird for regression.
+  *  - All: use all features
+  *  - OneThird: use 1/3 of the features
+  *  - Sqrt: use sqrt(number of features)
+  *  - Log2: use log2(number of features)
+  *  - Ratio: use (ratio * number of features) features
+  *  - NumberOfFeatures: use numberOfFeatures features.
+  * (default = Auto)
+  *
+  * These various settings are based on the following references:
+  *  - log2: tested in Breiman (2001)
+  *  - sqrt: recommended by Breiman manual for random forests
+  *  - The defaults of sqrt (classification) and onethird (regression) match the R randomForest
+  *    package.
+  * @see <a href="http://www.stat.berkeley.edu/~breiman/randomforest2001.pdf">Breiman (2001)</a>
+  * @see <a href="http://www.stat.berkeley.edu/~breiman/Using_random_forests_V3.1.pdf">
+  * Breiman manual for random forests</a>
+  */
 sealed abstract class FeatureSubsetStrategy private[ml](val sparkValue: String)
 object FeatureSubsetStrategy {
   case object Auto extends FeatureSubsetStrategy("auto")

--- a/ml/src/main/scala/frameless/ml/params/trees/FeatureSubsetStrategy.scala
+++ b/ml/src/main/scala/frameless/ml/params/trees/FeatureSubsetStrategy.scala
@@ -1,0 +1,14 @@
+package frameless
+package ml
+package params
+package trees
+
+sealed abstract class FeatureSubsetStrategy private[ml](val sparkValue: String)
+object FeatureSubsetStrategy {
+  case object Auto extends FeatureSubsetStrategy("auto")
+  case object All extends FeatureSubsetStrategy("all")
+  case object OneThird extends FeatureSubsetStrategy("onethird")
+  case object Sqrt extends FeatureSubsetStrategy("sqrt")
+  case object Log2 extends FeatureSubsetStrategy("log2")
+  case class StrictlyPositiveDouble(value: Double) extends FeatureSubsetStrategy(value.toString)
+}

--- a/ml/src/main/scala/frameless/ml/params/trees/FeatureSubsetStrategy.scala
+++ b/ml/src/main/scala/frameless/ml/params/trees/FeatureSubsetStrategy.scala
@@ -10,5 +10,6 @@ object FeatureSubsetStrategy {
   case object OneThird extends FeatureSubsetStrategy("onethird")
   case object Sqrt extends FeatureSubsetStrategy("sqrt")
   case object Log2 extends FeatureSubsetStrategy("log2")
-  case class StrictlyPositiveDouble(value: Double) extends FeatureSubsetStrategy(value.toString)
+  case class Ratio(value: Double) extends FeatureSubsetStrategy(value.toString)
+  case class NumberOfFeatures(value: Int) extends FeatureSubsetStrategy(value.toString)
 }

--- a/ml/src/main/scala/frameless/ml/regression/TypedRandomForestRegressor.scala
+++ b/ml/src/main/scala/frameless/ml/regression/TypedRandomForestRegressor.scala
@@ -59,7 +59,7 @@ object TypedRandomForestRegressor {
     }
   }
 
-  def create[Inputs]()(implicit inputsChecker: TreesInputsChecker[Inputs])
+  def apply[Inputs](implicit inputsChecker: TreesInputsChecker[Inputs])
   : TypedRandomForestRegressor[Inputs] = {
     new TypedRandomForestRegressor(new RandomForestRegressor(), inputsChecker.labelCol, inputsChecker.featuresCol)
   }

--- a/ml/src/main/scala/frameless/ml/regression/TypedRandomForestRegressor.scala
+++ b/ml/src/main/scala/frameless/ml/regression/TypedRandomForestRegressor.scala
@@ -6,6 +6,11 @@ import frameless.ml.internals.TreesInputsChecker
 import frameless.ml.params.trees.FeatureSubsetStrategy
 import org.apache.spark.ml.regression.{RandomForestRegressionModel, RandomForestRegressor}
 
+/**
+  * <a href="http://en.wikipedia.org/wiki/Random_forest">Random Forest</a>
+  * learning algorithm for regression.
+  * It supports both continuous and categorical features.
+  */
 final class TypedRandomForestRegressor[Inputs] private[ml](
   rf: RandomForestRegressor,
   labelCol: String,

--- a/ml/src/main/scala/frameless/ml/regression/TypedRandomForestRegressor.scala
+++ b/ml/src/main/scala/frameless/ml/regression/TypedRandomForestRegressor.scala
@@ -3,7 +3,7 @@ package ml
 package regression
 
 import frameless.ml.internals.TreesInputsChecker
-import frameless.ml.regression.TypedRandomForestRegressor.FeatureSubsetStrategy
+import frameless.ml.params.trees.FeatureSubsetStrategy
 import org.apache.spark.ml.regression.{RandomForestRegressionModel, RandomForestRegressor}
 
 final class TypedRandomForestRegressor[Inputs] private[ml](
@@ -34,30 +34,6 @@ final class TypedRandomForestRegressor[Inputs] private[ml](
 
 object TypedRandomForestRegressor {
   case class Outputs(prediction: Double)
-
-  sealed trait FeatureSubsetStrategy {
-    val sparkValue: String
-  }
-  object FeatureSubsetStrategy {
-    case object Auto extends FeatureSubsetStrategy {
-      val sparkValue = "auto"
-    }
-    case object All extends FeatureSubsetStrategy {
-      val sparkValue = "all"
-    }
-    case object OneThird extends FeatureSubsetStrategy {
-      val sparkValue = "onethird"
-    }
-    case object Sqrt extends FeatureSubsetStrategy {
-      val sparkValue = "sqrt"
-    }
-    case object Log2 extends FeatureSubsetStrategy {
-      val sparkValue = "log2"
-    }
-    case class StrictlyPositiveDouble(value: Double) extends FeatureSubsetStrategy {
-      val sparkValue = value.toString
-    }
-  }
 
   def apply[Inputs](implicit inputsChecker: TreesInputsChecker[Inputs])
   : TypedRandomForestRegressor[Inputs] = {

--- a/ml/src/main/scala/frameless/ml/regression/TypedRandomForestRegressor.scala
+++ b/ml/src/main/scala/frameless/ml/regression/TypedRandomForestRegressor.scala
@@ -1,0 +1,101 @@
+package frameless
+package ml
+package regression
+
+import frameless.ml.internals.SelectorByValue
+import frameless.ml.regression.TypedRandomForestRegressor.FeatureSubsetStrategy
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.regression.{RandomForestRegressionModel, RandomForestRegressor}
+import shapeless.ops.hlist.Length
+import shapeless.{HList, LabelledGeneric, Nat, Witness}
+import scala.annotation.implicitNotFound
+
+final class TypedRandomForestRegressor[Inputs] private[ml](
+  rf: RandomForestRegressor,
+  labelCol: String,
+  featuresCol: String
+) extends TypedEstimator[Inputs, TypedRandomForestRegressor.Outputs, RandomForestRegressionModel] {
+
+  val estimator: RandomForestRegressor =
+    rf
+      .setLabelCol(labelCol)
+      .setFeaturesCol(featuresCol)
+      .setPredictionCol(AppendTransformer.tempColumnName)
+
+  def setNumTrees(value: Int): TypedRandomForestRegressor[Inputs] = copy(rf.setNumTrees(value))
+  def setMaxDepth(value: Int): TypedRandomForestRegressor[Inputs] = copy(rf.setMaxDepth(value))
+  def setMinInfoGain(value: Double): TypedRandomForestRegressor[Inputs] = copy(rf.setMinInfoGain(value))
+  def setMinInstancesPerNode(value: Int): TypedRandomForestRegressor[Inputs] = copy(rf.setMinInstancesPerNode(value))
+  def setMaxMemoryInMB(value: Int): TypedRandomForestRegressor[Inputs] = copy(rf.setMaxMemoryInMB(value))
+  def setSubsamplingRate(value: Double): TypedRandomForestRegressor[Inputs] = copy(rf.setSubsamplingRate(value))
+  def setFeatureSubsetStrategy(value: FeatureSubsetStrategy): TypedRandomForestRegressor[Inputs] =
+    copy(rf.setFeatureSubsetStrategy(value.sparkValue))
+  def setMaxBins(value: Int): TypedRandomForestRegressor[Inputs] = copy(rf.setMaxBins(value))
+
+  private def copy(newRf: RandomForestRegressor): TypedRandomForestRegressor[Inputs] =
+    new TypedRandomForestRegressor[Inputs](newRf, labelCol, featuresCol)
+}
+
+object TypedRandomForestRegressor {
+  case class Outputs(prediction: Double)
+
+  sealed trait FeatureSubsetStrategy {
+    val sparkValue: String
+  }
+  object FeatureSubsetStrategy {
+    case object Auto extends FeatureSubsetStrategy {
+      val sparkValue = "auto"
+    }
+    case object All extends FeatureSubsetStrategy {
+      val sparkValue = "all"
+    }
+    case object OneThird extends FeatureSubsetStrategy {
+      val sparkValue = "onethird"
+    }
+    case object Sqrt extends FeatureSubsetStrategy {
+      val sparkValue = "sqrt"
+    }
+    case object Log2 extends FeatureSubsetStrategy {
+      val sparkValue = "log2"
+    }
+    case class StrictlyPositiveDouble(value: Double) extends FeatureSubsetStrategy {
+      val sparkValue = value.toString
+    }
+  }
+
+  def create[Inputs]()
+                    (implicit inputsChecker: TypedRandomForestRegressorInputsChecker[Inputs])
+  : TypedRandomForestRegressor[Inputs] = {
+    new TypedRandomForestRegressor(new RandomForestRegressor(), inputsChecker.labelCol, inputsChecker.featuresCol)
+  }
+}
+
+@implicitNotFound(
+  msg = "Cannot prove that ${Inputs} is a valid input type for TypedRandomForestRegressor. " +
+    "Input type must only contain a field of type Double (label) and a field of type Vector (features)."
+)
+private[ml] trait TypedRandomForestRegressorInputsChecker[Inputs] {
+  val labelCol: String
+  val featuresCol: String
+}
+
+private[ml] object TypedRandomForestRegressorInputsChecker {
+  implicit def checkInputs[
+  Inputs,
+  InputsRec <: HList,
+  LabelK <: Symbol,
+  FeaturesK <: Symbol](
+    implicit
+    inputsGen: LabelledGeneric.Aux[Inputs, InputsRec],
+    sizeCheck: Length.Aux[InputsRec, Nat._2],
+    labelSelect: SelectorByValue.Aux[InputsRec, Double, LabelK],
+    labelW: Witness.Aux[LabelK],
+    featuresSelect: SelectorByValue.Aux[InputsRec, Vector, FeaturesK],
+    featuresW: Witness.Aux[FeaturesK]
+  ): TypedRandomForestRegressorInputsChecker[Inputs] = {
+    new TypedRandomForestRegressorInputsChecker[Inputs] {
+      val labelCol: String = labelW.value.name
+      val featuresCol: String = featuresW.value.name
+    }
+  }
+}

--- a/ml/src/test/scala/frameless/ml/Generators.scala
+++ b/ml/src/test/scala/frameless/ml/Generators.scala
@@ -1,6 +1,7 @@
 package frameless
 package ml
 
+import frameless.ml.params.trees.FeatureSubsetStrategy
 import org.apache.spark.ml.linalg.{Matrices, Matrix, Vector, Vectors}
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -24,6 +25,20 @@ object Generators {
         }
       } yield matrix
     }
+  }
+
+  implicit val arbTreesFeaturesSubsetStrategy: Arbitrary[FeatureSubsetStrategy] = Arbitrary {
+    val genRatio = Gen.choose(0D, 1D).suchThat(_ > 0D).map(FeatureSubsetStrategy.Ratio)
+    val genNumberOfFeatures = Gen.choose(1, Int.MaxValue).map(FeatureSubsetStrategy.NumberOfFeatures)
+
+    Gen.oneOf(Gen.const(FeatureSubsetStrategy.All),
+      Gen.const(FeatureSubsetStrategy.All),
+      Gen.const(FeatureSubsetStrategy.Log2),
+      Gen.const(FeatureSubsetStrategy.OneThird),
+      Gen.const(FeatureSubsetStrategy.Sqrt),
+      genRatio,
+      genNumberOfFeatures
+    )
   }
 
 }

--- a/ml/src/test/scala/frameless/ml/classification/ClassificationIntegrationTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/ClassificationIntegrationTests.scala
@@ -19,14 +19,14 @@ class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers 
     val vectorAssembler = TypedVectorAssembler[Features]
 
     case class DataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector)
-    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).run().as[DataWithFeatures]
+    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).as[DataWithFeatures]
 
     case class StringIndexerInput(field3: String)
     val indexer = TypedStringIndexer[StringIndexerInput]
     val indexerModel = indexer.fit(dataWithFeatures).run()
 
     case class IndexedDataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector, indexedField3: Double)
-    val indexedData = indexerModel.transform(dataWithFeatures).run().as[IndexedDataWithFeatures]
+    val indexedData = indexerModel.transform(dataWithFeatures).as[IndexedDataWithFeatures]
 
     case class RFInputs(indexedField3: Double, features: Vector)
     val rf = TypedRandomForestClassifier[RFInputs]
@@ -38,8 +38,8 @@ class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers 
     val testData = TypedDataset.create(Seq(
       Data(0D, 10, "foo")
     ))
-    val testDataWithFeatures = vectorAssembler.transform(testData).run().as[DataWithFeatures]
-    val indexedTestData = indexerModel.transform(testDataWithFeatures).run().as[IndexedDataWithFeatures]
+    val testDataWithFeatures = vectorAssembler.transform(testData).as[DataWithFeatures]
+    val indexedTestData = indexerModel.transform(testDataWithFeatures).as[IndexedDataWithFeatures]
 
     case class PredictionInputs(features: Vector, indexedField3: Double)
     val testInput = indexedTestData.project[PredictionInputs]
@@ -51,7 +51,7 @@ class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers 
       probability: Vector,
       predictedField3Indexed: Double
     )
-    val predictionDs = model.transform(testInput).run().as[PredictionResultIndexed]
+    val predictionDs = model.transform(testInput).as[PredictionResultIndexed]
 
     case class IndexToStringInput(predictedField3Indexed: Double)
     val indexToString = TypedIndexToString[IndexToStringInput](indexerModel.transformer.labels)
@@ -64,7 +64,7 @@ class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers 
       predictedField3Indexed: Double,
       predictedField3: String
     )
-    val stringPredictionDs = indexToString.transform(predictionDs).run().as[PredictionResult]
+    val stringPredictionDs = indexToString.transform(predictionDs).as[PredictionResult]
 
     val prediction = stringPredictionDs.select(stringPredictionDs.col('predictedField3)).collect.run().toList
 

--- a/ml/src/test/scala/frameless/ml/classification/ClassificationIntegrationTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/ClassificationIntegrationTests.scala
@@ -19,27 +19,27 @@ class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers 
     val vectorAssembler = TypedVectorAssembler.create[Features]()
 
     case class DataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector)
-    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).as[DataWithFeatures]
+    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).run().as[DataWithFeatures]
 
     case class StringIndexerInput(field3: String)
     val indexer = TypedStringIndexer.create[StringIndexerInput]()
-    val indexerModel = indexer.fit(dataWithFeatures)
+    val indexerModel = indexer.fit(dataWithFeatures).run()
 
     case class IndexedDataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector, indexedField3: Double)
-    val indexedData = indexerModel.transform(dataWithFeatures).as[IndexedDataWithFeatures]
+    val indexedData = indexerModel.transform(dataWithFeatures).run().as[IndexedDataWithFeatures]
 
     case class RFInputs(indexedField3: Double, features: Vector)
     val rf = TypedRandomForestClassifier.create[RFInputs]()
 
-    val model = rf.fit(indexedData)
+    val model = rf.fit(indexedData).run()
 
     // Prediction
 
     val testData = TypedDataset.create(Seq(
       Data(0D, 10, "foo")
     ))
-    val testDataWithFeatures = vectorAssembler.transform(testData).as[DataWithFeatures]
-    val indexedTestData = indexerModel.transform(testDataWithFeatures).as[IndexedDataWithFeatures]
+    val testDataWithFeatures = vectorAssembler.transform(testData).run().as[DataWithFeatures]
+    val indexedTestData = indexerModel.transform(testDataWithFeatures).run().as[IndexedDataWithFeatures]
 
     case class PredictionInputs(features: Vector, indexedField3: Double)
     val testInput = indexedTestData.project[PredictionInputs]
@@ -51,7 +51,7 @@ class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers 
       probability: Vector,
       predictedField3Indexed: Double
     )
-    val predictionDs = model.transform(testInput).as[PredictionResultIndexed]
+    val predictionDs = model.transform(testInput).run().as[PredictionResultIndexed]
 
     case class IndexToStringInput(predictedField3Indexed: Double)
     val indexToString = TypedIndexToString.create[IndexToStringInput](indexerModel.transformer.labels)
@@ -64,7 +64,7 @@ class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers 
       predictedField3Indexed: Double,
       predictedField3: String
     )
-    val stringPredictionDs = indexToString.transform(predictionDs).as[PredictionResult]
+    val stringPredictionDs = indexToString.transform(predictionDs).run().as[PredictionResult]
 
     val prediction = stringPredictionDs.select(stringPredictionDs.col('predictedField3)).collect.run().toList
 

--- a/ml/src/test/scala/frameless/ml/classification/ClassificationIntegrationTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/ClassificationIntegrationTests.scala
@@ -16,20 +16,20 @@ class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers 
     val trainingDataDs = TypedDataset.create(Seq.fill(10)(Data(0D, 10, "foo")))
 
     case class Features(field1: Double, field2: Int)
-    val vectorAssembler = TypedVectorAssembler.create[Features]()
+    val vectorAssembler = TypedVectorAssembler[Features]
 
     case class DataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector)
     val dataWithFeatures = vectorAssembler.transform(trainingDataDs).run().as[DataWithFeatures]
 
     case class StringIndexerInput(field3: String)
-    val indexer = TypedStringIndexer.create[StringIndexerInput]()
+    val indexer = TypedStringIndexer[StringIndexerInput]
     val indexerModel = indexer.fit(dataWithFeatures).run()
 
     case class IndexedDataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector, indexedField3: Double)
     val indexedData = indexerModel.transform(dataWithFeatures).run().as[IndexedDataWithFeatures]
 
     case class RFInputs(indexedField3: Double, features: Vector)
-    val rf = TypedRandomForestClassifier.create[RFInputs]()
+    val rf = TypedRandomForestClassifier[RFInputs]
 
     val model = rf.fit(indexedData).run()
 
@@ -54,7 +54,7 @@ class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers 
     val predictionDs = model.transform(testInput).run().as[PredictionResultIndexed]
 
     case class IndexToStringInput(predictedField3Indexed: Double)
-    val indexToString = TypedIndexToString.create[IndexToStringInput](indexerModel.transformer.labels)
+    val indexToString = TypedIndexToString[IndexToStringInput](indexerModel.transformer.labels)
 
     case class PredictionResult(
       features: Vector,

--- a/ml/src/test/scala/frameless/ml/classification/ClassificationIntegrationTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/ClassificationIntegrationTests.scala
@@ -1,0 +1,74 @@
+package frameless
+package ml
+package classification
+
+import frameless.ml.feature.{TypedIndexToString, TypedStringIndexer, TypedVectorAssembler}
+import org.apache.spark.ml.linalg.Vector
+import org.scalatest.MustMatchers
+
+class ClassificationIntegrationTests extends FramelessMlSuite with MustMatchers {
+
+  test("predict field3 from field1 and field2 using a RandomForestClassifier") {
+    case class Data(field1: Double, field2: Int, field3: String)
+
+    // Training
+
+    val trainingDataDs = TypedDataset.create(Seq.fill(10)(Data(0D, 10, "foo")))
+
+    case class Features(field1: Double, field2: Int)
+    val vectorAssembler = TypedVectorAssembler.create[Features]()
+
+    case class DataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector)
+    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).as[DataWithFeatures]
+
+    case class StringIndexerInput(field3: String)
+    val indexer = TypedStringIndexer.create[StringIndexerInput]()
+    val indexerModel = indexer.fit(dataWithFeatures)
+
+    case class IndexedDataWithFeatures(field1: Double, field2: Int, field3: String, features: Vector, indexedField3: Double)
+    val indexedData = indexerModel.transform(dataWithFeatures).as[IndexedDataWithFeatures]
+
+    case class RFInputs(indexedField3: Double, features: Vector)
+    val rf = TypedRandomForestClassifier.create[RFInputs]()
+
+    val model = rf.fit(indexedData)
+
+    // Prediction
+
+    val testData = TypedDataset.create(Seq(
+      Data(0D, 10, "foo")
+    ))
+    val testDataWithFeatures = vectorAssembler.transform(testData).as[DataWithFeatures]
+    val indexedTestData = indexerModel.transform(testDataWithFeatures).as[IndexedDataWithFeatures]
+
+    case class PredictionInputs(features: Vector, indexedField3: Double)
+    val testInput = indexedTestData.project[PredictionInputs]
+
+    case class PredictionResultIndexed(
+      features: Vector,
+      indexedField3: Double,
+      rawPrediction: Vector,
+      probability: Vector,
+      predictedField3Indexed: Double
+    )
+    val predictionDs = model.transform(testInput).as[PredictionResultIndexed]
+
+    case class IndexToStringInput(predictedField3Indexed: Double)
+    val indexToString = TypedIndexToString.create[IndexToStringInput](indexerModel.transformer.labels)
+
+    case class PredictionResult(
+      features: Vector,
+      indexedField3: Double,
+      rawPrediction: Vector,
+      probability: Vector,
+      predictedField3Indexed: Double,
+      predictedField3: String
+    )
+    val stringPredictionDs = indexToString.transform(predictionDs).as[PredictionResult]
+
+    val prediction = stringPredictionDs.select(stringPredictionDs.col('predictedField3)).collect.run().toList
+
+    prediction mustEqual List("foo")
+  }
+
+}

--- a/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
@@ -1,0 +1,76 @@
+package frameless
+package ml
+package classification
+
+import shapeless.test.illTyped
+import org.apache.spark.ml.linalg._
+import TypedRandomForestClassifier.FeatureSubsetStrategy
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Prop._
+import org.scalatest.MustMatchers
+
+class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatchers {
+  implicit val arbDouble: Arbitrary[Double] =
+    Arbitrary(Gen.choose(1, 99).map(_.toDouble)) // num classes must be between 0 and 100
+  implicit val arbVectorNonEmpty: Arbitrary[Vector] =
+    Arbitrary(Generators.arbVector.arbitrary suchThat (_.size > 0)) // vector must not be empty for RandomForestClassifier
+
+  test("fit() returns a correct TypedTransformer") {
+    val prop = forAll { x2: X2[Double, Vector] =>
+      val rf = TypedRandomForestClassifier.create[X2[Double, Vector]]()
+      val ds = TypedDataset.create(Seq(x2))
+      val model = rf.fit(ds)
+      val pDs = model.transform(ds).as[X5[Double, Vector, Vector, Vector, Double]]
+
+      pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
+    }
+
+    val prop2 = forAll { x2: X2[Vector, Double] =>
+      val rf = TypedRandomForestClassifier.create[X2[Vector, Double]]()
+      val ds = TypedDataset.create(Seq(x2))
+      val model = rf.fit(ds)
+      val pDs = model.transform(ds).as[X5[Vector, Double, Vector, Vector, Double]]
+
+      pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
+    }
+
+    def prop3[A: TypedEncoder: Arbitrary] = forAll { x3: X3[Vector, Double, A] =>
+      val rf = TypedRandomForestClassifier.create[X2[Vector, Double]]()
+      val ds = TypedDataset.create(Seq(x3))
+      val model = rf.fit(ds)
+      val pDs = model.transform(ds).as[X6[Vector, Double, A, Vector, Vector, Double]]
+
+      pDs.select(pDs.col('a), pDs.col('b), pDs.col('c)).collect.run() == Seq((x3.a, x3.b, x3.c))
+    }
+
+    check(prop)
+    check(prop2)
+    check(prop3[String])
+    check(prop3[Double])
+  }
+
+  test("param setting is retained") {
+    val rf = TypedRandomForestClassifier.create[X2[Double, Vector]]()
+      .setNumTrees(10)
+      .setMaxBins(100)
+      .setFeatureSubsetStrategy(FeatureSubsetStrategy.All)
+      .setMaxDepth(10)
+
+    val ds = TypedDataset.create(Seq(X2(0D, Vectors.dense(0D))))
+    val model = rf.fit(ds)
+
+    model.transformer.getNumTrees mustEqual 10
+    model.transformer.getMaxBins mustEqual 100
+    model.transformer.getFeatureSubsetStrategy mustEqual "all"
+    model.transformer.getMaxDepth mustEqual 10
+  }
+
+  test("create() compiles only with correct inputs") {
+    illTyped("TypedRandomForestClassifier.create[Double]()")
+    illTyped("TypedRandomForestClassifier.create[X1[Double]]()")
+    illTyped("TypedRandomForestClassifier.create[X2[Double, Double]]()")
+    illTyped("TypedRandomForestClassifier.create[X3[Vector, Double, Int]]()")
+    illTyped("TypedRandomForestClassifier.create[X2[Vector, String]]()")
+  }
+
+}

--- a/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
@@ -4,7 +4,7 @@ package classification
 
 import shapeless.test.illTyped
 import org.apache.spark.ml.linalg._
-import TypedRandomForestClassifier.FeatureSubsetStrategy
+import frameless.ml.params.trees.FeatureSubsetStrategy
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Prop._
 import org.scalatest.MustMatchers

--- a/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
@@ -14,6 +14,7 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
     Arbitrary(Gen.choose(1, 99).map(_.toDouble)) // num classes must be between 0 and 100 for the test
   implicit val arbVectorNonEmpty: Arbitrary[Vector] =
     Arbitrary(Generators.arbVector.arbitrary suchThat (_.size > 0)) // vector must not be empty for RandomForestClassifier
+  import Generators.arbTreesFeaturesSubsetStrategy
 
   test("fit() returns a correct TypedTransformer") {
     val prop = forAll { x2: X2[Double, Vector] =>
@@ -50,19 +51,31 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
   }
 
   test("param setting is retained") {
-    val rf = TypedRandomForestClassifier[X2[Double, Vector]]
-      .setNumTrees(10)
-      .setMaxBins(100)
-      .setFeatureSubsetStrategy(FeatureSubsetStrategy.All)
-      .setMaxDepth(10)
+    val prop = forAll { featureSubsetStrategy: FeatureSubsetStrategy =>
+      val rf = TypedRandomForestClassifier[X2[Double, Vector]]
+        .setNumTrees(10)
+        .setMaxBins(100)
+        .setFeatureSubsetStrategy(featureSubsetStrategy)
+        .setMaxDepth(10)
+        .setMaxMemoryInMB(100)
+        .setMinInfoGain(0.1D)
+        .setMinInstancesPerNode(2)
+        .setSubsamplingRate(0.9D)
 
-    val ds = TypedDataset.create(Seq(X2(0D, Vectors.dense(0D))))
-    val model = rf.fit(ds).run()
+      val ds = TypedDataset.create(Seq(X2(0D, Vectors.dense(0D))))
+      val model = rf.fit(ds).run()
 
-    model.transformer.getNumTrees mustEqual 10
-    model.transformer.getMaxBins mustEqual 100
-    model.transformer.getFeatureSubsetStrategy mustEqual "all"
-    model.transformer.getMaxDepth mustEqual 10
+      model.transformer.getNumTrees == 10 &&
+        model.transformer.getMaxBins == 100 &&
+        model.transformer.getFeatureSubsetStrategy == featureSubsetStrategy.sparkValue &&
+        model.transformer.getMaxDepth == 10 &&
+        model.transformer.getMaxMemoryInMB == 100 &&
+        model.transformer.getMinInfoGain == 0.1D &&
+        model.transformer.getMinInstancesPerNode == 2 &&
+        model.transformer.getSubsamplingRate == 0.9D
+    }
+
+    check(prop)
   }
 
   test("create() compiles only with correct inputs") {

--- a/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
@@ -21,7 +21,7 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
       val rf = TypedRandomForestClassifier[X2[Double, Vector]]
       val ds = TypedDataset.create(Seq(x2))
       val model = rf.fit(ds).run()
-      val pDs = model.transform(ds).run().as[X5[Double, Vector, Vector, Vector, Double]]
+      val pDs = model.transform(ds).as[X5[Double, Vector, Vector, Vector, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
     }
@@ -30,7 +30,7 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
       val rf = TypedRandomForestClassifier[X2[Vector, Double]]
       val ds = TypedDataset.create(Seq(x2))
       val model = rf.fit(ds).run()
-      val pDs = model.transform(ds).run().as[X5[Vector, Double, Vector, Vector, Double]]
+      val pDs = model.transform(ds).as[X5[Vector, Double, Vector, Vector, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
     }
@@ -39,7 +39,7 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
       val rf = TypedRandomForestClassifier[X2[Vector, Double]]
       val ds = TypedDataset.create(Seq(x3))
       val model = rf.fit(ds).run()
-      val pDs = model.transform(ds).run().as[X6[Vector, Double, A, Vector, Vector, Double]]
+      val pDs = model.transform(ds).as[X6[Vector, Double, A, Vector, Vector, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b), pDs.col('c)).collect.run() == Seq((x3.a, x3.b, x3.c))
     }

--- a/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
@@ -19,8 +19,8 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
     val prop = forAll { x2: X2[Double, Vector] =>
       val rf = TypedRandomForestClassifier.create[X2[Double, Vector]]()
       val ds = TypedDataset.create(Seq(x2))
-      val model = rf.fit(ds)
-      val pDs = model.transform(ds).as[X5[Double, Vector, Vector, Vector, Double]]
+      val model = rf.fit(ds).run()
+      val pDs = model.transform(ds).run().as[X5[Double, Vector, Vector, Vector, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
     }
@@ -28,8 +28,8 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
     val prop2 = forAll { x2: X2[Vector, Double] =>
       val rf = TypedRandomForestClassifier.create[X2[Vector, Double]]()
       val ds = TypedDataset.create(Seq(x2))
-      val model = rf.fit(ds)
-      val pDs = model.transform(ds).as[X5[Vector, Double, Vector, Vector, Double]]
+      val model = rf.fit(ds).run()
+      val pDs = model.transform(ds).run().as[X5[Vector, Double, Vector, Vector, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
     }
@@ -37,8 +37,8 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
     def prop3[A: TypedEncoder: Arbitrary] = forAll { x3: X3[Vector, Double, A] =>
       val rf = TypedRandomForestClassifier.create[X2[Vector, Double]]()
       val ds = TypedDataset.create(Seq(x3))
-      val model = rf.fit(ds)
-      val pDs = model.transform(ds).as[X6[Vector, Double, A, Vector, Vector, Double]]
+      val model = rf.fit(ds).run()
+      val pDs = model.transform(ds).run().as[X6[Vector, Double, A, Vector, Vector, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b), pDs.col('c)).collect.run() == Seq((x3.a, x3.b, x3.c))
     }
@@ -57,7 +57,7 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
       .setMaxDepth(10)
 
     val ds = TypedDataset.create(Seq(X2(0D, Vectors.dense(0D))))
-    val model = rf.fit(ds)
+    val model = rf.fit(ds).run()
 
     model.transformer.getNumTrees mustEqual 10
     model.transformer.getMaxBins mustEqual 100

--- a/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
+++ b/ml/src/test/scala/frameless/ml/classification/TypedRandomForestClassifierTests.scala
@@ -11,13 +11,13 @@ import org.scalatest.MustMatchers
 
 class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatchers {
   implicit val arbDouble: Arbitrary[Double] =
-    Arbitrary(Gen.choose(1, 99).map(_.toDouble)) // num classes must be between 0 and 100
+    Arbitrary(Gen.choose(1, 99).map(_.toDouble)) // num classes must be between 0 and 100 for the test
   implicit val arbVectorNonEmpty: Arbitrary[Vector] =
     Arbitrary(Generators.arbVector.arbitrary suchThat (_.size > 0)) // vector must not be empty for RandomForestClassifier
 
   test("fit() returns a correct TypedTransformer") {
     val prop = forAll { x2: X2[Double, Vector] =>
-      val rf = TypedRandomForestClassifier.create[X2[Double, Vector]]()
+      val rf = TypedRandomForestClassifier[X2[Double, Vector]]
       val ds = TypedDataset.create(Seq(x2))
       val model = rf.fit(ds).run()
       val pDs = model.transform(ds).run().as[X5[Double, Vector, Vector, Vector, Double]]
@@ -26,7 +26,7 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
     }
 
     val prop2 = forAll { x2: X2[Vector, Double] =>
-      val rf = TypedRandomForestClassifier.create[X2[Vector, Double]]()
+      val rf = TypedRandomForestClassifier[X2[Vector, Double]]
       val ds = TypedDataset.create(Seq(x2))
       val model = rf.fit(ds).run()
       val pDs = model.transform(ds).run().as[X5[Vector, Double, Vector, Vector, Double]]
@@ -35,7 +35,7 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
     }
 
     def prop3[A: TypedEncoder: Arbitrary] = forAll { x3: X3[Vector, Double, A] =>
-      val rf = TypedRandomForestClassifier.create[X2[Vector, Double]]()
+      val rf = TypedRandomForestClassifier[X2[Vector, Double]]
       val ds = TypedDataset.create(Seq(x3))
       val model = rf.fit(ds).run()
       val pDs = model.transform(ds).run().as[X6[Vector, Double, A, Vector, Vector, Double]]
@@ -50,7 +50,7 @@ class TypedRandomForestClassifierTests extends FramelessMlSuite with MustMatcher
   }
 
   test("param setting is retained") {
-    val rf = TypedRandomForestClassifier.create[X2[Double, Vector]]()
+    val rf = TypedRandomForestClassifier[X2[Double, Vector]]
       .setNumTrees(10)
       .setMaxBins(100)
       .setFeatureSubsetStrategy(FeatureSubsetStrategy.All)

--- a/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
@@ -15,7 +15,7 @@ class TypedIndexToStringTests extends FramelessMlSuite with MustMatchers {
     def prop[A: TypedEncoder: Arbitrary] = forAll { x2: X2[Double, A] =>
       val transformer = TypedIndexToString.create[X1[Double]](Array.fill(100)("foo"))
       val ds = TypedDataset.create(Seq(x2))
-      val ds2 = transformer.transform(ds)
+      val ds2 = transformer.transform(ds).run()
 
       ds2.collect.run() == Seq((x2.a, x2.b, "foo"))
     }

--- a/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
@@ -1,0 +1,34 @@
+package frameless
+package ml
+package feature
+
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.MustMatchers
+import org.scalacheck.Prop._
+import shapeless.test.illTyped
+
+class TypedIndexToStringTests extends FramelessMlSuite with MustMatchers {
+
+  test(".transform() correctly transform an input dataset") {
+    implicit val arbDouble = Arbitrary(Gen.choose(1, 99).map(_.toDouble))
+
+    def prop[A: TypedEncoder: Arbitrary] = forAll { x2: X2[Double, A] =>
+      val transformer = TypedIndexToString.create[X1[Double]](Array.fill(99)("foo"))
+      val ds = TypedDataset.create(Seq(x2))
+      val ds2 = transformer.transform(ds)
+
+      ds2.collect.run() == Seq((x2.a, x2.b, "foo"))
+    }
+
+    check(prop[Double])
+    check(prop[String])
+  }
+
+  test("create() compiles only with correct inputs") {
+    illTyped("TypedIndexToString.create[String](Array(\"foo\"))")
+    illTyped("TypedIndexToString.create[X1[String]](Array(\"foo\"))")
+    illTyped("TypedIndexToString.create[X1[Long]](Array(\"foo\"))")
+    illTyped("TypedIndexToString.create[X2[String, Int]](Array(\"foo\"))")
+  }
+
+}

--- a/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
@@ -13,7 +13,7 @@ class TypedIndexToStringTests extends FramelessMlSuite with MustMatchers {
     implicit val arbDouble = Arbitrary(Gen.choose(0, 99).map(_.toDouble))
 
     def prop[A: TypedEncoder: Arbitrary] = forAll { x2: X2[Double, A] =>
-      val transformer = TypedIndexToString.create[X1[Double]](Array.fill(100)("foo"))
+      val transformer = TypedIndexToString[X1[Double]](Array.fill(100)("foo"))
       val ds = TypedDataset.create(Seq(x2))
       val ds2 = transformer.transform(ds).run()
 

--- a/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
@@ -15,7 +15,7 @@ class TypedIndexToStringTests extends FramelessMlSuite with MustMatchers {
     def prop[A: TypedEncoder: Arbitrary] = forAll { x2: X2[Double, A] =>
       val transformer = TypedIndexToString[X1[Double]](Array.fill(100)("foo"))
       val ds = TypedDataset.create(Seq(x2))
-      val ds2 = transformer.transform(ds).run()
+      val ds2 = transformer.transform(ds)
 
       ds2.collect.run() == Seq((x2.a, x2.b, "foo"))
     }

--- a/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedIndexToStringTests.scala
@@ -10,10 +10,10 @@ import shapeless.test.illTyped
 class TypedIndexToStringTests extends FramelessMlSuite with MustMatchers {
 
   test(".transform() correctly transform an input dataset") {
-    implicit val arbDouble = Arbitrary(Gen.choose(1, 99).map(_.toDouble))
+    implicit val arbDouble = Arbitrary(Gen.choose(0, 99).map(_.toDouble))
 
     def prop[A: TypedEncoder: Arbitrary] = forAll { x2: X2[Double, A] =>
-      val transformer = TypedIndexToString.create[X1[Double]](Array.fill(99)("foo"))
+      val transformer = TypedIndexToString.create[X1[Double]](Array.fill(100)("foo"))
       val ds = TypedDataset.create(Seq(x2))
       val ds2 = transformer.transform(ds)
 

--- a/ml/src/test/scala/frameless/ml/feature/TypedStringIndexerTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedStringIndexerTests.scala
@@ -11,7 +11,7 @@ class TypedStringIndexerTests extends FramelessMlSuite with MustMatchers {
 
   test(".fit() returns a correct TypedTransformer") {
     def prop[A: TypedEncoder : Arbitrary] = forAll { x2: X2[String, A] =>
-      val indexer = TypedStringIndexer.create[X1[String]]()
+      val indexer = TypedStringIndexer[X1[String]]
       val ds = TypedDataset.create(Seq(x2))
       val model = indexer.fit(ds).run()
       val resultDs = model.transform(ds).run().as[X3[String, A, Double]]
@@ -24,7 +24,7 @@ class TypedStringIndexerTests extends FramelessMlSuite with MustMatchers {
   }
 
   test("param setting is retained") {
-    val indexer = TypedStringIndexer.create[X1[String]]()
+    val indexer = TypedStringIndexer[X1[String]]
       .setHandleInvalid(TypedStringIndexer.HandleInvalid.Keep)
     val ds = TypedDataset.create(Seq(X1("foo")))
     val model = indexer.fit(ds).run()

--- a/ml/src/test/scala/frameless/ml/feature/TypedStringIndexerTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedStringIndexerTests.scala
@@ -13,8 +13,8 @@ class TypedStringIndexerTests extends FramelessMlSuite with MustMatchers {
     def prop[A: TypedEncoder : Arbitrary] = forAll { x2: X2[String, A] =>
       val indexer = TypedStringIndexer.create[X1[String]]()
       val ds = TypedDataset.create(Seq(x2))
-      val model = indexer.fit(ds)
-      val resultDs = model.transform(ds).as[X3[String, A, Double]]
+      val model = indexer.fit(ds).run()
+      val resultDs = model.transform(ds).run().as[X3[String, A, Double]]
 
       resultDs.collect.run() == Seq(X3(x2.a, x2.b, 0D))
     }
@@ -27,7 +27,7 @@ class TypedStringIndexerTests extends FramelessMlSuite with MustMatchers {
     val indexer = TypedStringIndexer.create[X1[String]]()
       .setHandleInvalid(TypedStringIndexer.HandleInvalid.Keep)
     val ds = TypedDataset.create(Seq(X1("foo")))
-    val model = indexer.fit(ds)
+    val model = indexer.fit(ds).run()
 
     model.transformer.getHandleInvalid mustEqual "keep"
   }

--- a/ml/src/test/scala/frameless/ml/feature/TypedStringIndexerTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedStringIndexerTests.scala
@@ -1,0 +1,41 @@
+package frameless
+package ml
+package feature
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.scalatest.MustMatchers
+import shapeless.test.illTyped
+
+class TypedStringIndexerTests extends FramelessMlSuite with MustMatchers {
+
+  test(".fit() returns a correct TypedTransformer") {
+    def prop[A: TypedEncoder : Arbitrary] = forAll { x2: X2[String, A] =>
+      val indexer = TypedStringIndexer.create[X1[String]]()
+      val ds = TypedDataset.create(Seq(x2))
+      val model = indexer.fit(ds)
+      val resultDs = model.transform(ds).as[X3[String, A, Double]]
+
+      resultDs.collect.run() == Seq(X3(x2.a, x2.b, 0D))
+    }
+
+    check(prop[Double])
+    check(prop[String])
+  }
+
+  test("param setting is retained") {
+    val indexer = TypedStringIndexer.create[X1[String]]()
+      .setHandleInvalid(TypedStringIndexer.HandleInvalid.Keep)
+    val ds = TypedDataset.create(Seq(X1("foo")))
+    val model = indexer.fit(ds)
+
+    model.transformer.getHandleInvalid mustEqual "keep"
+  }
+
+  test("create() compiles only with correct inputs") {
+    illTyped("TypedStringIndexer.create[Double]()")
+    illTyped("TypedStringIndexer.create[X1[Double]]()")
+    illTyped("TypedStringIndexer.create[X2[String, Long]]()")
+  }
+
+}

--- a/ml/src/test/scala/frameless/ml/feature/TypedStringIndexerTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedStringIndexerTests.scala
@@ -15,7 +15,7 @@ class TypedStringIndexerTests extends FramelessMlSuite with MustMatchers {
       val indexer = TypedStringIndexer[X1[String]]
       val ds = TypedDataset.create(Seq(x2))
       val model = indexer.fit(ds).run()
-      val resultDs = model.transform(ds).run().as[X3[String, A, Double]]
+      val resultDs = model.transform(ds).as[X3[String, A, Double]]
 
       resultDs.collect.run() == Seq(X3(x2.a, x2.b, 0D))
     }

--- a/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
@@ -13,7 +13,7 @@ class TypedVectorAssemblerTests extends FramelessMlSuite {
     def prop[A: TypedEncoder: Arbitrary] = forAll { x5: X5[Int, Long, Double, Boolean, A] =>
       val assembler = TypedVectorAssembler.create[X4[Int, Long, Double, Boolean]]()
       val ds = TypedDataset.create(Seq(x5))
-      val ds2 = assembler.transform(ds).as[X6[Int, Long, Double, Boolean, A, Vector]]
+      val ds2 = assembler.transform(ds).run().as[X6[Int, Long, Double, Boolean, A, Vector]]
 
       ds2.collect.run() ==
         Seq(X6(x5.a, x5.b, x5.c, x5.d, x5.e, Vectors.dense(x5.a.toDouble, x5.b.toDouble, x5.c, if (x5.d) 0D else 1D)))

--- a/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
@@ -13,7 +13,7 @@ class TypedVectorAssemblerTests extends FramelessMlSuite {
     def prop[A: TypedEncoder: Arbitrary] = forAll { x5: X5[Int, Long, Double, Boolean, A] =>
       val assembler = TypedVectorAssembler[X4[Int, Long, Double, Boolean]]
       val ds = TypedDataset.create(Seq(x5))
-      val ds2 = assembler.transform(ds).run().as[X6[Int, Long, Double, Boolean, A, Vector]]
+      val ds2 = assembler.transform(ds).as[X6[Int, Long, Double, Boolean, A, Vector]]
 
       ds2.collect.run() ==
         Seq(X6(x5.a, x5.b, x5.c, x5.d, x5.e, Vectors.dense(x5.a.toDouble, x5.b.toDouble, x5.c, if (x5.d) 1D else 0D)))
@@ -22,7 +22,7 @@ class TypedVectorAssemblerTests extends FramelessMlSuite {
     def prop2[A: TypedEncoder: Arbitrary] = forAll { x5: X5[Boolean, BigDecimal, Byte, Short, A] =>
       val assembler = TypedVectorAssembler[X4[Boolean, BigDecimal, Byte, Short]]
       val ds = TypedDataset.create(Seq(x5))
-      val ds2 = assembler.transform(ds).run().as[X6[Boolean, BigDecimal, Byte, Short, A, Vector]]
+      val ds2 = assembler.transform(ds).as[X6[Boolean, BigDecimal, Byte, Short, A, Vector]]
 
       ds2.collect.run() ==
         Seq(X6(x5.a, x5.b, x5.c, x5.d, x5.e, Vectors.dense(if (x5.a) 1D else 0D, x5.b.toDouble, x5.c.toDouble, x5.d.toDouble)))

--- a/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
@@ -11,7 +11,7 @@ class TypedVectorAssemblerTests extends FramelessMlSuite {
 
   test(".transform() returns a correct TypedTransformer") {
     def prop[A: TypedEncoder: Arbitrary] = forAll { x5: X5[Int, Long, Double, Boolean, A] =>
-      val assembler = TypedVectorAssembler.create[X4[Int, Long, Double, Boolean]]()
+      val assembler = TypedVectorAssembler[X4[Int, Long, Double, Boolean]]
       val ds = TypedDataset.create(Seq(x5))
       val ds2 = assembler.transform(ds).run().as[X6[Int, Long, Double, Boolean, A, Vector]]
 

--- a/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
@@ -1,0 +1,30 @@
+package frameless
+package ml
+package feature
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.apache.spark.ml.linalg._
+import shapeless.test.illTyped
+
+class TypedVectorAssemblerTests extends FramelessMlSuite {
+
+  test(".transform() returns a correct TypedTransformer") {
+    def prop[A: TypedEncoder: Arbitrary] = forAll { x5: X5[Int, Long, Double, Boolean, A] =>
+      val assembler = TypedVectorAssembler.create[X4[Int, Long, Double, Boolean]]()
+      val ds = TypedDataset.create(Seq(x5))
+      val ds2 = assembler.transform(ds).as[X6[Int, Long, Double, Boolean, A, Vector]]
+
+      ds2.collect.run() ==
+        Seq(X6(x5.a, x5.b, x5.c, x5.d, x5.e, Vectors.dense(x5.a.toDouble, x5.b.toDouble, x5.c, if (x5.d) 0D else 1D)))
+    }
+  }
+
+  test("create() compiles only with correct inputs") {
+    illTyped("TypedVectorAssembler.create[Double]()")
+    illTyped("TypedVectorAssembler.create[X1[String]]()")
+    illTyped("TypedVectorAssembler.create[X2[String, Double]]()")
+    illTyped("TypedVectorAssembler.create[X3[Int, String, Double]]()")
+  }
+
+}

--- a/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
+++ b/ml/src/test/scala/frameless/ml/feature/TypedVectorAssemblerTests.scala
@@ -16,8 +16,22 @@ class TypedVectorAssemblerTests extends FramelessMlSuite {
       val ds2 = assembler.transform(ds).run().as[X6[Int, Long, Double, Boolean, A, Vector]]
 
       ds2.collect.run() ==
-        Seq(X6(x5.a, x5.b, x5.c, x5.d, x5.e, Vectors.dense(x5.a.toDouble, x5.b.toDouble, x5.c, if (x5.d) 0D else 1D)))
+        Seq(X6(x5.a, x5.b, x5.c, x5.d, x5.e, Vectors.dense(x5.a.toDouble, x5.b.toDouble, x5.c, if (x5.d) 1D else 0D)))
     }
+
+    def prop2[A: TypedEncoder: Arbitrary] = forAll { x5: X5[Boolean, BigDecimal, Byte, Short, A] =>
+      val assembler = TypedVectorAssembler[X4[Boolean, BigDecimal, Byte, Short]]
+      val ds = TypedDataset.create(Seq(x5))
+      val ds2 = assembler.transform(ds).run().as[X6[Boolean, BigDecimal, Byte, Short, A, Vector]]
+
+      ds2.collect.run() ==
+        Seq(X6(x5.a, x5.b, x5.c, x5.d, x5.e, Vectors.dense(if (x5.a) 1D else 0D, x5.b.toDouble, x5.c.toDouble, x5.d.toDouble)))
+    }
+
+    check(prop[String])
+    check(prop[Double])
+    check(prop2[Long])
+    check(prop2[Boolean])
   }
 
   test("create() compiles only with correct inputs") {

--- a/ml/src/test/scala/frameless/ml/regression/RegressionIntegrationTests.scala
+++ b/ml/src/test/scala/frameless/ml/regression/RegressionIntegrationTests.scala
@@ -16,13 +16,13 @@ class RegressionIntegrationTests extends FramelessMlSuite with MustMatchers {
     val trainingDataDs = TypedDataset.create(Seq.fill(10)(Data(0D, 10, 0D)))
 
     case class Features(field1: Double, field2: Int)
-    val vectorAssembler = TypedVectorAssembler.create[Features]()
+    val vectorAssembler = TypedVectorAssembler[Features]
 
     case class DataWithFeatures(field1: Double, field2: Int, field3: Double, features: Vector)
     val dataWithFeatures = vectorAssembler.transform(trainingDataDs).run().as[DataWithFeatures]
 
     case class RFInputs(field3: Double, features: Vector)
-    val rf = TypedRandomForestRegressor.create[RFInputs]()
+    val rf = TypedRandomForestRegressor[RFInputs]
 
     val model = rf.fit(dataWithFeatures).run()
 

--- a/ml/src/test/scala/frameless/ml/regression/RegressionIntegrationTests.scala
+++ b/ml/src/test/scala/frameless/ml/regression/RegressionIntegrationTests.scala
@@ -19,22 +19,22 @@ class RegressionIntegrationTests extends FramelessMlSuite with MustMatchers {
     val vectorAssembler = TypedVectorAssembler.create[Features]()
 
     case class DataWithFeatures(field1: Double, field2: Int, field3: Double, features: Vector)
-    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).as[DataWithFeatures]
+    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).run().as[DataWithFeatures]
 
     case class RFInputs(field3: Double, features: Vector)
     val rf = TypedRandomForestRegressor.create[RFInputs]()
 
-    val model = rf.fit(dataWithFeatures)
+    val model = rf.fit(dataWithFeatures).run()
 
     // Prediction
 
     val testData = TypedDataset.create(Seq(
       Data(0D, 10, 0D)
     ))
-    val testDataWithFeatures = vectorAssembler.transform(testData).as[DataWithFeatures]
+    val testDataWithFeatures = vectorAssembler.transform(testData).run().as[DataWithFeatures]
 
     case class PredictionResult(field1: Double, field2: Int, field3: Double, features: Vector, predictedField3: Double)
-    val predictionDs = model.transform(testDataWithFeatures).as[PredictionResult]
+    val predictionDs = model.transform(testDataWithFeatures).run().as[PredictionResult]
 
     val prediction = predictionDs.select(predictionDs.col('predictedField3)).collect.run().toList
 

--- a/ml/src/test/scala/frameless/ml/regression/RegressionIntegrationTests.scala
+++ b/ml/src/test/scala/frameless/ml/regression/RegressionIntegrationTests.scala
@@ -1,0 +1,44 @@
+package frameless
+package ml
+package regression
+
+import frameless.ml.feature.TypedVectorAssembler
+import org.apache.spark.ml.linalg.Vector
+import org.scalatest.MustMatchers
+
+class RegressionIntegrationTests extends FramelessMlSuite with MustMatchers {
+
+  test("predict field3 from field1 and field2 using a RandomForestRegressor") {
+    case class Data(field1: Double, field2: Int, field3: Double)
+
+    // Training
+
+    val trainingDataDs = TypedDataset.create(Seq.fill(10)(Data(0D, 10, 0D)))
+
+    case class Features(field1: Double, field2: Int)
+    val vectorAssembler = TypedVectorAssembler.create[Features]()
+
+    case class DataWithFeatures(field1: Double, field2: Int, field3: Double, features: Vector)
+    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).as[DataWithFeatures]
+
+    case class RFInputs(field3: Double, features: Vector)
+    val rf = TypedRandomForestRegressor.create[RFInputs]()
+
+    val model = rf.fit(dataWithFeatures)
+
+    // Prediction
+
+    val testData = TypedDataset.create(Seq(
+      Data(0D, 10, 0D)
+    ))
+    val testDataWithFeatures = vectorAssembler.transform(testData).as[DataWithFeatures]
+
+    case class PredictionResult(field1: Double, field2: Int, field3: Double, features: Vector, predictedField3: Double)
+    val predictionDs = model.transform(testDataWithFeatures).as[PredictionResult]
+
+    val prediction = predictionDs.select(predictionDs.col('predictedField3)).collect.run().toList
+
+    prediction mustEqual List(0D)
+  }
+
+}

--- a/ml/src/test/scala/frameless/ml/regression/RegressionIntegrationTests.scala
+++ b/ml/src/test/scala/frameless/ml/regression/RegressionIntegrationTests.scala
@@ -19,7 +19,7 @@ class RegressionIntegrationTests extends FramelessMlSuite with MustMatchers {
     val vectorAssembler = TypedVectorAssembler[Features]
 
     case class DataWithFeatures(field1: Double, field2: Int, field3: Double, features: Vector)
-    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).run().as[DataWithFeatures]
+    val dataWithFeatures = vectorAssembler.transform(trainingDataDs).as[DataWithFeatures]
 
     case class RFInputs(field3: Double, features: Vector)
     val rf = TypedRandomForestRegressor[RFInputs]
@@ -31,10 +31,10 @@ class RegressionIntegrationTests extends FramelessMlSuite with MustMatchers {
     val testData = TypedDataset.create(Seq(
       Data(0D, 10, 0D)
     ))
-    val testDataWithFeatures = vectorAssembler.transform(testData).run().as[DataWithFeatures]
+    val testDataWithFeatures = vectorAssembler.transform(testData).as[DataWithFeatures]
 
     case class PredictionResult(field1: Double, field2: Int, field3: Double, features: Vector, predictedField3: Double)
-    val predictionDs = model.transform(testDataWithFeatures).run().as[PredictionResult]
+    val predictionDs = model.transform(testDataWithFeatures).as[PredictionResult]
 
     val prediction = predictionDs.select(predictionDs.col('predictedField3)).collect.run().toList
 

--- a/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
+++ b/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
@@ -15,7 +15,7 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
 
   test("fit() returns a correct TypedTransformer") {
     val prop = forAll { x2: X2[Double, Vector] =>
-      val rf = TypedRandomForestRegressor.create[X2[Double, Vector]]()
+      val rf = TypedRandomForestRegressor[X2[Double, Vector]]
       val ds = TypedDataset.create(Seq(x2))
       val model = rf.fit(ds).run()
       val pDs = model.transform(ds).run().as[X3[Double, Vector, Double]]
@@ -24,7 +24,7 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
     }
 
     val prop2 = forAll { x2: X2[Vector, Double] =>
-      val rf = TypedRandomForestRegressor.create[X2[Vector, Double]]()
+      val rf = TypedRandomForestRegressor[X2[Vector, Double]]
       val ds = TypedDataset.create(Seq(x2))
       val model = rf.fit(ds).run()
       val pDs = model.transform(ds).run().as[X3[Vector, Double, Double]]
@@ -33,7 +33,7 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
     }
 
     def prop3[A: TypedEncoder: Arbitrary] = forAll { x3: X3[Vector, Double, A] =>
-      val rf = TypedRandomForestRegressor.create[X2[Vector, Double]]()
+      val rf = TypedRandomForestRegressor[X2[Vector, Double]]
       val ds = TypedDataset.create(Seq(x3))
       val model = rf.fit(ds).run()
       val pDs = model.transform(ds).run().as[X4[Vector, Double, A, Double]]
@@ -48,7 +48,7 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
   }
 
   test("param setting is retained") {
-    val rf = TypedRandomForestRegressor.create[X2[Double, Vector]]()
+    val rf = TypedRandomForestRegressor[X2[Double, Vector]]
       .setNumTrees(10)
       .setMaxBins(100)
       .setFeatureSubsetStrategy(FeatureSubsetStrategy.All)

--- a/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
+++ b/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
@@ -17,8 +17,8 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
     val prop = forAll { x2: X2[Double, Vector] =>
       val rf = TypedRandomForestRegressor.create[X2[Double, Vector]]()
       val ds = TypedDataset.create(Seq(x2))
-      val model = rf.fit(ds)
-      val pDs = model.transform(ds).as[X3[Double, Vector, Double]]
+      val model = rf.fit(ds).run()
+      val pDs = model.transform(ds).run().as[X3[Double, Vector, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
     }
@@ -26,8 +26,8 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
     val prop2 = forAll { x2: X2[Vector, Double] =>
       val rf = TypedRandomForestRegressor.create[X2[Vector, Double]]()
       val ds = TypedDataset.create(Seq(x2))
-      val model = rf.fit(ds)
-      val pDs = model.transform(ds).as[X3[Vector, Double, Double]]
+      val model = rf.fit(ds).run()
+      val pDs = model.transform(ds).run().as[X3[Vector, Double, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
     }
@@ -35,8 +35,8 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
     def prop3[A: TypedEncoder: Arbitrary] = forAll { x3: X3[Vector, Double, A] =>
       val rf = TypedRandomForestRegressor.create[X2[Vector, Double]]()
       val ds = TypedDataset.create(Seq(x3))
-      val model = rf.fit(ds)
-      val pDs = model.transform(ds).as[X4[Vector, Double, A, Double]]
+      val model = rf.fit(ds).run()
+      val pDs = model.transform(ds).run().as[X4[Vector, Double, A, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b), pDs.col('c)).collect.run() == Seq((x3.a, x3.b, x3.c))
     }
@@ -55,7 +55,7 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
       .setMaxDepth(10)
 
     val ds = TypedDataset.create(Seq(X2(0D, Vectors.dense(0D))))
-    val model = rf.fit(ds)
+    val model = rf.fit(ds).run()
 
     model.transformer.getNumTrees mustEqual 10
     model.transformer.getMaxBins mustEqual 100

--- a/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
+++ b/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
@@ -1,0 +1,74 @@
+package frameless
+package ml
+package regression
+
+import shapeless.test.illTyped
+import org.apache.spark.ml.linalg._
+import frameless.ml.regression.TypedRandomForestRegressor.FeatureSubsetStrategy
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.scalatest.MustMatchers
+
+class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers {
+  implicit val arbVectorNonEmpty: Arbitrary[Vector] =
+    Arbitrary(Generators.arbVector.arbitrary suchThat (_.size > 0)) // vector must not be empty for RandomForestRegressor
+
+  test("fit() returns a correct TypedTransformer") {
+    val prop = forAll { x2: X2[Double, Vector] =>
+      val rf = TypedRandomForestRegressor.create[X2[Double, Vector]]()
+      val ds = TypedDataset.create(Seq(x2))
+      val model = rf.fit(ds)
+      val pDs = model.transform(ds).as[X3[Double, Vector, Double]]
+
+      pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
+    }
+
+    val prop2 = forAll { x2: X2[Vector, Double] =>
+      val rf = TypedRandomForestRegressor.create[X2[Vector, Double]]()
+      val ds = TypedDataset.create(Seq(x2))
+      val model = rf.fit(ds)
+      val pDs = model.transform(ds).as[X3[Vector, Double, Double]]
+
+      pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
+    }
+
+    def prop3[A: TypedEncoder: Arbitrary] = forAll { x3: X3[Vector, Double, A] =>
+      val rf = TypedRandomForestRegressor.create[X2[Vector, Double]]()
+      val ds = TypedDataset.create(Seq(x3))
+      val model = rf.fit(ds)
+      val pDs = model.transform(ds).as[X4[Vector, Double, A, Double]]
+
+      pDs.select(pDs.col('a), pDs.col('b), pDs.col('c)).collect.run() == Seq((x3.a, x3.b, x3.c))
+    }
+
+    check(prop)
+    check(prop2)
+    check(prop3[String])
+    check(prop3[Double])
+  }
+
+  test("param setting is retained") {
+    val rf = TypedRandomForestRegressor.create[X2[Double, Vector]]()
+      .setNumTrees(10)
+      .setMaxBins(100)
+      .setFeatureSubsetStrategy(FeatureSubsetStrategy.All)
+      .setMaxDepth(10)
+
+    val ds = TypedDataset.create(Seq(X2(0D, Vectors.dense(0D))))
+    val model = rf.fit(ds)
+
+    model.transformer.getNumTrees mustEqual 10
+    model.transformer.getMaxBins mustEqual 100
+    model.transformer.getFeatureSubsetStrategy mustEqual "all"
+    model.transformer.getMaxDepth mustEqual 10
+  }
+
+  test("create() compiles only with correct inputs") {
+    illTyped("TypedRandomForestRegressor.create[Double]()")
+    illTyped("TypedRandomForestRegressor.create[X1[Double]]()")
+    illTyped("TypedRandomForestRegressor.create[X2[Double, Double]]()")
+    illTyped("TypedRandomForestRegressor.create[X3[Vector, Double, Int]]()")
+    illTyped("TypedRandomForestRegressor.create[X2[Vector, String]]()")
+  }
+
+}

--- a/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
+++ b/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
@@ -19,7 +19,7 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
       val rf = TypedRandomForestRegressor[X2[Double, Vector]]
       val ds = TypedDataset.create(Seq(x2))
       val model = rf.fit(ds).run()
-      val pDs = model.transform(ds).run().as[X3[Double, Vector, Double]]
+      val pDs = model.transform(ds).as[X3[Double, Vector, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
     }
@@ -28,7 +28,7 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
       val rf = TypedRandomForestRegressor[X2[Vector, Double]]
       val ds = TypedDataset.create(Seq(x2))
       val model = rf.fit(ds).run()
-      val pDs = model.transform(ds).run().as[X3[Vector, Double, Double]]
+      val pDs = model.transform(ds).as[X3[Vector, Double, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b)).collect.run() == Seq(x2.a -> x2.b)
     }
@@ -37,7 +37,7 @@ class TypedRandomForestRegressorTests extends FramelessMlSuite with MustMatchers
       val rf = TypedRandomForestRegressor[X2[Vector, Double]]
       val ds = TypedDataset.create(Seq(x3))
       val model = rf.fit(ds).run()
-      val pDs = model.transform(ds).run().as[X4[Vector, Double, A, Double]]
+      val pDs = model.transform(ds).as[X4[Vector, Double, A, Double]]
 
       pDs.select(pDs.col('a), pDs.col('b), pDs.col('c)).collect.run() == Seq((x3.a, x3.b, x3.c))
     }

--- a/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
+++ b/ml/src/test/scala/frameless/ml/regression/TypedRandomForestRegressorTests.scala
@@ -2,9 +2,9 @@ package frameless
 package ml
 package regression
 
+import frameless.ml.params.trees.FeatureSubsetStrategy
 import shapeless.test.illTyped
 import org.apache.spark.ml.linalg._
-import frameless.ml.regression.TypedRandomForestRegressor.FeatureSubsetStrategy
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 import org.scalatest.MustMatchers


### PR DESCRIPTION
This PR introduces ```TypedEstimator``` and ```TypedTransformer``` to frameless-ml, the type-safe equivalents of Spark ML's ```Estimator``` and ```Transformer```. The goal is to provide a type-safe API for Spark ML (which currently only deals with DataFrames, the data structure with the lowest level of type-safety in Spark).

Several ML models and ML transformers have been implemented extending ```TypedEstimator``` and ```TypedTransformer```, such as ```TypedRandomForestRegressor```, ```TypedRandomForestClassifier```, ```TypedIndexToString```, ```TypedVectorAssemlber``` and ```TypedStringIndexer```. The final goal is to provide a typed version for every estimator and transformer of Spark ML.

As an example, the following code snippet uses a Random Forest algorithm to predict ```field3``` from ```field1``` and ```field2```. Every transformation and fitting are type-safe (input fields are checked for correctness at compile-time), so no runtime exception can be thrown from the below code. For non-frameless user, please note that ```typedDataset.as[...]``` is a type-safe cast.

```scala
import frameless._
import frameless.syntax._
import frameless.ml._
import frameless.ml.feature.TypedVectorAssembler
import frameless.ml.regression.TypedRandomForestRegressor
import org.apache.spark.ml.linalg.Vector

case class Data(field1: Double, field2: Int, field3: Double)

// Training

val trainingData = TypedDataset.create(
  Seq.fill(10)(Data(0D, 10, 0D))
)

case class Features(field1: Double, field2: Int)
val assembler = TypedVectorAssembler[Features]

case class DataWithFeatures(field1: Double, field2: Int, field3: Double, features: Vector)
val trainingDataWithFeatures = assembler.transform(trainingData).as[DataWithFeatures]

case class RFInputs(field3: Double, features: Vector)
val rf = TypedRandomForestRegressor[RFInputs]

val model = rf.fit(trainingDataWithFeatures).run()

// Prediction

val testData = TypedDataset.create(Seq(Data(0D, 10, 0D)))
val testDataWithFeatures = assembler.transform(testData).as[DataWithFeatures]

case class PredictionResult(
  field1: Double, 
  field2: Int, 
  field3: Double, 
  features: Vector, 
  predictedField3: Double
)
val results = model.transform(testDataWithFeatures).as[PredictionResult]

val predictions = results.select(results.col('predictedField3))
  .collect
  .run()

predictions == Seq(0D) // returns true
```

In the above example, ```TypedRandomForestRegressor[RFInputs]``` will compile only if the given ```RFInputs``` case class contains only one field of type Double (the label) and one field of type Vector (the features). 
The resulting ```rf.fit(trainingDataWithFeatures)``` fitting will only compile if ```trainingData``` contains the same fields (names and types) as ```RFInputs```.

All checks are done at compile-time so runtime performance is the same as with Spark ML DataFrame API (or even better if you consider the fact that a ML model input mismatch is now catched at compile-time rather than after one hour of feature engineering on your Spark cluster ;))

I have not updated the documentation for now, I prefer to wait for reviews and then write it once we all agree on the API.
