### PR TITLE
[FEEDBACK WANTED] Don't create column from dataset

### DIFF
--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -170,7 +170,7 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
       i0: TypedColumn.Exists[T, column.T, A],
       i1: TypedEncoder[A]
     ): TypedColumn[T, A] = {
-      val colExpr = dataset.col(column.value.name).as[A](TypedExpressionEncoder[A])
+      val colExpr = new Column(column.value.name).as[A](TypedExpressionEncoder[A])
       new TypedColumn[T, A](colExpr)
     }
 


### PR DESCRIPTION
I may be missing some context here, but it seems like the current way of selecting a column can lead to runtime errors that the compiler okays.
Currently, columns are selected using the dataset's `col` method. The compile time check however only ensures that the field exists in the Dataset's type `T`. However, this does not prevent one from selecting a column from a different dataset of the same `T` at compile time resulting in a runtime blow up.

One way to get around this is started in this PR. Instead of selecting the dataset's col, create a general column instead. This would at least line up with what the compiler is proving, simply that a col of field `foo` exists in `T` and has the type `U` but not that the column requested is that specific dataset's column.

example:
```scala
val ds1: TypedDataset[X2[Int, Int]] = TypedDataset.create(Seq.empty[X2[Int, Int]])
val ds2: TypedDataset[X2[Int, Int]] = TypedDataset.create(Seq.empty[X2[Int, Int]])

//this will compile but blow up at runtime
ds2.filter(ds1('a) === 1)
```

Are there other ways to get around this?
Is this not considered an issue to be concerned about?