### PR TITLE
Anonymize/reformat all implicit parameter lists

### DIFF
--- a/dataset/src/main/scala/frameless/RecordEncoder.scala
+++ b/dataset/src/main/scala/frameless/RecordEncoder.scala
@@ -21,81 +21,81 @@ trait RecordEncoderFields[T <: HList] extends Serializable {
 }
 
 object RecordEncoderFields {
-  implicit def deriveRecordLast[K <: Symbol, H](
-    implicit
-    key: Witness.Aux[K],
-    head: TypedEncoder[H]
-  ): RecordEncoderFields[FieldType[K, H] :: HNil] = new RecordEncoderFields[FieldType[K, H] :: HNil] {
-    def value: List[RecordEncoderField] = RecordEncoderField(0, key.value.name, head) :: Nil
-  }
-
-  implicit def deriveRecordCons[K <: Symbol, H, T <: HList](
-    implicit
-    key: Witness.Aux[K],
-    head: TypedEncoder[H],
-    tail: RecordEncoderFields[T]
-  ): RecordEncoderFields[FieldType[K, H] :: T] = new RecordEncoderFields[FieldType[K, H] :: T] {
-    def value: List[RecordEncoderField] = {
-      val fieldName = key.value.name
-      val fieldEncoder = RecordEncoderField(0, fieldName, head)
-
-      fieldEncoder :: tail.value.map(x => x.copy(ordinal = x.ordinal + 1))
+  implicit def deriveRecordLast[K <: Symbol, H]
+    (implicit
+      key: Witness.Aux[K],
+      head: TypedEncoder[H]
+    ): RecordEncoderFields[FieldType[K, H] :: HNil] = new RecordEncoderFields[FieldType[K, H] :: HNil] {
+      def value: List[RecordEncoderField] = RecordEncoderField(0, key.value.name, head) :: Nil
     }
-  }
+
+  implicit def deriveRecordCons[K <: Symbol, H, T <: HList]
+    (implicit
+      key: Witness.Aux[K],
+      head: TypedEncoder[H],
+      tail: RecordEncoderFields[T]
+    ): RecordEncoderFields[FieldType[K, H] :: T] = new RecordEncoderFields[FieldType[K, H] :: T] {
+      def value: List[RecordEncoderField] = {
+        val fieldName = key.value.name
+        val fieldEncoder = RecordEncoderField(0, fieldName, head)
+
+        fieldEncoder :: tail.value.map(x => x.copy(ordinal = x.ordinal + 1))
+      }
+    }
 }
 
-class RecordEncoder[F, G <: HList](
-  implicit
-  lgen: LabelledGeneric.Aux[F, G],
-  fields: Lazy[RecordEncoderFields[G]],
-  classTag: ClassTag[F]
-) extends TypedEncoder[F] {
-  def nullable: Boolean = false
+class RecordEncoder[F, G <: HList]
+  (implicit
+    lgen: LabelledGeneric.Aux[F, G],
+    fields: Lazy[RecordEncoderFields[G]],
+    classTag: ClassTag[F]
+  ) extends TypedEncoder[F] {
+    def nullable: Boolean = false
 
-  def jvmRepr: DataType = FramelessInternals.objectTypeFor[F]
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[F]
 
-  def catalystRepr: DataType = {
-    val structFields = fields.value.value.map { field =>
-      StructField(
-        name = field.name,
-        dataType = field.encoder.catalystRepr,
-        nullable = field.encoder.nullable,
-        metadata = Metadata.empty
-      )
-    }
-
-    StructType(structFields)
-  }
-
-  def toCatalyst(path: Expression): Expression = {
-    val nameExprs = fields.value.value.map { field =>
-      Literal(field.name)
-    }
-
-    val valueExprs = fields.value.value.map { field =>
-      val fieldPath = Invoke(path, field.name, field.encoder.jvmRepr, Nil)
-      field.encoder.toCatalyst(fieldPath)
-    }
-
-    // the way exprs are encoded in CreateNamedStruct
-    val exprs = nameExprs.zip(valueExprs).flatMap {
-      case (nameExpr, valueExpr) => nameExpr :: valueExpr :: Nil
-    }
-
-    CreateNamedStruct(exprs)
-  }
-
-  def fromCatalyst(path: Expression): Expression = {
-    val exprs = fields.value.value.map { field =>
-      val fieldPath = path match {
-        case BoundReference(ordinal, dataType, nullable) =>
-          GetColumnByOrdinal(field.ordinal, field.encoder.jvmRepr)
-        case other =>
-          GetStructField(path, field.ordinal, Some(field.name))
+    def catalystRepr: DataType = {
+      val structFields = fields.value.value.map { field =>
+        StructField(
+          name = field.name,
+          dataType = field.encoder.catalystRepr,
+          nullable = field.encoder.nullable,
+          metadata = Metadata.empty
+        )
       }
-      field.encoder.fromCatalyst(fieldPath)
+
+      StructType(structFields)
     }
 
-    NewInstance(classTag.runtimeClass, exprs, jvmRepr, propagateNull = true)
-  }
+    def toCatalyst(path: Expression): Expression = {
+      val nameExprs = fields.value.value.map { field =>
+        Literal(field.name)
+      }
+
+      val valueExprs = fields.value.value.map { field =>
+        val fieldPath = Invoke(path, field.name, field.encoder.jvmRepr, Nil)
+        field.encoder.toCatalyst(fieldPath)
+      }
+
+      // the way exprs are encoded in CreateNamedStruct
+      val exprs = nameExprs.zip(valueExprs).flatMap {
+        case (nameExpr, valueExpr) => nameExpr :: valueExpr :: Nil
+      }
+
+      CreateNamedStruct(exprs)
+    }
+
+    def fromCatalyst(path: Expression): Expression = {
+      val exprs = fields.value.value.map { field =>
+        val fieldPath = path match {
+          case BoundReference(ordinal, dataType, nullable) =>
+            GetColumnByOrdinal(field.ordinal, field.encoder.jvmRepr)
+          case other =>
+            GetStructField(path, field.ordinal, Some(field.name))
+        }
+        field.encoder.fromCatalyst(fieldPath)
+      }
+
+      NewInstance(classTag.runtimeClass, exprs, jvmRepr, propagateNull = true)
+    }
 }

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -412,7 +412,7 @@ sealed class TypedAggregate[T, U](val expr: Expression)(
   val uencoder: TypedEncoder[U]
 ) extends UntypedExpression[T] {
 
-  def this(column: Column)(implicit uenc: TypedEncoder[U]) {
+  def this(column: Column)(implicit e: TypedEncoder[U]) {
     this(FramelessInternals.expr(column))
   }
 }
@@ -428,29 +428,25 @@ object TypedColumn {
   trait ExistsMany[T, K <: HList, V]
 
   object ExistsMany {
-    implicit def deriveCons[T, KH, KT <: HList, V0, V1](
-      implicit
-      head: Exists[T, KH, V0],
-      tail: ExistsMany[V0, KT, V1]
-    ): ExistsMany[T, KH :: KT, V1] = new ExistsMany[T, KH :: KT, V1] {}
+    implicit def deriveCons[T, KH, KT <: HList, V0, V1]
+      (implicit
+        head: Exists[T, KH, V0],
+        tail: ExistsMany[V0, KT, V1]
+      ): ExistsMany[T, KH :: KT, V1] =
+        new ExistsMany[T, KH :: KT, V1] {}
 
-    implicit def deriveHNil[T, K, V](
-      implicit
-      head: Exists[T, K, V]
-    ): ExistsMany[T, K :: HNil, V] = new ExistsMany[T, K :: HNil, V] {}
+    implicit def deriveHNil[T, K, V](implicit head: Exists[T, K, V]): ExistsMany[T, K :: HNil, V] =
+      new ExistsMany[T, K :: HNil, V] {}
   }
 
   object Exists {
-    def apply[T, V](column: Witness)(
-      implicit
-      exists: Exists[T, column.T, V]
-    ): Exists[T, column.T, V] = exists
+    def apply[T, V](column: Witness)(implicit e: Exists[T, column.T, V]): Exists[T, column.T, V] = e
 
-    implicit def deriveRecord[T, H <: HList, K, V](
-      implicit
-      lgen: LabelledGeneric.Aux[T, H],
-      selector: Selector.Aux[H, K, V]
-    ): Exists[T, K, V] = new Exists[T, K, V] {}
+    implicit def deriveRecord[T, H <: HList, K, V]
+      (implicit
+        i0: LabelledGeneric.Aux[T, H],
+        i1: Selector.Aux[H, K, V]
+      ): Exists[T, K, V] = new Exists[T, K, V] {}
   }
 
   implicit class OrderedTypedColumnSyntax[T, U: CatalystOrdered](col: TypedColumn[T, U]) {

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -94,7 +94,6 @@ object TypedEncoder {
 
   implicit val charEncoder: TypedEncoder[Char] = new TypedEncoder[Char] {
     // tricky because while Char is primitive type, Spark doesn't support it
-
     implicit val charAsString: Injection[java.lang.Character, String] = new Injection[java.lang.Character, String] {
       def apply(a: java.lang.Character): String = String.valueOf(a)
       def invert(b: String): java.lang.Character = {
@@ -196,176 +195,172 @@ object TypedEncoder {
       )
   }
 
-  implicit def arrayEncoder[T: ClassTag](
-    implicit
-    encodeT: TypedEncoder[T]
-  ): TypedEncoder[Array[T]] = new TypedEncoder[Array[T]] {
-    def nullable: Boolean = false
-
-    def jvmRepr: DataType = encodeT.jvmRepr match {
-      case ByteType => BinaryType
-      case _        => FramelessInternals.objectTypeFor[Array[T]]
-    }
-
-    def catalystRepr: DataType = encodeT.jvmRepr match {
-      case ByteType => BinaryType
-      case _        => ArrayType(encodeT.catalystRepr, encodeT.nullable)
-    }
-
-    def toCatalyst(path: Expression): Expression =
-      encodeT.jvmRepr match {
-        case IntegerType | LongType | DoubleType | FloatType | ShortType | BooleanType  =>
-          StaticInvoke(classOf[UnsafeArrayData], catalystRepr, "fromPrimitiveArray", path :: Nil)
-
-        case ByteType => path
-
-        case otherwise => MapObjects(encodeT.toCatalyst, path, encodeT.jvmRepr, encodeT.nullable)
-      }
-
-    def fromCatalyst(path: Expression): Expression =
-      encodeT.jvmRepr match {
-        case IntegerType => Invoke(path, "toIntArray", jvmRepr)
-        case LongType => Invoke(path, "toLongArray", jvmRepr)
-        case DoubleType => Invoke(path, "toDoubleArray", jvmRepr)
-        case FloatType => Invoke(path, "toFloatArray", jvmRepr)
-        case ShortType => Invoke(path, "toShortArray", jvmRepr)
-        case BooleanType => Invoke(path, "toBooleanArray", jvmRepr)
-
-        case ByteType => path
-
-        case otherwise =>
-          Invoke(MapObjects(encodeT.fromCatalyst, path, encodeT.catalystRepr, encodeT.nullable), "array", jvmRepr)
-      }
-  }
-
-  implicit def collectionEncoder[C[X] <: Seq[X], T](
-    implicit
-    encodeT: TypedEncoder[T],
-    CT: ClassTag[C[T]]): TypedEncoder[C[T]] =
-    new TypedEncoder[C[T]] {
+  implicit def arrayEncoder[T: ClassTag](implicit encodeT: TypedEncoder[T]): TypedEncoder[Array[T]] =
+    new TypedEncoder[Array[T]] {
       def nullable: Boolean = false
 
-      def jvmRepr: DataType = FramelessInternals.objectTypeFor[C[T]](CT)
+      def jvmRepr: DataType = encodeT.jvmRepr match {
+        case ByteType => BinaryType
+        case _        => FramelessInternals.objectTypeFor[Array[T]]
+      }
 
-      def catalystRepr: DataType = ArrayType(encodeT.catalystRepr, encodeT.nullable)
+      def catalystRepr: DataType = encodeT.jvmRepr match {
+        case ByteType => BinaryType
+        case _        => ArrayType(encodeT.catalystRepr, encodeT.nullable)
+      }
 
       def toCatalyst(path: Expression): Expression =
-        if (ScalaReflection.isNativeType(encodeT.jvmRepr))
-          NewInstance(classOf[GenericArrayData], path :: Nil, catalystRepr)
-        else MapObjects(encodeT.toCatalyst, path, encodeT.jvmRepr, encodeT.nullable)
+        encodeT.jvmRepr match {
+          case IntegerType | LongType | DoubleType | FloatType | ShortType | BooleanType  =>
+            StaticInvoke(classOf[UnsafeArrayData], catalystRepr, "fromPrimitiveArray", path :: Nil)
+
+          case ByteType => path
+
+          case otherwise => MapObjects(encodeT.toCatalyst, path, encodeT.jvmRepr, encodeT.nullable)
+        }
 
       def fromCatalyst(path: Expression): Expression =
-        MapObjects(
-          encodeT.fromCatalyst,
-          path,
-          encodeT.catalystRepr,
-          encodeT.nullable,
-          Some(CT.runtimeClass) // This will cause MapObjects to build a collection of type C[_] directly
-        )
+        encodeT.jvmRepr match {
+          case IntegerType => Invoke(path, "toIntArray", jvmRepr)
+          case LongType => Invoke(path, "toLongArray", jvmRepr)
+          case DoubleType => Invoke(path, "toDoubleArray", jvmRepr)
+          case FloatType => Invoke(path, "toFloatArray", jvmRepr)
+          case ShortType => Invoke(path, "toShortArray", jvmRepr)
+          case BooleanType => Invoke(path, "toBooleanArray", jvmRepr)
+
+          case ByteType => path
+
+          case otherwise =>
+            Invoke(MapObjects(encodeT.fromCatalyst, path, encodeT.catalystRepr, encodeT.nullable), "array", jvmRepr)
+        }
     }
 
-  implicit def mapEncoder[A: NotCatalystNullable, B](
-    implicit
-    encodeA: TypedEncoder[A],
-    encodeB: TypedEncoder[B]
-  ): TypedEncoder[Map[A, B]] = new TypedEncoder[Map[A, B]] {
-    def nullable: Boolean = false
+  implicit def collectionEncoder[C[X] <: Seq[X], T]
+    (implicit
+      encodeT: TypedEncoder[T],
+      CT: ClassTag[C[T]]
+    ): TypedEncoder[C[T]] =
+      new TypedEncoder[C[T]] {
+        def nullable: Boolean = false
 
-    def jvmRepr: DataType = FramelessInternals.objectTypeFor[Map[A, B]]
+        def jvmRepr: DataType = FramelessInternals.objectTypeFor[C[T]](CT)
 
-    def catalystRepr: DataType = MapType(encodeA.catalystRepr, encodeB.catalystRepr, encodeB.nullable)
+        def catalystRepr: DataType = ArrayType(encodeT.catalystRepr, encodeT.nullable)
 
-    def fromCatalyst(path: Expression): Expression = {
-      val keyArrayType = ArrayType(encodeA.catalystRepr, containsNull = false)
-      val keyData = Invoke(
-        MapObjects(
-          encodeA.fromCatalyst,
-          Invoke(path, "keyArray", keyArrayType),
-          encodeA.catalystRepr
-        ),
-        "array",
-        FramelessInternals.objectTypeFor[Array[Any]]
-      )
+        def toCatalyst(path: Expression): Expression =
+          if (ScalaReflection.isNativeType(encodeT.jvmRepr))
+            NewInstance(classOf[GenericArrayData], path :: Nil, catalystRepr)
+          else MapObjects(encodeT.toCatalyst, path, encodeT.jvmRepr, encodeT.nullable)
 
-      val valueArrayType = ArrayType(encodeB.catalystRepr, encodeB.nullable)
-      val valueData = Invoke(
-        MapObjects(
-          encodeB.fromCatalyst,
-          Invoke(path, "valueArray", valueArrayType),
-          encodeB.catalystRepr
-        ),
-        "array",
-        FramelessInternals.objectTypeFor[Array[Any]]
-      )
-
-      StaticInvoke(
-        ArrayBasedMapData.getClass,
-        jvmRepr,
-        "toScalaMap",
-        keyData :: valueData :: Nil)
-    }
-
-    def toCatalyst(path: Expression): Expression = ExternalMapToCatalyst(
-      path,
-      encodeA.jvmRepr,
-      encodeA.toCatalyst,
-      encodeB.jvmRepr,
-      encodeB.toCatalyst,
-      encodeB.nullable)
-
-  }
-
-  implicit def optionEncoder[A](
-    implicit
-    underlying: TypedEncoder[A]
-  ): TypedEncoder[Option[A]] = new TypedEncoder[Option[A]] {
-    def nullable: Boolean = true
-
-    def jvmRepr: DataType = FramelessInternals.objectTypeFor[Option[A]](classTag)
-    def catalystRepr: DataType = underlying.catalystRepr
-
-    def toCatalyst(path: Expression): Expression = {
-      // for primitive types we must manually unbox the value of the object
-      underlying.jvmRepr match {
-        case IntegerType =>
-          Invoke(
-            UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Integer], path),
-            "intValue",
-            IntegerType)
-        case LongType =>
-          Invoke(
-            UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Long], path),
-            "longValue",
-            LongType)
-        case DoubleType =>
-          Invoke(
-            UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Double], path),
-            "doubleValue",
-            DoubleType)
-        case FloatType =>
-          Invoke(
-            UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Float], path),
-            "floatValue",
-            FloatType)
-        case ShortType =>
-          Invoke(
-            UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Short], path),
-            "shortValue",
-            ShortType)
-        case ByteType =>
-          Invoke(
-            UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Byte], path),
-            "byteValue",
-            ByteType)
-        case BooleanType =>
-          Invoke(
-            UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Boolean], path),
-            "booleanValue",
-            BooleanType)
-
-        case other => underlying.toCatalyst(UnwrapOption(underlying.jvmRepr, path))
+        def fromCatalyst(path: Expression): Expression =
+          MapObjects(
+            encodeT.fromCatalyst,
+            path,
+            encodeT.catalystRepr,
+            encodeT.nullable,
+            Some(CT.runtimeClass) // This will cause MapObjects to build a collection of type C[_] directly
+          )
       }
+
+  implicit def mapEncoder[A: NotCatalystNullable, B]
+    (implicit
+      encodeA: TypedEncoder[A],
+      encodeB: TypedEncoder[B]
+    ): TypedEncoder[Map[A, B]] = new TypedEncoder[Map[A, B]] {
+      def nullable: Boolean = false
+
+      def jvmRepr: DataType = FramelessInternals.objectTypeFor[Map[A, B]]
+
+      def catalystRepr: DataType = MapType(encodeA.catalystRepr, encodeB.catalystRepr, encodeB.nullable)
+
+      def fromCatalyst(path: Expression): Expression = {
+        val keyArrayType = ArrayType(encodeA.catalystRepr, containsNull = false)
+        val keyData = Invoke(
+          MapObjects(
+            encodeA.fromCatalyst,
+            Invoke(path, "keyArray", keyArrayType),
+            encodeA.catalystRepr
+          ),
+          "array",
+          FramelessInternals.objectTypeFor[Array[Any]]
+        )
+
+        val valueArrayType = ArrayType(encodeB.catalystRepr, encodeB.nullable)
+        val valueData = Invoke(
+          MapObjects(
+            encodeB.fromCatalyst,
+            Invoke(path, "valueArray", valueArrayType),
+            encodeB.catalystRepr
+          ),
+          "array",
+          FramelessInternals.objectTypeFor[Array[Any]]
+        )
+
+        StaticInvoke(
+          ArrayBasedMapData.getClass,
+          jvmRepr,
+          "toScalaMap",
+          keyData :: valueData :: Nil)
+      }
+
+      def toCatalyst(path: Expression): Expression = ExternalMapToCatalyst(
+        path,
+        encodeA.jvmRepr,
+        encodeA.toCatalyst,
+        encodeB.jvmRepr,
+        encodeB.toCatalyst,
+        encodeB.nullable)
     }
+
+  implicit def optionEncoder[A](implicit underlying: TypedEncoder[A]): TypedEncoder[Option[A]] =
+    new TypedEncoder[Option[A]] {
+      def nullable: Boolean = true
+
+      def jvmRepr: DataType = FramelessInternals.objectTypeFor[Option[A]](classTag)
+      def catalystRepr: DataType = underlying.catalystRepr
+
+      def toCatalyst(path: Expression): Expression = {
+        // for primitive types we must manually unbox the value of the object
+        underlying.jvmRepr match {
+          case IntegerType =>
+            Invoke(
+              UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Integer], path),
+              "intValue",
+              IntegerType)
+          case LongType =>
+            Invoke(
+              UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Long], path),
+              "longValue",
+              LongType)
+          case DoubleType =>
+            Invoke(
+              UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Double], path),
+              "doubleValue",
+              DoubleType)
+          case FloatType =>
+            Invoke(
+              UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Float], path),
+              "floatValue",
+              FloatType)
+          case ShortType =>
+            Invoke(
+              UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Short], path),
+              "shortValue",
+              ShortType)
+          case ByteType =>
+            Invoke(
+              UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Byte], path),
+              "byteValue",
+              ByteType)
+          case BooleanType =>
+            Invoke(
+              UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Boolean], path),
+              "booleanValue",
+              BooleanType)
+
+          case other => underlying.toCatalyst(UnwrapOption(underlying.jvmRepr, path))
+        }
+      }
 
     def fromCatalyst(path: Expression): Expression =
       WrapOption(underlying.fromCatalyst(path), underlying.jvmRepr)
@@ -391,12 +386,12 @@ object TypedEncoder {
       }
 
   /** Encodes things as records if there is not Injection defined */
-  implicit def usingDerivation[F, G <: HList](
-    implicit
-    lgen: LabelledGeneric.Aux[F, G],
-    recordEncoder: Lazy[RecordEncoderFields[G]],
-    classTag: ClassTag[F]
-  ): TypedEncoder[F] = new RecordEncoder[F, G]
+  implicit def usingDerivation[F, G <: HList]
+    (implicit
+      i0: LabelledGeneric.Aux[F, G],
+      i1: Lazy[RecordEncoderFields[G]],
+      i2: ClassTag[F]
+    ): TypedEncoder[F] = new RecordEncoder[F, G]
 
   /** Encodes things using a Spark SQL's User Defined Type (UDT) if there is one defined in implicit */
   implicit def usingUserDefinedType[A >: Null : UserDefinedType : ClassTag]: TypedEncoder[A] = {

--- a/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
@@ -145,10 +145,7 @@ trait AggregateFunctions {
     *
     *       apache/spark
     */
-  def stddevPop[A, T](column: TypedColumn[T, A])(
-    implicit
-    evCanBeDoubleA: CatalystCast[A, Double]
-  ): TypedAggregate[T, Option[Double]] = {
+  def stddevPop[A, T](column: TypedColumn[T, A])(implicit ev: CatalystCast[A, Double]): TypedAggregate[T, Option[Double]] = {
     implicit val c1 = column.uencoder
 
     new TypedAggregate[T, Option[Double]](
@@ -164,10 +161,7 @@ trait AggregateFunctions {
     *
     *       apache/spark
     */
-  def stddevSamp[A, T](column: TypedColumn[T, A])(
-    implicit
-    evCanBeDoubleA: CatalystCast[A, Double]
-  ): TypedAggregate[T, Option[Double]] = {
+  def stddevSamp[A, T](column: TypedColumn[T, A])(implicit ev: CatalystCast[A, Double] ): TypedAggregate[T, Option[Double]] = {
     implicit val c1 = column.uencoder
 
     new TypedAggregate[T, Option[Double]](
@@ -226,18 +220,17 @@ trait AggregateFunctions {
     *
     *       apache/spark
     */
-  def corr[A, B, T](column1: TypedColumn[T, A], column2: TypedColumn[T, B])(
-    implicit
-    evCanBeDoubleA: CatalystCast[A, Double],
-    evCanBeDoubleB: CatalystCast[B, Double]
-  ): TypedAggregate[T, Option[Double]] = {
-    implicit val c1 = column1.uencoder
-    implicit val c2 = column2.uencoder
-
-    new TypedAggregate[T, Option[Double]](
-      untyped.corr(column1.cast[Double].untyped, column2.cast[Double].untyped)
-    )
-  }
+  def corr[A, B, T](column1: TypedColumn[T, A], column2: TypedColumn[T, B])
+    (implicit
+      i0: CatalystCast[A, Double],
+      i1: CatalystCast[B, Double]
+    ): TypedAggregate[T, Option[Double]] = {
+      implicit val c1 = column1.uencoder
+      implicit val c2 = column2.uencoder
+      new TypedAggregate[T, Option[Double]](
+        untyped.corr(column1.cast[Double].untyped, column2.cast[Double].untyped)
+      )
+    }
 
   /**
     * Aggregate function: returns the covariance of two collumns.
@@ -247,18 +240,17 @@ trait AggregateFunctions {
     *
     *       apache/spark
     */
-  def covarPop[A, B, T](column1: TypedColumn[T, A], column2: TypedColumn[T, B])(
-    implicit
-    evCanBeDoubleA: CatalystCast[A, Double],
-    evCanBeDoubleB: CatalystCast[B, Double]
-  ): TypedAggregate[T, Option[Double]] = {
-    implicit val c1 = column1.uencoder
-    implicit val c2 = column2.uencoder
-
-    new TypedAggregate[T, Option[Double]](
-      untyped.covar_pop(column1.cast[Double].untyped, column2.cast[Double].untyped)
-    )
-  }
+  def covarPop[A, B, T](column1: TypedColumn[T, A], column2: TypedColumn[T, B])
+    (implicit
+      i0: CatalystCast[A, Double],
+      i1: CatalystCast[B, Double]
+    ): TypedAggregate[T, Option[Double]] = {
+      implicit val c1 = column1.uencoder
+      implicit val c2 = column2.uencoder
+      new TypedAggregate[T, Option[Double]](
+        untyped.covar_pop(column1.cast[Double].untyped, column2.cast[Double].untyped)
+      )
+    }
 
   /**
     * Aggregate function: returns the covariance of two columns.
@@ -268,18 +260,17 @@ trait AggregateFunctions {
     *
     *       apache/spark
     */
-  def covarSamp[A, B, T](column1: TypedColumn[T, A], column2: TypedColumn[T, B])(
-    implicit
-    evCanBeDoubleA: CatalystCast[A, Double],
-    evCanBeDoubleB: CatalystCast[B, Double]
-  ): TypedAggregate[T, Option[Double]] = {
-    implicit val c1 = column1.uencoder
-    implicit val c2 = column2.uencoder
-
-    new TypedAggregate[T, Option[Double]](
-      untyped.covar_samp(column1.cast[Double].untyped, column2.cast[Double].untyped)
-    )
-  }
+  def covarSamp[A, B, T](column1: TypedColumn[T, A], column2: TypedColumn[T, B])
+    (implicit
+      i0: CatalystCast[A, Double],
+      i1: CatalystCast[B, Double]
+    ): TypedAggregate[T, Option[Double]] = {
+      implicit val c1 = column1.uencoder
+      implicit val c2 = column2.uencoder
+      new TypedAggregate[T, Option[Double]](
+        untyped.covar_samp(column1.cast[Double].untyped, column2.cast[Double].untyped)
+      )
+    }
 
 
   /**
@@ -290,12 +281,8 @@ trait AggregateFunctions {
     *
     *       apache/spark
     */
-  def kurtosis[A, T](column: TypedColumn[T, A])(
-    implicit
-    evCanBeDoubleA: CatalystCast[A, Double]
-  ): TypedAggregate[T, Option[Double]] = {
+  def kurtosis[A, T](column: TypedColumn[T, A])(implicit ev: CatalystCast[A, Double]): TypedAggregate[T, Option[Double]] = {
     implicit val c1 = column.uencoder
-
     new TypedAggregate[T, Option[Double]](
       untyped.kurtosis(column.cast[Double].untyped)
     )
@@ -309,12 +296,8 @@ trait AggregateFunctions {
     *
     *       apache/spark
     */
-  def skewness[A, T](column: TypedColumn[T, A])(
-    implicit
-    evCanBeDoubleA: CatalystCast[A, Double]
-  ): TypedAggregate[T, Option[Double]] = {
+  def skewness[A, T](column: TypedColumn[T, A])(implicit ev: CatalystCast[A, Double]): TypedAggregate[T, Option[Double]] = {
     implicit val c1 = column.uencoder
-
     new TypedAggregate[T, Option[Double]](
       untyped.skewness(column.cast[Double].untyped)
     )

--- a/dataset/src/main/scala/frameless/implicits.scala
+++ b/dataset/src/main/scala/frameless/implicits.scala
@@ -4,32 +4,28 @@ object implicits {
   object widen {
     // frameless prefixed to avoid implicit name collision
 
-    implicit def framelessByteToShort[T](col: TypedColumn[T, Byte]): TypedColumn[T, Short] = col.cast[Short]
-    implicit def framelessByteToInt[T](col: TypedColumn[T, Byte]): TypedColumn[T, Int] = col.cast[Int]
-    implicit def framelessByteToLong[T](col: TypedColumn[T, Byte]): TypedColumn[T, Long] = col.cast[Long]
-    implicit def framelessByteToDouble[T](col: TypedColumn[T, Byte]): TypedColumn[T, Double] = col.cast[Double]
-    implicit def framelessByteToBigDecimal[T](col: TypedColumn[T, Byte]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
-
-    implicit def framelessShortToInt[T](col: TypedColumn[T, Short]): TypedColumn[T, Int] = col.cast[Int]
-    implicit def framelessShortToLong[T](col: TypedColumn[T, Short]): TypedColumn[T, Long] = col.cast[Long]
-    implicit def framelessShortToDouble[T](col: TypedColumn[T, Short]): TypedColumn[T, Double] = col.cast[Double]
-    implicit def framelessShortToBigDecimal[T](col: TypedColumn[T, Short]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
-
-    implicit def framelessIntToLong[T](col: TypedColumn[T, Int]): TypedColumn[T, Long] = col.cast[Long]
-    implicit def framelessIntToDouble[T](col: TypedColumn[T, Int]): TypedColumn[T, Double] = col.cast[Double]
-    implicit def framelessIntToBigDecimal[T](col: TypedColumn[T, Int]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
-
-    implicit def framelessLongToDouble[T](col: TypedColumn[T, Long]): TypedColumn[T, Double] = col.cast[Double]
-    implicit def framelessLongToBigDecimal[T](col: TypedColumn[T, Long]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
-
+    implicit def framelessByteToShort       [T](col: TypedColumn[T, Byte]):   TypedColumn[T, Short] = col.cast[Short]
+    implicit def framelessByteToInt         [T](col: TypedColumn[T, Byte]):   TypedColumn[T, Int] = col.cast[Int]
+    implicit def framelessByteToLong        [T](col: TypedColumn[T, Byte]):   TypedColumn[T, Long] = col.cast[Long]
+    implicit def framelessByteToDouble      [T](col: TypedColumn[T, Byte]):   TypedColumn[T, Double] = col.cast[Double]
+    implicit def framelessByteToBigDecimal  [T](col: TypedColumn[T, Byte]):   TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
+    implicit def framelessShortToInt        [T](col: TypedColumn[T, Short]):  TypedColumn[T, Int] = col.cast[Int]
+    implicit def framelessShortToLong       [T](col: TypedColumn[T, Short]):  TypedColumn[T, Long] = col.cast[Long]
+    implicit def framelessShortToDouble     [T](col: TypedColumn[T, Short]):  TypedColumn[T, Double] = col.cast[Double]
+    implicit def framelessShortToBigDecimal [T](col: TypedColumn[T, Short]):  TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
+    implicit def framelessIntToLong         [T](col: TypedColumn[T, Int]):    TypedColumn[T, Long] = col.cast[Long]
+    implicit def framelessIntToDouble       [T](col: TypedColumn[T, Int]):    TypedColumn[T, Double] = col.cast[Double]
+    implicit def framelessIntToBigDecimal   [T](col: TypedColumn[T, Int]):    TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
+    implicit def framelessLongToDouble      [T](col: TypedColumn[T, Long]):   TypedColumn[T, Double] = col.cast[Double]
+    implicit def framelessLongToBigDecimal  [T](col: TypedColumn[T, Long]):   TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
     implicit def framelessDoubleToBigDecimal[T](col: TypedColumn[T, Double]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
 
     // we don't have floats yet, but then this is lawful (or not?):
     //
-    // implicit def byteToFloat[T](col: TypedColumn[T, Byte]): TypedColumn[T, Float] = col.cast[Float]
-    // implicit def intToFloat[T](col: TypedColumn[T, Int]): TypedColumn[T, Float] = col.cast[Float]
-    // implicit def longToFloat[T](col: TypedColumn[T, Long]): TypedColumn[T, Float] = col.cast[Float]
-    // implicit def floatToDouble[T](col: TypedColumn[T, Float]): TypedColumn[T, Double] = col.cast[Double]
+    // implicit def byteToFloat      [T](col: TypedColumn[T, Byte]):  TypedColumn[T, Float] = col.cast[Float]
+    // implicit def intToFloat       [T](col: TypedColumn[T, Int]):   TypedColumn[T, Float] = col.cast[Float]
+    // implicit def longToFloat      [T](col: TypedColumn[T, Long]):  TypedColumn[T, Float] = col.cast[Float]
+    // implicit def floatToDouble    [T](col: TypedColumn[T, Float]): TypedColumn[T, Double] = col.cast[Double]
     // implicit def floatToBigDecimal[T](col: TypedColumn[T, Float]): TypedColumn[T, BigDecimal] = col.cast[BigDecimal]
   }
 }

--- a/dataset/src/main/scala/frameless/ops/As.scala
+++ b/dataset/src/main/scala/frameless/ops/As.scala
@@ -6,10 +6,10 @@ import shapeless.{Generic, HList}
 class As[T, U](implicit val encoder: TypedEncoder[U])
 
 object As {
-  implicit def deriveProduct[T, U, S <: HList](
-    implicit
-    e: TypedEncoder[U],
-    t: Generic.Aux[T, S],
-    u: Generic.Aux[U, S]
-  ): As[T, U] = new As[T, U]
+  implicit def deriveProduct[T, U, S <: HList]
+    (implicit
+      i0: TypedEncoder[U],
+      i1: Generic.Aux[T, S],
+      i2: Generic.Aux[U, S]
+    ): As[T, U] = new As[T, U]
 }

--- a/dataset/src/main/scala/frameless/ops/GroupByOps.scala
+++ b/dataset/src/main/scala/frameless/ops/GroupByOps.scala
@@ -8,43 +8,41 @@ import shapeless._
 import shapeless.ops.hlist.{Length, Mapped, Prepend, ToList, ToTraversable, Tupler}
 
 
-class GroupedByManyOps[T, TK <: HList, K <: HList, KT](
-  self: TypedDataset[T],
-  groupedBy: TK
-)(
-  implicit
-  ct: ColumnTypes.Aux[T, TK, K],
-  toTraversable: ToTraversable.Aux[TK, List, UntypedExpression[T]],
-  tupler: Tupler.Aux[K, KT]
-) {
+class GroupedByManyOps[T, TK <: HList, K <: HList, KT]
+  (self: TypedDataset[T], groupedBy: TK)
+  (implicit
+    i0: ColumnTypes.Aux[T, TK, K],
+    i1: ToTraversable.Aux[TK, List, UntypedExpression[T]],
+    i3: Tupler.Aux[K, KT]
+  ) {
   object agg extends ProductArgs {
-    def applyProduct[TC <: HList, C <: HList, Out0 <: HList, Out1](columns: TC)(
-      implicit
-      tc: AggregateTypes.Aux[T, TC, C],
-      append: Prepend.Aux[K, C, Out0],
-      toTuple: Tupler.Aux[Out0, Out1],
-      encoder: TypedEncoder[Out1],
-      columnsToList: ToTraversable.Aux[TC, List, UntypedExpression[T]]
-    ): TypedDataset[Out1] = {
+    def applyProduct[TC <: HList, C <: HList, Out0 <: HList, Out1]
+      (columns: TC)
+      (implicit
+        i3: AggregateTypes.Aux[T, TC, C],
+        i4: Prepend.Aux[K, C, Out0],
+        i5: Tupler.Aux[Out0, Out1],
+        i6: TypedEncoder[Out1],
+        i7: ToTraversable.Aux[TC, List, UntypedExpression[T]]
+      ): TypedDataset[Out1] = {
+        def expr(c: UntypedExpression[T]): Column = new Column(c.expr)
 
-      def expr(c: UntypedExpression[T]): Column = new Column(c.expr)
+        val groupByExprs = groupedBy.toList[UntypedExpression[T]].map(expr)
+        val aggregates =
+          if (retainGroupColumns) columns.toList[UntypedExpression[T]].map(expr)
+          else groupByExprs ++ columns.toList[UntypedExpression[T]].map(expr)
 
-      val groupByExprs = toTraversable(groupedBy).map(expr)
-      val aggregates =
-        if (retainGroupColumns) columnsToList(columns).map(expr)
-        else groupByExprs ++ columnsToList(columns).map(expr)
+        val aggregated = self.dataset.toDF()
+          .groupBy(groupByExprs: _*)
+          .agg(aggregates.head, aggregates.tail: _*)
+          .as[Out1](TypedExpressionEncoder[Out1])
 
-      val aggregated = self.dataset.toDF()
-        .groupBy(groupByExprs: _*)
-        .agg(aggregates.head, aggregates.tail: _*)
-        .as[Out1](TypedExpressionEncoder[Out1])
-
-      TypedDataset.create[Out1](aggregated)
-    }
+        TypedDataset.create[Out1](aggregated)
+      }
   }
 
   def mapGroups[U: TypedEncoder](f: (KT, Iterator[T]) => U)(
-    implicit kencoder: TypedEncoder[KT]
+    implicit e: TypedEncoder[KT]
   ): TypedDataset[U] = {
     val func = (key: KT, it: Iterator[T]) => Iterator(f(key, it))
     flatMapGroups(func)
@@ -52,10 +50,10 @@ class GroupedByManyOps[T, TK <: HList, K <: HList, KT](
 
   def flatMapGroups[U: TypedEncoder](
     f: (KT, Iterator[T]) => TraversableOnce[U]
-  )(implicit kencoder: TypedEncoder[KT]): TypedDataset[U] = {
+  )(implicit e: TypedEncoder[KT]): TypedDataset[U] = {
     implicit val tendcoder = self.encoder
 
-    val cols = toTraversable(groupedBy)
+    val cols = groupedBy.toList[UntypedExpression[T]]
     val logicalPlan = FramelessInternals.logicalPlan(self.dataset)
     val withKeyColumns = logicalPlan.output ++ cols.map(_.expr).map(UnresolvedAlias(_))
     val withKey = Project(withKeyColumns, logicalPlan)
@@ -197,39 +195,32 @@ final case class Pivot[T, GroupedColumns <: HList, PivotType, Values <: HList](
 ) {
 
   object agg extends ProductArgs {
-    def applyProduct[
-    AggrColumns <: HList,
-    AggrColumnTypes <: HList,
-    GroupedColumnTypes <: HList,
-    NumValues <: Nat,
-    TypesForPivotedValues <: HList,
-    TypesForPivotedValuesOpt <: HList,
-    OutAsHList <: HList,
-    Out](aggrColumns: AggrColumns)(
-      implicit
-      tc: AggregateTypes.Aux[T, AggrColumns, AggrColumnTypes],
-      columnTypes: ColumnTypes.Aux[T, GroupedColumns, GroupedColumnTypes],
-      len: Length.Aux[Values, NumValues],
-      rep: Repeat.Aux[AggrColumnTypes, NumValues, TypesForPivotedValues],
-      opt: Mapped.Aux[TypesForPivotedValues, Option, TypesForPivotedValuesOpt],
-      append: Prepend.Aux[GroupedColumnTypes, TypesForPivotedValuesOpt, OutAsHList],
-      toTuple: Tupler.Aux[OutAsHList, Out],
-      encoder: TypedEncoder[Out]
-    ): TypedDataset[Out] = {
-      def mapAny[X](h: HList)(f: Any => X): List[X] =
-        h match {
-          case HNil    => Nil
-          case x :: xs => f(x) :: mapAny(xs)(f)
-        }
+    def applyProduct[AggrColumns <: HList, AggrColumnTypes <: HList, GroupedColumnTypes <: HList, NumValues <: Nat, TypesForPivotedValues <: HList, TypesForPivotedValuesOpt <: HList, OutAsHList <: HList, Out]
+      (aggrColumns: AggrColumns)
+      (implicit
+        i0: AggregateTypes.Aux[T, AggrColumns, AggrColumnTypes],
+        i1: ColumnTypes.Aux[T, GroupedColumns, GroupedColumnTypes],
+        i2: Length.Aux[Values, NumValues],
+        i3: Repeat.Aux[AggrColumnTypes, NumValues, TypesForPivotedValues],
+        i4: Mapped.Aux[TypesForPivotedValues, Option, TypesForPivotedValuesOpt],
+        i5: Prepend.Aux[GroupedColumnTypes, TypesForPivotedValuesOpt, OutAsHList],
+        i6: Tupler.Aux[OutAsHList, Out],
+        i7: TypedEncoder[Out]
+      ): TypedDataset[Out] = {
+        def mapAny[X](h: HList)(f: Any => X): List[X] =
+          h match {
+            case HNil    => Nil
+            case x :: xs => f(x) :: mapAny(xs)(f)
+          }
 
-      val aggCols: Seq[Column] = mapAny(aggrColumns)(x => new Column(x.asInstanceOf[TypedAggregate[_,_]].expr))
-      val tmp = ds.dataset.toDF()
-        .groupBy(mapAny(groupedBy)(_.asInstanceOf[TypedColumn[_, _]].untyped): _*)
-        .pivot(pivotedBy.untyped.toString, mapAny(values)(identity))
-        .agg(aggCols.head, aggCols.tail:_*)
-        .as[Out](TypedExpressionEncoder[Out])
-      TypedDataset.create(tmp)
-    }
+        val aggCols: Seq[Column] = mapAny(aggrColumns)(x => new Column(x.asInstanceOf[TypedAggregate[_,_]].expr))
+        val tmp = ds.dataset.toDF()
+          .groupBy(mapAny(groupedBy)(_.asInstanceOf[TypedColumn[_, _]].untyped): _*)
+          .pivot(pivotedBy.untyped.toString, mapAny(values)(identity))
+          .agg(aggCols.head, aggCols.tail:_*)
+          .as[Out](TypedExpressionEncoder[Out])
+        TypedDataset.create(tmp)
+      }
   }
 }
 
@@ -240,7 +231,6 @@ final case class PivotNotValues[T, GroupedColumns <: HList, PivotType](
 ) extends ProductArgs {
 
   def onProduct[Values <: HList](values: Values)(
-    implicit
-    validValues: ToList[Values, PivotType] // validValues: FilterNot.Aux[Values, PivotType, HNil] // did not work
+    implicit validValues: ToList[Values, PivotType] // validValues: FilterNot.Aux[Values, PivotType, HNil] // did not work
   ): Pivot[T, GroupedColumns, PivotType, Values] = Pivot(ds, groupedBy, pivotedBy, values)
 }

--- a/dataset/src/main/scala/frameless/ops/Repeat.scala
+++ b/dataset/src/main/scala/frameless/ops/Repeat.scala
@@ -24,10 +24,10 @@ object Repeat {
   }
 
   implicit def succ[L <: HList, Prev <: Nat, PrevOut <: HList, P <: HList]
-  (implicit
-   prev: Aux[L, Prev, PrevOut],
-   prepend: Prepend.Aux[L, PrevOut, P]
-  ): Aux[L, Succ[Prev], P] = new Repeat[L, Succ[Prev]] {
-    type Out = P
-  }
+    (implicit
+      i0: Aux[L, Prev, PrevOut],
+      i1: Prepend.Aux[L, PrevOut, P]
+    ): Aux[L, Succ[Prev], P] = new Repeat[L, Succ[Prev]] {
+      type Out = P
+    }
 }

--- a/dataset/src/main/scala/frameless/ops/SmartProject.scala
+++ b/dataset/src/main/scala/frameless/ops/SmartProject.scala
@@ -16,13 +16,13 @@ object SmartProject {
     * (a) both T and U are Products for which a LabelledGeneric can be derived (e.g., case classes),
     * (b) all members of U have a corresponding member in T that has both the same name and type.
     *
-    * @param tgen the LabelledGeneric derived for T
-    * @param ugen the LabelledGeneric derived for U
-    * @param keys the keys of U
-    * @param select selects all the values from T using the keys of U
-    * @param values selects all the values of LabeledGeneric[U]
-    * @param typeEqualityProof proof that U and the projection of T have the same type
-    * @param keysTraverse allows for traversing the keys of U
+    * @param i0 the LabelledGeneric derived for T
+    * @param i1 the LabelledGeneric derived for U
+    * @param i2 the keys of U
+    * @param i3 selects all the values from T using the keys of U
+    * @param i4 selects all the values of LabeledGeneric[U]
+    * @param i5 proof that U and the projection of T have the same type
+    * @param i6 allows for traversing the keys of U
     * @tparam T the original type T
     * @tparam U the projected type U
     * @tparam TRec shapeless' Record representation of T
@@ -32,25 +32,17 @@ object SmartProject {
     * @tparam UKeys the keys of U as an HList
     * @return a projection if it exists
     */
-  implicit def deriveProduct[
-  T: TypedEncoder,
-  U: TypedEncoder,
-  TRec <: HList,
-  TProj <: HList,
-  URec <: HList,
-  UVals <: HList,
-  UKeys <: HList](
-    implicit
-    tgen: LabelledGeneric.Aux[T, TRec],
-    ugen: LabelledGeneric.Aux[U, URec],
-    keys: Keys.Aux[URec, UKeys],
-    select: SelectAll.Aux[TRec, UKeys, TProj],
-    values: Values.Aux[URec, UVals],
-    typeEqualityProof: UVals =:= TProj,
-    keysTraverse: ToTraversable.Aux[UKeys, Seq, Symbol]
-  ): SmartProject[T,U] = SmartProject[T, U]( from => {
-        val names = keys.apply.to[Seq].map(_.name).map(from.dataset.col)
-        TypedDataset.create(from.dataset.toDF().select(names: _*).as[U](TypedExpressionEncoder[U]))
-      }
-    )
+  implicit def deriveProduct[T: TypedEncoder, U: TypedEncoder, TRec <: HList, TProj <: HList, URec <: HList, UVals <: HList, UKeys <: HList]
+    (implicit
+      i0: LabelledGeneric.Aux[T, TRec],
+      i1: LabelledGeneric.Aux[U, URec],
+      i2: Keys.Aux[URec, UKeys],
+      i3: SelectAll.Aux[TRec, UKeys, TProj],
+      i4: Values.Aux[URec, UVals],
+      i5: UVals =:= TProj,
+      i6: ToTraversable.Aux[UKeys, Seq, Symbol]
+    ): SmartProject[T,U] = SmartProject[T, U]({ from =>
+      val names = implicitly[Keys.Aux[URec, UKeys]].apply.to[Seq].map(_.name).map(from.dataset.col)
+      TypedDataset.create(from.dataset.toDF().select(names: _*).as[U](TypedExpressionEncoder[U]))
+    })
 }


### PR DESCRIPTION
This is cosmetic PR that anonymizes and re indented all the implicit blocks in frameless.

I don't think the names of implicits help at all for readability. To understand what a shapeless program does it's best to look at the type! Also, because the type arguments are often the most important part of a function definition it makes sense to have them in their own level of indentation as implemented in this PR.