### PR TITLE
Forwarding Typed Dataset methods

### DIFF
--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -119,6 +119,20 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     TypedDataset.create(dataset.as[U](TypedExpressionEncoder[U]))
   }
 
+  /**
+    * Returns a checkpointed version of this [[TypedDataset]]. Checkpointing can be used to truncate the
+    * logical plan of this Dataset, which is especially useful in iterative algorithms where the
+    * plan may grow exponentially. It will be saved to files inside the checkpoint
+    * directory set with `SparkContext#setCheckpointDir`.
+    *
+    * Differs from `Dataset#checkpoint` by wrapping it's result into an effect-suspending `F[_]`.
+    *
+    * apache/spark
+    */
+
+  def checkpoint[F[_]](eager: Boolean)(implicit F: SparkDelay[F]): F[TypedDataset[T]] =
+    F.delay(TypedDataset.create[T](dataset.checkpoint(eager)))
+
   /** Returns a new [[TypedDataset]] where each record has been mapped on to the specified type.
     * Unlike `as` the projection U may include a subset of the columns of T and the column names and types must agree.
     *

--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -189,14 +189,6 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
       }
   }
 
-  /**
-    * Returns an `Array` that contains all column names in this [[TypedDataset]].
-    *
-    * Differs from `Dataset#columns` by wrapping it's result into an effect-suspending `F[_]`.
-    */
-  def columns[F[_]](implicit F: SparkDelay[F]): F[Array[String]] =
-    F.delay(dataset.columns)
-
   /** Returns a `Seq` that contains all the elements in this [[TypedDataset]].
     *
     * Running this operation requires moving all the data into the application's driver process, and
@@ -668,43 +660,6 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     * @see [[frameless.TypedDataset#project]]
     */
   def drop[U](implicit projector: SmartProject[T,U]): TypedDataset[U] = project[U]
-  
-  /**
-    * Returns a `QueryExecution` from this [[TypedDataset]].
-    *
-    * It is the primary workflow for executing relational queries using Spark.  Designed to allow easy
-    * access to the intermediate phases of query execution for developers.
-    *
-    * Differs from `Dataset#queryExecution` by wrapping it's result into an effect-suspending `F[_]`.
-    *
-    * apache/spark
-    */
-  def queryExecution[F[_]](implicit F: SparkDelay[F]) : F[QueryExecution] =
-    F.delay(dataset.queryExecution)
-
-  /**
-    * Returns the schema of this [[TypedDataset]].
-    *
-    * Differs from `Dataset#schema` by wrapping it's result into an effect-suspending `F[_]`.
-    */
-  def schema[F[_]](implicit F: SparkDelay[F]): F[StructType] =
-    F.delay(dataset.schema)
-
-  /**
-    * Returns a `SparkSession` from this [[TypedDataset]].
-    *
-    * Differs from `Dataset#sparkSession` by wrapping it's result into an effect-suspending `F[_]`.
-    */
-  def sparkSession[F[_]](implicit F: SparkDelay[F]): F[SparkSession] =
-    F.delay(dataset.sparkSession)
-
-  /**
-    * Returns a `SQLContext` from this [[TypedDataset]].
-    *
-    * Differs from `Dataset#sqlContext` by wrapping it's result into an effect-suspending `F[_]`.
-    */
-  def sqlContext[F[_]](implicit F: SparkDelay[F]): F[SQLContext] =
-    F.delay(dataset.sqlContext)
 
   /** Prepends a new column to the Dataset.
     *

--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -2,12 +2,11 @@ package frameless
 
 import frameless.ops._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, CreateStruct, EqualTo}
 import org.apache.spark.sql.catalyst.plans.logical.{Join, Project}
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.catalyst.plans.{Inner, LeftOuter}
-import org.apache.spark.sql._
-import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.types.StructType
 import shapeless._
 import shapeless.labelled.FieldType
 import shapeless.ops.hlist.{Diff, IsHCons, Prepend, ToTraversable, Tupler}

--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -676,6 +676,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     * access to the intermediate phases of query execution for developers.
     *
     * Differs from `Dataset#queryExecution` by wrapping it's result into an effect-suspending `F[_]`.
+    *
+    * apache/spark
     */
   def queryExecution[F[_]](implicit F: SparkDelay[F]) : F[QueryExecution] =
     F.delay(dataset.queryExecution)

--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -670,7 +670,7 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
   def drop[U](implicit projector: SmartProject[T,U]): TypedDataset[U] = project[U]
   
   /**
-    * Returns an [[org.apache.spark.sql.execution.QueryExecution]] from this [[TypedDataset]].
+    * Returns a `QueryExecution` from this [[TypedDataset]].
     *
     * It is the primary workflow for executing relational queries using Spark.  Designed to allow easy
     * access to the intermediate phases of query execution for developers.
@@ -691,7 +691,7 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     F.delay(dataset.schema)
 
   /**
-    * Returns an [[org.apache.spark.sql.SparkSession]] from this [[TypedDataset]].
+    * Returns a `SparkSession` from this [[TypedDataset]].
     *
     * Differs from `Dataset#sparkSession` by wrapping it's result into an effect-suspending `F[_]`.
     */
@@ -699,7 +699,7 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
     F.delay(dataset.sparkSession)
 
   /**
-    * Returns an [[org.apache.spark.sql.SQLContext]] from this [[TypedDataset]].
+    * Returns a `SQLContext` from this [[TypedDataset]].
     *
     * Differs from `Dataset#sqlContext` by wrapping it's result into an effect-suspending `F[_]`.
     */

--- a/dataset/src/main/scala/frameless/TypedDatasetForwarded.scala
+++ b/dataset/src/main/scala/frameless/TypedDatasetForwarded.scala
@@ -1,7 +1,8 @@
 package frameless
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.{DataFrame, Dataset, SQLContext, SparkSession}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.StorageLevel
 
@@ -19,6 +20,18 @@ trait TypedDatasetForwarded[T] { self: TypedDataset[T] =>
 
   override def toString: String =
     dataset.toString
+
+  /**
+    * Returns a `SparkSession` from this [[TypedDataset]].
+    */
+  def sparkSession: SparkSession =
+    dataset.sparkSession
+
+  /**
+    * Returns a `SQLContext` from this [[TypedDataset]].
+    */
+  def sqlContext: SQLContext =
+    dataset.sqlContext
 
   /**
     * Returns the schema of this Dataset.
@@ -41,6 +54,17 @@ trait TypedDatasetForwarded[T] { self: TypedDataset[T] =>
    */
   def explain(extended: Boolean = false): Unit =
     dataset.explain(extended)
+
+  /**
+    * Returns a `QueryExecution` from this [[TypedDataset]].
+    *
+    * It is the primary workflow for executing relational queries using Spark.  Designed to allow easy
+    * access to the intermediate phases of query execution for developers.
+    *
+    * apache/spark
+    */
+  def queryExecution: QueryExecution =
+    dataset.queryExecution
 
   /** Converts this strongly typed collection of data to generic Dataframe.  In contrast to the
     * strongly typed objects that Dataset operations work on, a Dataframe returns generic Row
@@ -75,6 +99,12 @@ trait TypedDatasetForwarded[T] { self: TypedDataset[T] =>
   def coalesce(numPartitions: Int): TypedDataset[T] =
     TypedDataset.create(dataset.coalesce(numPartitions))
 
+  /**
+    * Returns an `Array` that contains all column names in this [[TypedDataset]].
+    */
+  def columns: Array[String] =
+    dataset.columns
+  
   /** Concise syntax for chaining custom transformations.
     *
     * apache/spark

--- a/dataset/src/main/scala/frameless/TypedDatasetForwarded.scala
+++ b/dataset/src/main/scala/frameless/TypedDatasetForwarded.scala
@@ -2,8 +2,8 @@ package frameless
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.QueryExecution
-import org.apache.spark.sql.{DataFrame, Dataset, SQLContext, SparkSession}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SQLContext, SparkSession}
 import org.apache.spark.storage.StorageLevel
 
 import scala.util.Random
@@ -104,7 +104,7 @@ trait TypedDatasetForwarded[T] { self: TypedDataset[T] =>
     */
   def columns: Array[String] =
     dataset.columns
-  
+
   /** Concise syntax for chaining custom transformations.
     *
     * apache/spark

--- a/dataset/src/test/scala/frameless/SchemaTests.scala
+++ b/dataset/src/test/scala/frameless/SchemaTests.scala
@@ -8,7 +8,12 @@ import org.scalatest.Matchers
 class SchemaTests extends TypedDatasetSuite with Matchers {
 
   def prop[A](dataset: TypedDataset[A]): Prop = {
-    TypedExpressionEncoder.targetStructType(dataset.encoder) ?= dataset.dataset.schema
+    val schema = dataset.dataset.schema
+
+    Prop.all(
+      dataset.schema[Job].run() ?= schema,
+      TypedExpressionEncoder.targetStructType(dataset.encoder) ?= schema
+    )
   }
 
   test("schema of groupBy('a).agg(sum('b))") {

--- a/dataset/src/test/scala/frameless/SchemaTests.scala
+++ b/dataset/src/test/scala/frameless/SchemaTests.scala
@@ -11,7 +11,7 @@ class SchemaTests extends TypedDatasetSuite with Matchers {
     val schema = dataset.dataset.schema
 
     Prop.all(
-      dataset.schema[Job].run() ?= schema,
+      dataset.schema ?= schema,
       TypedExpressionEncoder.targetStructType(dataset.encoder) ?= schema
     )
   }

--- a/dataset/src/test/scala/frameless/forward/CheckpointTests.scala
+++ b/dataset/src/test/scala/frameless/forward/CheckpointTests.scala
@@ -1,0 +1,21 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop.{forAll, _}
+
+
+class CheckpointTests extends TypedDatasetSuite {
+  test("checkpoint") {
+    def prop[A: TypedEncoder](data: Vector[A], isEager: Boolean): Prop = {
+      val dataset = TypedDataset.create(data)
+
+      dataset.sparkSession.sparkContext.setCheckpointDir(TEST_OUTPUT_DIR)
+
+      dataset.checkpoint(isEager).run().queryExecution.toString() =?
+        dataset.dataset.checkpoint(isEager).queryExecution.toString()
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/ColumnsTests.scala
+++ b/dataset/src/test/scala/frameless/forward/ColumnsTests.scala
@@ -1,0 +1,30 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop.forAll
+
+class ColumnsTests extends TypedDatasetSuite {
+  test("columns") {
+    def prop(i: Int, s: String, b: Boolean, l: Long, d: Double, by: Byte): Prop = {
+      val x1 = X1(i) :: Nil
+      val x2 = X2(i, s) :: Nil
+      val x3 = X3(i, s, b) :: Nil
+      val x4 = X4(i, s, b, l) :: Nil
+      val x5 = X5(i, s, b, l, d) :: Nil
+      val x6 = X6(i, s, b, l, d, by) :: Nil
+
+      val datasets = Seq(TypedDataset.create(x1), TypedDataset.create(x2),
+        TypedDataset.create(x3), TypedDataset.create(x4),
+        TypedDataset.create(x5), TypedDataset.create(x6))
+
+      Prop.all(datasets.flatMap { dataset =>
+        val columns = dataset.dataset.columns
+        dataset.columns.run().map(col =>
+          Prop.propBoolean(columns contains col)
+        )
+      }: _*)
+    }
+
+    check(forAll(prop _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/ColumnsTests.scala
+++ b/dataset/src/test/scala/frameless/forward/ColumnsTests.scala
@@ -19,7 +19,7 @@ class ColumnsTests extends TypedDatasetSuite {
 
       Prop.all(datasets.flatMap { dataset =>
         val columns = dataset.dataset.columns
-        dataset.columns.run().map(col =>
+        dataset.columns.map(col =>
           Prop.propBoolean(columns contains col)
         )
       }: _*)

--- a/dataset/src/test/scala/frameless/forward/InputFilesTests.scala
+++ b/dataset/src/test/scala/frameless/forward/InputFilesTests.scala
@@ -1,0 +1,48 @@
+package frameless
+
+import java.util.UUID
+
+import org.apache.spark.sql.SparkSession
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+import org.scalatest.Matchers
+
+class InputFilesTests extends TypedDatasetSuite with Matchers {
+  test("inputFiles") {
+
+    def propText[A: TypedEncoder](data: Vector[A]): Prop = {
+      val filePath = s"$TEST_OUTPUT_DIR/${UUID.randomUUID()}.txt"
+
+      TypedDataset.create(data).dataset.write.text(filePath)
+      val dataset = TypedDataset.create(implicitly[SparkSession].sparkContext.textFile(filePath))
+
+      Prop.propBoolean(dataset.inputFiles sameElements dataset.dataset.inputFiles)
+    }
+
+    def propCsv[A: TypedEncoder](data: Vector[A]): Prop = {
+      val filePath = s"$TEST_OUTPUT_DIR/${UUID.randomUUID()}.csv"
+      val inputDataset = TypedDataset.create(data)
+      inputDataset.dataset.write.csv(filePath)
+
+      val dataset = TypedDataset.createUnsafe(
+        implicitly[SparkSession].sqlContext.read.schema(inputDataset.schema).csv(filePath))
+
+      Prop.propBoolean(dataset.inputFiles sameElements dataset.dataset.inputFiles)
+    }
+
+    def propJson[A: TypedEncoder](data: Vector[A]): Prop = {
+      val filePath = s"$TEST_OUTPUT_DIR/${UUID.randomUUID()}.json"
+      val inputDataset = TypedDataset.create(data)
+      inputDataset.dataset.write.json(filePath)
+
+      val dataset = TypedDataset.createUnsafe(
+        implicitly[SparkSession].sqlContext.read.schema(inputDataset.schema).json(filePath))
+
+      Prop.propBoolean(dataset.inputFiles sameElements dataset.dataset.inputFiles)
+    }
+
+    check(forAll(propText[String] _))
+    check(forAll(propCsv[String] _))
+    check(forAll(propJson[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/InputFilesTests.scala
+++ b/dataset/src/test/scala/frameless/forward/InputFilesTests.scala
@@ -16,7 +16,7 @@ class InputFilesTests extends TypedDatasetSuite with Matchers {
       TypedDataset.create(data).dataset.write.text(filePath)
       val dataset = TypedDataset.create(implicitly[SparkSession].sparkContext.textFile(filePath))
 
-      Prop.propBoolean(dataset.inputFiles sameElements dataset.dataset.inputFiles)
+      dataset.inputFiles sameElements dataset.dataset.inputFiles
     }
 
     def propCsv[A: TypedEncoder](data: Vector[A]): Prop = {
@@ -27,7 +27,7 @@ class InputFilesTests extends TypedDatasetSuite with Matchers {
       val dataset = TypedDataset.createUnsafe(
         implicitly[SparkSession].sqlContext.read.schema(inputDataset.schema).csv(filePath))
 
-      Prop.propBoolean(dataset.inputFiles sameElements dataset.dataset.inputFiles)
+      dataset.inputFiles sameElements dataset.dataset.inputFiles
     }
 
     def propJson[A: TypedEncoder](data: Vector[A]): Prop = {
@@ -38,7 +38,7 @@ class InputFilesTests extends TypedDatasetSuite with Matchers {
       val dataset = TypedDataset.createUnsafe(
         implicitly[SparkSession].sqlContext.read.schema(inputDataset.schema).json(filePath))
 
-      Prop.propBoolean(dataset.inputFiles sameElements dataset.dataset.inputFiles)
+      dataset.inputFiles sameElements dataset.dataset.inputFiles
     }
 
     check(forAll(propText[String] _))

--- a/dataset/src/test/scala/frameless/forward/IsLocalTests.scala
+++ b/dataset/src/test/scala/frameless/forward/IsLocalTests.scala
@@ -1,0 +1,17 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+
+class IsLocalTests extends TypedDatasetSuite {
+  test("isLocal") {
+    def prop[A: TypedEncoder](data: Vector[A]): Prop = {
+      val dataset = TypedDataset.create(data)
+
+      dataset.isLocal ?= dataset.dataset.isLocal
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/IsStreamingTests.scala
+++ b/dataset/src/test/scala/frameless/forward/IsStreamingTests.scala
@@ -1,0 +1,17 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+
+class IsStreamingTests extends TypedDatasetSuite {
+  test("isStreaming") {
+    def prop[A: TypedEncoder](data: Vector[A]): Prop = {
+      val dataset = TypedDataset.create(data)
+
+      dataset.isStreaming ?= dataset.dataset.isStreaming
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/QueryExecutionTests.scala
+++ b/dataset/src/test/scala/frameless/forward/QueryExecutionTests.scala
@@ -1,0 +1,17 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop.{forAll, _}
+
+class QueryExecutionTests extends TypedDatasetSuite {
+  test("queryExecution") {
+    def prop[A: TypedEncoder](data: Vector[A]): Prop = {
+      val dataset = TypedDataset.create[A](data)
+
+      dataset.sparkSession.run() =? dataset.dataset.sparkSession
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/QueryExecutionTests.scala
+++ b/dataset/src/test/scala/frameless/forward/QueryExecutionTests.scala
@@ -8,7 +8,7 @@ class QueryExecutionTests extends TypedDatasetSuite {
     def prop[A: TypedEncoder](data: Vector[A]): Prop = {
       val dataset = TypedDataset.create[A](data)
 
-      dataset.queryExecution.run() =? dataset.dataset.queryExecution
+      dataset.queryExecution =? dataset.dataset.queryExecution
     }
 
     check(forAll(prop[Int] _))

--- a/dataset/src/test/scala/frameless/forward/QueryExecutionTests.scala
+++ b/dataset/src/test/scala/frameless/forward/QueryExecutionTests.scala
@@ -8,7 +8,7 @@ class QueryExecutionTests extends TypedDatasetSuite {
     def prop[A: TypedEncoder](data: Vector[A]): Prop = {
       val dataset = TypedDataset.create[A](data)
 
-      dataset.sparkSession.run() =? dataset.dataset.sparkSession
+      dataset.queryExecution.run() =? dataset.dataset.queryExecution
     }
 
     check(forAll(prop[Int] _))

--- a/dataset/src/test/scala/frameless/forward/RandomSplitTests.scala
+++ b/dataset/src/test/scala/frameless/forward/RandomSplitTests.scala
@@ -10,7 +10,6 @@ import scala.collection.JavaConversions._
 class RandomSplitTests extends TypedDatasetSuite with Matchers {
 
   val nonEmptyPositiveArray: Gen[Array[Double]] = Gen.nonEmptyListOf(Gen.posNum[Double]).map(_.toArray)
-  def vectorGen[A: Arbitrary]: Gen[Vector[A]] = arbVector[A].arbitrary
 
   test("randomSplit(weight, seed)") {
     def prop[A: TypedEncoder : Arbitrary] = forAll(vectorGen[A], nonEmptyPositiveArray, arbitrary[Long]) {

--- a/dataset/src/test/scala/frameless/forward/RandomSplitTests.scala
+++ b/dataset/src/test/scala/frameless/forward/RandomSplitTests.scala
@@ -1,0 +1,40 @@
+package frameless
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.Matchers
+
+import scala.collection.JavaConversions._
+
+class RandomSplitTests extends TypedDatasetSuite with Matchers {
+
+  val nonEmptyPositiveArray: Gen[Array[Double]] = Gen.nonEmptyListOf(Gen.posNum[Double]).map(_.toArray)
+  def vectorGen[A: Arbitrary]: Gen[Vector[A]] = arbVector[A].arbitrary
+
+  test("randomSplit(weight, seed)") {
+    def prop[A: TypedEncoder : Arbitrary] = forAll(vectorGen[A], nonEmptyPositiveArray, arbitrary[Long]) {
+      (data: Vector[A], weights: Array[Double], seed: Long) =>
+        val dataset = TypedDataset.create(data)
+
+        dataset.randomSplit(weights, seed).map(_.count().run()) sameElements
+          dataset.dataset.randomSplit(weights, seed).map(_.count())
+    }
+
+    check(prop[Int])
+    check(prop[String])
+  }
+
+  test("randomSplitAsList(weight, seed)") {
+    def prop[A: TypedEncoder : Arbitrary] = forAll(vectorGen[A], nonEmptyPositiveArray, arbitrary[Long]) {
+      (data: Vector[A], weights: Array[Double], seed: Long) =>
+        val dataset = TypedDataset.create(data)
+
+        dataset.randomSplitAsList(weights, seed).map(_.count().run()) sameElements
+          dataset.dataset.randomSplitAsList(weights, seed).map(_.count())
+    }
+
+    check(prop[Int])
+    check(prop[String])
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/SQLContextTests.scala
+++ b/dataset/src/test/scala/frameless/forward/SQLContextTests.scala
@@ -1,0 +1,17 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop.{forAll, _}
+
+class SQLContextTests extends TypedDatasetSuite {
+  test("sqlContext") {
+    def prop[A: TypedEncoder](data: Vector[A]): Prop = {
+      val dataset = TypedDataset.create[A](data)
+
+      dataset.sqlContext.run() =? dataset.dataset.sqlContext
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/SQLContextTests.scala
+++ b/dataset/src/test/scala/frameless/forward/SQLContextTests.scala
@@ -8,7 +8,7 @@ class SQLContextTests extends TypedDatasetSuite {
     def prop[A: TypedEncoder](data: Vector[A]): Prop = {
       val dataset = TypedDataset.create[A](data)
 
-      dataset.sqlContext.run() =? dataset.dataset.sqlContext
+      dataset.sqlContext =? dataset.dataset.sqlContext
     }
 
     check(forAll(prop[Int] _))

--- a/dataset/src/test/scala/frameless/forward/SparkSessionTests.scala
+++ b/dataset/src/test/scala/frameless/forward/SparkSessionTests.scala
@@ -8,7 +8,7 @@ class SparkSessionTests extends TypedDatasetSuite {
     def prop[A: TypedEncoder](data: Vector[A]): Prop = {
       val dataset = TypedDataset.create[A](data)
 
-      dataset.sparkSession.run() =? dataset.dataset.sparkSession
+      dataset.sparkSession =? dataset.dataset.sparkSession
     }
 
     check(forAll(prop[Int] _))

--- a/dataset/src/test/scala/frameless/forward/SparkSessionTests.scala
+++ b/dataset/src/test/scala/frameless/forward/SparkSessionTests.scala
@@ -1,0 +1,17 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+
+class SparkSessionTests extends TypedDatasetSuite {
+  test("sparkSession") {
+    def prop[A: TypedEncoder](data: Vector[A]): Prop = {
+      val dataset = TypedDataset.create[A](data)
+
+      dataset.sparkSession.run() =? dataset.dataset.sparkSession
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/StorageLevelTests.scala
+++ b/dataset/src/test/scala/frameless/forward/StorageLevelTests.scala
@@ -1,0 +1,29 @@
+package frameless
+
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.storage.StorageLevel._
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Gen}
+
+class StorageLevelTests extends TypedDatasetSuite {
+
+  val storageLevelGen: Gen[StorageLevel] = Gen.oneOf(Seq(NONE, DISK_ONLY, DISK_ONLY_2, MEMORY_ONLY,
+    MEMORY_ONLY_2, MEMORY_ONLY_SER, MEMORY_ONLY_SER_2, MEMORY_AND_DISK,
+    MEMORY_AND_DISK_2, MEMORY_AND_DISK_SER, MEMORY_AND_DISK_SER_2, OFF_HEAP))
+
+  test("storageLevel") {
+    def prop[A: TypedEncoder : Arbitrary] = forAll(vectorGen[A], storageLevelGen) {
+      (data: Vector[A], storageLevel: StorageLevel) =>
+        val dataset = TypedDataset.create(data)
+        if (storageLevel != StorageLevel.NONE)
+          dataset.persist(storageLevel)
+
+        dataset.count().run()
+
+        dataset.storageLevel() ?= dataset.dataset.storageLevel
+    }
+
+    check(prop[Int])
+    check(prop[String])
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/ToJSONTests.scala
+++ b/dataset/src/test/scala/frameless/forward/ToJSONTests.scala
@@ -1,0 +1,17 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+
+class ToJSONTests extends TypedDatasetSuite {
+  test("toJSON") {
+    def prop[A: TypedEncoder](data: Vector[A]): Prop = {
+      val dataset = TypedDataset.create(data)
+
+      dataset.toJSON.collect().run() ?= dataset.dataset.toJSON.collect()
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/ToLocalIteratorTests.scala
+++ b/dataset/src/test/scala/frameless/forward/ToLocalIteratorTests.scala
@@ -1,0 +1,19 @@
+package frameless
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+import org.scalatest.Matchers
+import scala.collection.JavaConversions._
+
+class ToLocalIteratorTests extends TypedDatasetSuite with Matchers {
+  test("toLocalIterator") {
+    def prop[A: TypedEncoder](data: Vector[A]): Prop = {
+      val dataset = TypedDataset.create(data)
+
+      dataset.toLocalIterator().run().toIterator sameElements dataset.dataset.toLocalIterator().toIterator
+    }
+
+    check(forAll(prop[Int] _))
+    check(forAll(prop[String] _))
+  }
+}

--- a/dataset/src/test/scala/frameless/forward/WriteTests.scala
+++ b/dataset/src/test/scala/frameless/forward/WriteTests.scala
@@ -1,0 +1,26 @@
+package frameless
+
+import java.util.UUID
+
+import org.apache.spark.sql.SparkSession
+import org.scalacheck.Prop._
+import org.scalacheck.{Gen, Prop}
+
+class WriteTests extends TypedDatasetSuite {
+  test("write") {
+    def prop[A: TypedEncoder](data: List[A]): Prop = {
+      val filePath = s"$TEST_OUTPUT_DIR/${UUID.randomUUID()}"
+      val input = TypedDataset.create(data)
+      input.write.csv(filePath)
+
+      val dataset = TypedDataset.createUnsafe(
+        implicitly[SparkSession].sqlContext.read.schema(input.schema).csv(filePath))
+
+      dataset.collect().run().groupBy(identity) ?= input.collect().run().groupBy(identity)
+    }
+
+    check(forAll(Gen.listOf(Gen.alphaNumStr.suchThat(_.nonEmpty)))(prop[String]))
+    check(forAll(prop[Int] _))
+  }
+
+}

--- a/dataset/src/test/scala/frameless/package.scala
+++ b/dataset/src/test/scala/frameless/package.scala
@@ -37,4 +37,5 @@ package object frameless {
     } yield new UdtEncodedClass(int, doubles.toArray)
   }
 
+  val TEST_OUTPUT_DIR = "target/test-output"
 }

--- a/dataset/src/test/scala/frameless/package.scala
+++ b/dataset/src/test/scala/frameless/package.scala
@@ -30,6 +30,8 @@ package object frameless {
   implicit def arbVector[A](implicit A: Arbitrary[A]): Arbitrary[Vector[A]] =
     Arbitrary(Gen.listOf(A.arbitrary).map(_.toVector))
 
+  def vectorGen[A: Arbitrary]: Gen[Vector[A]] = arbVector[A].arbitrary
+
   implicit val arbUdtEncodedClass: Arbitrary[UdtEncodedClass] = Arbitrary {
     for {
       int <- Arbitrary.arbitrary[Int]


### PR DESCRIPTION
Connects to #163 

My plan is to implement all ```Straightforward TODO (forwarders)``` from #163 but first I wanted to make sure if I'm doing it right. 

I'm not sure if I should implement it like I did (using ``` F.delay ```) or in ```TypedDatasetForwarded``` trait