### PR TITLE
add withColumn to a case class

### DIFF
--- a/dataset/src/main/scala/frameless/ops/SmartProject.scala
+++ b/dataset/src/main/scala/frameless/ops/SmartProject.scala
@@ -19,7 +19,7 @@ object SmartProject {
     * @param tgen the LabelledGeneric derived for T
     * @param ugen the LabelledGeneric derived for U
     * @param keys the keys of U
-    * @param select selects all the keys of U from T
+    * @param select selects all the values from T using the keys of U
     * @param values selects all the values of LabeledGeneric[U]
     * @param typeEqualityProof proof that U and the projection of T have the same type
     * @param keysTraverse allows for traversing the keys of U

--- a/dataset/src/test/scala/frameless/WithColumnTest.scala
+++ b/dataset/src/test/scala/frameless/WithColumnTest.scala
@@ -2,18 +2,48 @@ package frameless
 
 import org.scalacheck.Prop
 import org.scalacheck.Prop._
+import shapeless.test.illTyped
 
 class WithColumnTest extends TypedDatasetSuite {
-  test("append five columns") {
+  import WithColumnTest._
+
+  test("fail to compile on missing value") {
+    val f: TypedDataset[X] = TypedDataset.create(X(1,1) :: X(1,1) :: X(1,10) :: Nil)
+    illTyped {
+      """val fNew: TypedDataset[XMissing] = f.withColumn[XMissing](f('j) === 10)"""
+    }
+  }
+
+  test("fail to compile on different column name") {
+    val f: TypedDataset[X] = TypedDataset.create(X(1,1) :: X(1,1) :: X(1,10) :: Nil)
+    illTyped {
+      """val fNew: TypedDataset[XDifferentColumnName] = f.withColumn[XDifferentColumnName](f('j) === 10)"""
+    }
+  }
+
+  test("fail to compile on added column name") {
+    val f: TypedDataset[X] = TypedDataset.create(X(1,1) :: X(1,1) :: X(1,10) :: Nil)
+    illTyped {
+      """val fNew: TypedDataset[XAdded] = f.withColumn[XAdded](f('j) === 10)"""
+    }
+  }
+
+  test("fail to compile on wrong typed column") {
+    val f: TypedDataset[X] = TypedDataset.create(X(1,1) :: X(1,1) :: X(1,10) :: Nil)
+    illTyped {
+      """val fNew: TypedDataset[XWrongType] = f.withColumn[XWrongType](f('j) === 10)"""
+    }
+  }
+
+  test("append four columns") {
     def prop[A: TypedEncoder](value: A): Prop = {
       val d = TypedDataset.create(X1(value) :: Nil)
-      val d1 = d.withColumn(d('a))
-      val d2 = d1.withColumn(d1('_1))
-      val d3 = d2.withColumn(d2('_2))
-      val d4 = d3.withColumn(d3('_3))
-      val d5 = d4.withColumn(d4('_4))
+      val d1 = d.withColumn[X2[A, A]](d('a))
+      val d2 = d1.withColumn[X3[A, A, A]](d1('b))
+      val d3 = d2.withColumn[X4[A, A, A, A]](d2('c))
+      val d4 = d3.withColumn[X5[A, A, A, A, A]](d3('d))
 
-      (value, value, value, value, value, value) ?= d5.collect().run().head
+      X5(value, value, value, value, value) ?= d4.collect().run().head
     }
 
     check(prop[Int] _)
@@ -22,4 +52,13 @@ class WithColumnTest extends TypedDatasetSuite {
     check(prop[SQLDate] _)
     check(prop[Option[X1[Boolean]]] _)
   }
+}
+
+object WithColumnTest {
+  case class X(i: Int, j: Int)
+  case class XMissing(i: Int, k: Boolean)
+  case class XDifferentColumnName(i: Int, ji: Int, k: Boolean)
+  case class XAdded(i: Int, j: Int, k: Boolean, l: Int)
+  case class XWrongType(i: Int, j: Int, k: Int)
+  case class XGood(i: Int, j: Int, k: Boolean)
 }

--- a/dataset/src/test/scala/frameless/WithColumnTupledTest.scala
+++ b/dataset/src/test/scala/frameless/WithColumnTupledTest.scala
@@ -1,0 +1,25 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+
+class WithColumnTupledTest extends TypedDatasetSuite {
+  test("append five columns") {
+    def prop[A: TypedEncoder](value: A): Prop = {
+      val d = TypedDataset.create(X1(value) :: Nil)
+      val d1 = d.withColumnTupled(d('a))
+      val d2 = d1.withColumnTupled(d1('_1))
+      val d3 = d2.withColumnTupled(d2('_2))
+      val d4 = d3.withColumnTupled(d3('_3))
+      val d5 = d4.withColumnTupled(d4('_4))
+
+      (value, value, value, value, value, value) ?= d5.collect().run().head
+    }
+
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[String] _)
+    check(prop[SQLDate] _)
+    check(prop[Option[X1[Boolean]]] _)
+  }
+}


### PR DESCRIPTION
Connects to #207 

Allows the addition of a column similar to `withColumn` https://github.com/typelevel/frameless/blob/daca214a740343e1263a94d9124b75c0ddaad6ae/dataset/src/main/scala/frameless/TypedDataset.scala#L616 but returning a case class rather than tuple. This is especially useful if your starting type has > 22 columns.

I'd love feedback on the general approach, and a better name for the method.

One thing that's still missing is the ability to add multiple columns in one go rather than requiring a case class representation for each new column added (see #188). I can take a stab at that if this is deemed reasonable.