### PR TITLE
Adding a getOrElse version for literal values.

### DIFF
--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -117,6 +117,14 @@ sealed class TypedColumn[T, U](
     Coalesce(Seq(expr, default.expr))
   }.typed(default.uencoder)
 
+  /** Convert an Optional column by providing a default value
+    * {{{
+    *   df( df('opt).getOrElse(defaultConstant) )
+    * }}}
+    */
+  def getOrElse[Out: TypedEncoder](default: Out)(implicit isOption: U =:= Option[Out]): TypedColumn[T, Out] =
+    getOrElse(lit[Out, T](default))
+
   /** Sum of this expression and another expression.
     * {{{
     *   // The following selects the sum of a person's height and weight.
@@ -237,7 +245,7 @@ sealed class TypedColumn[T, U](
     *   people.select( people('height) / people('weight) )
     * }}}
     *
-    * @param u another column of the same type
+    * @param other another column of the same type
     * apache/spark
     */
   def divide[Out: TypedEncoder](other: TypedColumn[T, U])(implicit n: CatalystDivisible[U, Out]): TypedColumn[T, Out] =
@@ -250,10 +258,13 @@ sealed class TypedColumn[T, U](
     *   people.select( people('height) / people('weight) )
     * }}}
     *
-    * @param u another column of the same type
+    * @param other another column of the same type
     * apache/spark
     */
-  def /[Out](other: TypedColumn[T, U])(implicit n: CatalystDivisible[U, Out], e: TypedEncoder[Out]): TypedColumn[T, Out] = divide(other)
+  def /[Out](other: TypedColumn[T, U])
+     (implicit
+        n: CatalystDivisible[U, Out],
+        e: TypedEncoder[Out]): TypedColumn[T, Out] = divide(other)
 
   /**
     * Division this expression by another expression.

--- a/dataset/src/test/scala/frameless/ColumnTests.scala
+++ b/dataset/src/test/scala/frameless/ColumnTests.scala
@@ -48,14 +48,14 @@ class ColumnTests extends TypedDatasetSuite {
     def prop[A: TypedEncoder](a: A, opt: Option[A]) = {
       val dataset = TypedDataset.create(X2(a, opt) :: Nil)
 
-      val defaulted = dataset
-        .select(dataset('b).getOrElse(dataset('a)))
+      val defaulted: (A, A) = dataset
+        .select(dataset('b).getOrElse(dataset('a)), dataset('b).getOrElse(a))
         .collect()
-        .run
+        .run()
         .toList
         .head
 
-      defaulted ?= opt.getOrElse(a)
+      defaulted.?=((opt.getOrElse(a), opt.getOrElse(a)))
     }
 
     check(forAll(prop[Int] _))


### PR DESCRIPTION
Trivial addition to the getOrElse by @frosforever. It also contains some comment changes and refactoring. 

```scala
scala> case class X(o: Int, b: Option[Boolean])
defined class X

scala> val t = TypedDataset.create(Seq(X(1,Some(true)), X(12,None)))
t: frameless.TypedDataset[X] = [o: int, b: boolean]

scala> t.select(t('b).getOrElse(true)).show().run
+----+
|  _1|
+----+
|true|
|true|
+----+
```