### PR TITLE
Add type safe column contains and boolean methods

### DIFF
--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -409,6 +409,54 @@ sealed class TypedColumn[T, U](
     */
   def cast[A: TypedEncoder](implicit c: CatalystCast[U, A]): TypedColumn[T, A] =
     self.untyped.cast(TypedEncoder[A].catalystRepr).typed
+
+  /** Contains test.
+    * {{{
+    *   df.filter ( df.col('a).contains("foo") )
+    * }}}
+    */
+  def contains(other: String)(implicit ev: U =:= String): TypedColumn[T, Boolean] =
+    self.untyped.contains(other).typed
+
+  /** Contains test.
+    * {{{
+    *   df.filter ( df.col('a).contains(df.col('b) )
+    * }}}
+    */
+  def contains(other: TypedColumn[T, U])(implicit ev: U =:= String): TypedColumn[T, Boolean] =
+    self.untyped.contains(other.untyped).typed
+
+  /** Boolean AND.
+    * {{{
+    *   df.filter ( (df.col('a) === 1).and(df.col('b) > 5) )
+    * }}}
+    */
+  def and(other: TypedColumn[T, Boolean]): TypedColumn[T, Boolean] =
+    self.untyped.and(other.untyped).typed
+
+  /** Boolean AND.
+    * {{{
+    *   df.filter ( df.col('a) === 1 && df.col('b) > 5)
+    * }}}
+    */
+  def && (other: TypedColumn[T, Boolean]): TypedColumn[T, Boolean] =
+    and(other)
+
+  /** Boolean OR.
+    * {{{
+    *   df.filter ( (df.col('a) === 1).or(df.col('b) > 5) )
+    * }}}
+    */
+  def or(other: TypedColumn[T, Boolean]): TypedColumn[T, Boolean] =
+    self.untyped.or(other.untyped).typed
+
+  /** Boolean OR.
+    * {{{
+    *   df.filter ( df.col('a) === 1 || df.col('b) > 5)
+    * }}}
+    */
+  def || (other: TypedColumn[T, Boolean]): TypedColumn[T, Boolean] =
+    or(other)
 }
 
 /** Expression used in `groupBy`-like constructions.


### PR DESCRIPTION
Connects to #164 

Adds column boolean `and` and `or` as well as `contains`.

This `contains` is different from the standard spark implementation in that it will only operate on `String`. Spark's `contains` can also work on numerics, `123` contains `2`, it can also work on dates as an equals even between timestamps and dates. I'm sure there are other types where `contains` works as well if anyone wants to enumerate the rest of them.

Is that something that frameless should support? Should `contain` take an `implicit CatalystCast[U, String]` and do the casting itself? Can we leave the onus on the user to check in a way that's much more explicit what's going on by themselves calling `cast[String]`?

Personally, I've been hit more than a few times with spark's `contains` blowing up at runtime as it takes `Any` https://spark.apache.org/docs/2.2.0/api/scala/index.html#org.apache.spark.sql.Column@contains(other:Any):org.apache.spark.sql.Column. 