### PR TITLE
add size for column of Map

### DIFF
--- a/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala
@@ -6,12 +6,19 @@ import org.apache.spark.sql.{Column, functions => sparkFunctions}
 import scala.math.Ordering
 
 trait UnaryFunctions {
-  /** Returns length of array or map.
+  /** Returns length of array
     *
     * apache/spark
     */
   def size[T, A, V[_] : CatalystSizableCollection](column: TypedColumn[T, V[A]]): TypedColumn[T, Int] =
     new TypedColumn[T, Int](implicitly[CatalystSizableCollection[V]].sizeOp(column.untyped))
+
+  /** Returns length of Map
+    *
+    * apache/spark
+    */
+  def size[T, A, B](column: TypedColumn[T, Map[A, B]]): TypedColumn[T, Int] =
+    new TypedColumn[T, Int](sparkFunctions.size(column.untyped))
 
   /** Sorts the input array for the given column in ascending order, according to
     * the natural ordering of the array elements.
@@ -55,6 +62,7 @@ object CatalystSizableCollection {
   implicit def sizableList: CatalystSizableCollection[List] = new CatalystSizableCollection[List] {
     def sizeOp(col: Column): Column = sparkFunctions.size(col)
   }
+
 }
 
 trait CatalystExplodableCollection[V[_]]

--- a/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
+++ b/dataset/src/test/scala/frameless/functions/UnaryFunctionsTest.scala
@@ -42,6 +42,21 @@ class UnaryFunctionsTest extends TypedDatasetSuite {
     check(forAll(prop[X2[Int, Option[Long]]] _))
   }
 
+  test("size on Map") {
+    def prop[A](xs: List[X1[Map[A, A]]])(implicit arb: Arbitrary[Map[A, A]], enc: TypedEncoder[Map[A, A]]): Prop = {
+      val tds = TypedDataset.create(xs)
+
+      val framelessResults = tds.select(size(tds('a))).collect().run().toVector
+      val scalaResults = xs.map(x => x.a.size).toVector
+
+      framelessResults ?= scalaResults
+    }
+
+    check(forAll(prop[Long] _))
+    check(forAll(prop[Int] _))
+    check(forAll(prop[Char] _))
+  }
+
   test("sort in ascending order") {
     def prop[F[X] <: SeqLike[X, F[X]] : CatalystSortableCollection, A: Ordering](xs: List[X1[F[A]]])(implicit enc: TypedEncoder[F[A]]): Prop = {
       val tds = TypedDataset.create(xs)


### PR DESCRIPTION
The curent implementation of [size](https://github.com/typelevel/frameless/blob/master/dataset/src/main/scala/frameless/functions/UnaryFunctions.scala#L13) doesn't handle Map as it needs two types for key and value.

The following example leads to this error:

```scala
    import frameless.TypedDataset
    import frameless.functions.size
    case class Foo(a: Map[String, String])
    val ds = TypedDataset.create(List(Foo(Map("foo" -> "bar"))))
    ds.select(size(ds('a)))
```
```bash
no type parameters for method size: (column: frameless.TypedColumn[T,V[A]])(implicit evidence$1: frameless.functions.CatalystSizableCollection[V])frameless.TypedColumn[T,Int] exist so that it can be applied to arguments (frameless.TypedColumn[Foo,Map[String,String]])
[error]  --- because ---
[error] argument expression's type is not compatible with formal parameter type;
[error]  found   : frameless.TypedColumn[Foo,Map[String,String]]
[error]  required: frameless.TypedColumn[?T,?V[?A]]
[error]     ds.select(size(ds('a)))

```

This PR adds a size function to handle Map

