### PR TITLE
allow creating TypedDataset from DFs with different column order

### DIFF
--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -1036,8 +1036,15 @@ object TypedDataset {
     val shouldReshape = output.zip(targetColNames).exists {
       case (expr, colName) => expr.name != colName
     }
+    val canSelect = targetColNames.toSet.subsetOf(output.map(_.name).toSet)
 
-    val reshaped = if (shouldReshape) df.toDF(targetColNames: _*) else df
+    val reshaped = if (shouldReshape && canSelect) {
+      df.select(targetColNames.head, targetColNames.tail:_*)
+    } else if (shouldReshape) {
+      df.toDF(targetColNames: _*)
+    } else {
+      df
+    }
 
     new TypedDataset[A](reshaped.as[A](TypedExpressionEncoder[A]))
   }

--- a/dataset/src/test/scala/frameless/CreateTests.scala
+++ b/dataset/src/test/scala/frameless/CreateTests.scala
@@ -143,9 +143,10 @@ class CreateTests extends TypedDatasetSuite with Matchers {
           Vector((b1, a1))
         ).dataset.toDF("b", "a").as[X2[A, B]](TypedExpressionEncoder[X2[A, B]])
         TypedDataset.create(ds).collect().run().head ?= X2(a1, b1)
+
       }
     }
-    check(prop[Double, Double])
+    check(prop[X1[Double], X1[X1[SQLDate]]])
     check(prop[String, Int])
   }
 }


### PR DESCRIPTION
as they can appear when loading partitioned datasets from e.g. parquet.

Vanilla spark is able to deserialize from dataframes where the fields are in different order.
The reshaping in `TypedDataset.createUnsafe` just renamed column so that types did not align anymore, although beforehand, in this particular case, it actually should have worked.

Given a dataframe of `("a": A, "b": B, "c": C)` we want a Dataset of `case class X(b: B, c: C, a: A)` from it. When using `TypedDataset.createUnsafe` we an encoder which will try to read the underlying relation/dataframe as: `("b": A, "c": B, "a": C)` which will clearly fail to serialize/deserialize to `X`.

To work around this issue, we now check if the target columns are a subset of the source df columns and if so, do a select instead of a `.toDf(names)` which only renames.