### PR TITLE
Automatic derivation of CatalystOrdered for sortable case classes/tuples (#247)

### DIFF
--- a/core/src/main/scala/frameless/CatalystOrdered.scala
+++ b/core/src/main/scala/frameless/CatalystOrdered.scala
@@ -1,6 +1,7 @@
 package frameless
 
 import scala.annotation.implicitNotFound
+import shapeless._
 
 /** Types that can be ordered/compared by Catalyst. */
 @implicitNotFound("Cannot compare columns of type ${A}.")
@@ -27,4 +28,21 @@ object CatalystOrdered {
       i0: Injection[A, B],
       i1: CatalystOrdered[B]
     ): CatalystOrdered[A] = of[A]
+
+  implicit def deriveHNil[H](implicit head: CatalystOrdered[H]): CatalystOrdered[H :: HNil] =
+    of[H :: HNil]
+
+  implicit def deriveCons[H, T <: HList]
+    (implicit
+      i0: CatalystOrdered[H],
+      i1: CatalystOrdered[T]
+    ): CatalystOrdered[H :: T] =
+      of[H :: T]
+
+  implicit def deriveCaseClass[C, H <: HList]
+    (implicit
+      i0: Generic.Aux[C, H],
+      i1: CatalystOrdered[H]
+    ): CatalystOrdered[C] =
+      of[C]
 }

--- a/core/src/main/scala/frameless/CatalystOrdered.scala
+++ b/core/src/main/scala/frameless/CatalystOrdered.scala
@@ -42,7 +42,7 @@ object CatalystOrdered {
   implicit def deriveCaseClass[C, H <: HList]
     (implicit
       i0: Generic.Aux[C, H],
-      i1: CatalystOrdered[H]
+      i1: Lazy[CatalystOrdered[H]]
     ): CatalystOrdered[C] =
       of[C]
 }

--- a/core/src/main/scala/frameless/CatalystOrdered.scala
+++ b/core/src/main/scala/frameless/CatalystOrdered.scala
@@ -1,7 +1,8 @@
 package frameless
 
 import scala.annotation.implicitNotFound
-import shapeless._
+import shapeless.{Generic, HList, Lazy}
+import shapeless.ops.hlist.LiftAll
 
 /** Types that can be ordered/compared by Catalyst. */
 @implicitNotFound("Cannot compare columns of type ${A}.")
@@ -29,20 +30,9 @@ object CatalystOrdered {
       i1: CatalystOrdered[B]
     ): CatalystOrdered[A] = of[A]
 
-  implicit def deriveHNil[H](implicit head: CatalystOrdered[H]): CatalystOrdered[H :: HNil] =
-    of[H :: HNil]
-
-  implicit def deriveCons[H, T <: HList]
+  implicit def deriveGeneric[G, H <: HList]
     (implicit
-      i0: CatalystOrdered[H],
-      i1: CatalystOrdered[T]
-    ): CatalystOrdered[H :: T] =
-      of[H :: T]
-
-  implicit def deriveCaseClass[C, H <: HList]
-    (implicit
-      i0: Generic.Aux[C, H],
-      i1: Lazy[CatalystOrdered[H]]
-    ): CatalystOrdered[C] =
-      of[C]
+      i0: Generic.Aux[G, H],
+      i1: Lazy[LiftAll[CatalystOrdered, H]]
+    ): CatalystOrdered[G] = of[G]
 }

--- a/dataset/src/test/scala/frameless/OrderByTests.scala
+++ b/dataset/src/test/scala/frameless/OrderByTests.scala
@@ -158,4 +158,31 @@ class OrderByTests extends TypedDatasetSuite with Matchers {
     illTyped("""d.orderBy(d('b).desc)""")
     illTyped("""d.sortWithinPartitions(d('b).desc)""")
   }
+
+  test("derives a CatalystOrdered for case classes when all fields are comparable") {
+    type T[A, B] = X3[Int, Boolean, X2[A, B]]
+    def prop[
+      A: TypedEncoder : CatalystOrdered,
+      B: TypedEncoder : CatalystOrdered
+    ](data: Vector[T[A, B]]): Prop = {
+      val ds = TypedDataset.create(data)
+
+      sortings[X2[A, B], T[A, B]].map { case (typX2, untypX2) =>
+        val vanilla   = ds.dataset.orderBy(untypX2(ds.dataset.col("c"))).collect().toVector
+        val frameless = ds.orderBy(typX2(ds('c))).collect().run.toVector
+        vanilla ?= frameless
+      }.reduce(_ && _)
+    }
+
+    check(forAll(prop[Int, Long] _))
+    check(forAll(prop[String, SQLDate] _))
+    // Check that nested case classes are properly derived too
+    check(forAll(prop[X2[Boolean, Float], X4[SQLTimestamp, Double, Short, Byte]] _))
+  }
+
+  test("fails to compile when one of the field isn't comparable") {
+    type T = X2[Int, X2[Int, Map[String, String]]]
+    val d = TypedDataset.create(X2(1, X2(2, Map("not" -> "comparable"))) :: Nil)
+    illTyped("d.orderBy(d('b).desc)", """Cannot compare columns of type frameless.X2\[Int,scala.collection.immutable.Map\[String,String]].""")
+  }
 }


### PR DESCRIPTION
Provides an implicit `CatalystOrdered[T]` as long as there is a `Generic[T]` and all the elements of the `HList` have a `CatalystOrdered` instance.

See issue https://github.com/typelevel/frameless/issues/247.