### PR TITLE
withColumn update column value

### DIFF
--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -666,12 +666,15 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
       TypedDataset.create[Out](selected)
   }
 
-  /**
-    * Returns a new TypedDataset with the specified column updated with a new value
-    *
+  /** Returns a new [[frameless.TypedDataset]] with the specified column updated with a new value
+    * {{{
+    *   case class X(i: Int, j: Int)
+    *   val f: TypedDataset[X] = TypedDataset.create(X(1,10) :: Nil)
+    *   val fNew: TypedDataset[X] = f.withColumn('j, f('i)) // results in X(1, 1) :: Nil
+    * }}}
     * @param column column given as a symbol to replace
     * @param replacement column to replace the value with
-    * @param i0 Eviendence that a column with the correct type and name exists
+    * @param i0 Evidence that a column with the correct type and name exists
     */
   def withColumn[A](
     column: Witness.Lt[Symbol],

--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -666,6 +666,25 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
       TypedDataset.create[Out](selected)
   }
 
+  /**
+    * Returns a new TypedDataset with the specified column updated with a new value
+    *
+    * @param column column given as a symbol to replace
+    * @param replacement column to replace the value with
+    * @param i0 Eviendence that a column with the correct type and name exists
+    */
+  def withColumn[A](
+    column: Witness.Lt[Symbol],
+    replacement: TypedColumn[T, A]
+  )(implicit
+    i0: TypedColumn.Exists[T, column.T, A]
+  ): TypedDataset[T] = {
+    val updated = dataset.toDF().withColumn(column.value.name, replacement.untyped)
+      .as[T](TypedExpressionEncoder[T])
+
+    TypedDataset.create[T](updated)
+  }
+
   /** Adds a column to a Dataset so long as the specified output type, `U`, has
     * an extra column from `T` that has type `A`.
     *

--- a/dataset/src/test/scala/frameless/WithColumnTest.scala
+++ b/dataset/src/test/scala/frameless/WithColumnTest.scala
@@ -52,6 +52,24 @@ class WithColumnTest extends TypedDatasetSuite {
     check(prop[SQLDate] _)
     check(prop[Option[X1[Boolean]]] _)
   }
+
+  test("update in place") {
+    def prop[A : TypedEncoder](startValue: A, replaceValue: A): Prop = {
+      val d = TypedDataset.create(X2(startValue, replaceValue) :: Nil)
+
+      val X2(a, b) = d.withColumn('a, d('b))
+        .collect()
+        .run()
+        .head
+
+      a ?= b
+    }
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[String] _)
+    check(prop[SQLDate] _)
+    check(prop[Option[X1[Boolean]]] _)
+  }
 }
 
 object WithColumnTest {


### PR DESCRIPTION
Connects to #163 

Allows for updating a column of a dataset provided the types align. 
Think case class's `copy`.