### PR TITLE
use Spark's DateType/TimestampType for SQLDate/SQLTimestamp

### DIFF
--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -177,14 +177,14 @@ object TypedEncoder {
     def catalystRepr: DataType = DateType
 
     def toCatalyst(path: Expression): Expression =
-      Invoke(path, "days", IntegerType)
+      Invoke(path, "days", DateType)
 
     def fromCatalyst(path: Expression): Expression =
       StaticInvoke(
         staticObject = SQLDate.getClass,
         dataType = jvmRepr,
         functionName = "apply",
-        arguments = intEncoder.fromCatalyst(path) :: Nil,
+        arguments = path :: Nil,
         propagateNull = true
       )
   }
@@ -196,14 +196,14 @@ object TypedEncoder {
     def catalystRepr: DataType = TimestampType
 
     def toCatalyst(path: Expression): Expression =
-      Invoke(path, "us", LongType)
+      Invoke(path, "us", TimestampType)
 
     def fromCatalyst(path: Expression): Expression =
       StaticInvoke(
         staticObject = SQLTimestamp.getClass,
         dataType = jvmRepr,
         functionName = "apply",
-        arguments = longEncoder.fromCatalyst(path) :: Nil,
+        arguments = path :: Nil,
         propagateNull = true
       )
   }


### PR DESCRIPTION
Related issue: https://github.com/typelevel/frameless/issues/234.

In local testing (I haven't run the full test suite), changing the representation of `SQLDate`/`SQLTimestamp` fixes the issues I had with silently changing schemas in a minimal example.

I don't know if this is the correct fix, if it's intended, or if this PR even addresses the breadth of the issue, so I appreciate comments or context!