### PR TITLE
Support for unit types in products

### DIFF
--- a/dataset/src/main/scala/frameless/RecordEncoder.scala
+++ b/dataset/src/main/scala/frameless/RecordEncoder.scala
@@ -46,7 +46,7 @@ object RecordEncoderFields {
     }
 }
 
-trait NewInstanceExprs[T <: HList] {
+trait NewInstanceExprs[T <: HList] extends Serializable {
   def from(exprs: List[Expression]): Seq[Expression]
 }
 

--- a/dataset/src/main/scala/frameless/RecordEncoder.scala
+++ b/dataset/src/main/scala/frameless/RecordEncoder.scala
@@ -47,8 +47,8 @@ object RecordEncoderFields {
 }
 
 /**
-  * Assists the generation of constructor call parameters from a [[LabelledGeneric]] representation.
-  * As [[Unit]] typed fields were removed earlier, we need to put back [[()]] literals in the  appropriate positions.
+  * Assists the generation of constructor call parameters from a labelled generic representation.
+  * As Unit typed fields were removed earlier, we need to put back unit literals in the  appropriate positions.
   *
   * @tparam T labelled generic representation of type fields
   */
@@ -80,7 +80,7 @@ object NewInstanceExprs {
 }
 
 /**
-  * Drops fields with [[Unit]] type from [[LabelledGeneric]] representation of types.
+  * Drops fields with Unit type from labelled generic representation of types.
   *
   * @tparam L labelled generic representation of type fields
   */

--- a/dataset/src/main/scala/frameless/RecordEncoder.scala
+++ b/dataset/src/main/scala/frameless/RecordEncoder.scala
@@ -46,6 +46,12 @@ object RecordEncoderFields {
     }
 }
 
+/**
+  * Assists the generation of constructor call parameters from a [[LabelledGeneric]] representation.
+  * As [[Unit]] typed fields were removed earlier, we need to put back [[()]] literals in the  appropriate positions.
+  *
+  * @tparam T labelled generic representation of type fields
+  */
 trait NewInstanceExprs[T <: HList] extends Serializable {
   def from(exprs: List[Expression]): Seq[Expression]
 }
@@ -73,6 +79,11 @@ object NewInstanceExprs {
     }
 }
 
+/**
+  * Drops fields with [[Unit]] type from [[LabelledGeneric]] representation of types.
+  *
+  * @tparam L labelled generic representation of type fields
+  */
 trait DropUnitValues[L <: HList] extends DepFn1[L] with Serializable { type Out <: HList }
 
 object DropUnitValues {
@@ -105,9 +116,9 @@ object DropUnitValues {
 
 class RecordEncoder[F, G <: HList, H <: HList]
   (implicit
-    lgen: LabelledGeneric.Aux[F, G],
-    nonUnitFields: DropUnitValues.Aux[G, H],
-    hasFields: IsHCons[H],
+    i0: LabelledGeneric.Aux[F, G],
+    i1: DropUnitValues.Aux[G, H],
+    i2: IsHCons[H],
     fields: Lazy[RecordEncoderFields[H]],
     newInstanceExprs: Lazy[NewInstanceExprs[G]],
     classTag: ClassTag[F]

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -9,8 +9,7 @@ import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import shapeless._
-import shapeless.labelled.FieldType
-import shapeless.ops.hlist.{FilterNot, IsHCons, SubtypeUnifier}
+import shapeless.ops.hlist.IsHCons
 
 import scala.reflect.ClassTag
 
@@ -403,16 +402,15 @@ object TypedEncoder {
       }
 
   /** Encodes things as records if there is not Injection defined */
-  implicit def usingDerivation[F, G <: HList, H <: HList, I <: HList]
+  implicit def usingDerivation[F, G <: HList, H <: HList]
     (implicit
       i0: LabelledGeneric.Aux[F, G],
-      i1: SubtypeUnifier.Aux[G, FieldType[_, Unit], H],
-      i2: FilterNot.Aux[H, FieldType[_, Unit], I],
-      i3: IsHCons[I],
-      i4: Lazy[RecordEncoderFields[I]],
-      i5: Lazy[NewInstanceExprs[G]],
-      i6: ClassTag[F]
-    ): TypedEncoder[F] = new RecordEncoder[F, G, H, I]
+      i1: DropUnitValues.Aux[G, H],
+      i2: IsHCons[H],
+      i3: Lazy[RecordEncoderFields[H]],
+      i4: Lazy[NewInstanceExprs[G]],
+      i5: ClassTag[F]
+    ): TypedEncoder[F] = new RecordEncoder[F, G, H]
 
   /** Encodes things using a Spark SQL's User Defined Type (UDT) if there is one defined in implicit */
   implicit def usingUserDefinedType[A >: Null : UserDefinedType : ClassTag]: TypedEncoder[A] = {

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -401,7 +401,7 @@ object TypedEncoder {
         }
       }
 
-  /** Encodes things as records if there is not Injection defined */
+  /** Encodes things as records if there is no Injection defined */
   implicit def usingDerivation[F, G <: HList, H <: HList]
     (implicit
       i0: LabelledGeneric.Aux[F, G],

--- a/dataset/src/test/scala/frameless/CreateTests.scala
+++ b/dataset/src/test/scala/frameless/CreateTests.scala
@@ -24,6 +24,7 @@ class CreateTests extends TypedDatasetSuite with Matchers {
     check(forAll(prop[Int, Char, X2[Option[Country], Country], Int] _))
     check(forAll(prop[X2[Int, Int], Int, Boolean, Vector[Food]] _))
     check(forAll(prop[String, Food, X3[Food, Country, Boolean], Int] _))
+    check(forAll(prop[String, Food, X3U[Food, Country, Boolean], Int] _))
     check(forAll(prop[
       Option[Vector[Food]],
       Vector[Vector[X2[Vector[(Person, X1[Char])], Country]]],

--- a/dataset/src/test/scala/frameless/InjectionTests.scala
+++ b/dataset/src/test/scala/frameless/InjectionTests.scala
@@ -94,6 +94,7 @@ class InjectionTests extends TypedDatasetSuite {
     check(forAll(prop[X1[X1[Food]]] _))
     check(forAll(prop[X2[Country, X2[LocalDateTime, Food]]] _))
     check(forAll(prop[X3[Country, LocalDateTime, Food]] _))
+    check(forAll(prop[X3U[Country, LocalDateTime, Food]] _))
 
     check(forAll(prop[I[Int]] _))
     check(forAll(prop[I[Option[Int]]] _))

--- a/dataset/src/test/scala/frameless/InjectionTests.scala
+++ b/dataset/src/test/scala/frameless/InjectionTests.scala
@@ -130,7 +130,7 @@ class InjectionTests extends TypedDatasetSuite {
 
   test("Resolve ambiguity by importing usingDerivation") {
     import TypedEncoder.usingDerivation
-    assert(implicitly[TypedEncoder[Person]].isInstanceOf[RecordEncoder[Person, _, _, _]])
+    assert(implicitly[TypedEncoder[Person]].isInstanceOf[RecordEncoder[Person, _, _]])
     check(forAll(prop[Person] _))
   }
 }

--- a/dataset/src/test/scala/frameless/InjectionTests.scala
+++ b/dataset/src/test/scala/frameless/InjectionTests.scala
@@ -130,7 +130,7 @@ class InjectionTests extends TypedDatasetSuite {
 
   test("Resolve ambiguity by importing usingDerivation") {
     import TypedEncoder.usingDerivation
-    assert(implicitly[TypedEncoder[Person]].isInstanceOf[RecordEncoder[Person, _]])
+    assert(implicitly[TypedEncoder[Person]].isInstanceOf[RecordEncoder[Person, _, _, _]])
     check(forAll(prop[Person] _))
   }
 }

--- a/dataset/src/test/scala/frameless/RecordEncoderTests.scala
+++ b/dataset/src/test/scala/frameless/RecordEncoderTests.scala
@@ -12,15 +12,15 @@ object TupleWithUnits {
 }
 
 class RecordEncoderTests extends TypedDatasetSuite with Matchers {
-  test("Unable to encode only units") {
+  test("Unable to encode products made from units only") {
     illTyped("""TypedEncoder[UnitsOnly]""")
   }
 
-  test("Unit fields are skipped") {
+  test("Representation skips units") {
     assert(TypedEncoder[(Int, String)].catalystRepr == TypedEncoder[TupleWithUnits].catalystRepr)
   }
 
-  test("") {
+  test("Serialization skips units") {
     val df = session.createDataFrame(Seq((1, "one"), (2, "two")))
     val ds = df.as[TupleWithUnits](TypedExpressionEncoder[TupleWithUnits])
     val tds = TypedDataset.create(Seq(TupleWithUnits(1, "one"), TupleWithUnits(2, "two")))

--- a/dataset/src/test/scala/frameless/RecordEncoderTests.scala
+++ b/dataset/src/test/scala/frameless/RecordEncoderTests.scala
@@ -1,6 +1,7 @@
 package frameless
 
 import org.scalatest.Matchers
+import shapeless.{HList, LabelledGeneric}
 import shapeless.test.illTyped
 
 case class UnitsOnly(a: Unit, b: Unit)
@@ -14,6 +15,12 @@ object TupleWithUnits {
 class RecordEncoderTests extends TypedDatasetSuite with Matchers {
   test("Unable to encode products made from units only") {
     illTyped("""TypedEncoder[UnitsOnly]""")
+  }
+
+  test("Dropping fields") {
+    def dropUnitValues[L <: HList](l: L)(implicit d: DropUnitValues[L]): d.Out = d(l)
+    val fields = LabelledGeneric[TupleWithUnits].to(TupleWithUnits(42, "something"))
+    dropUnitValues(fields) shouldEqual LabelledGeneric[(Int, String)].to((42, "something"))
   }
 
   test("Representation skips units") {

--- a/dataset/src/test/scala/frameless/RecordEncoderTests.scala
+++ b/dataset/src/test/scala/frameless/RecordEncoderTests.scala
@@ -1,0 +1,31 @@
+package frameless
+
+import org.scalatest.Matchers
+import shapeless.test.illTyped
+
+case class UnitsOnly(a: Unit, b: Unit)
+
+case class TupleWithUnits(u0: Unit, _1: Int, u1: Unit, u2: Unit, _2: String, u3: Unit)
+
+object TupleWithUnits {
+  def apply(_1: Int, _2: String): TupleWithUnits = TupleWithUnits((), _1, (), (), _2, ())
+}
+
+class RecordEncoderTests extends TypedDatasetSuite with Matchers {
+  test("Unable to encode only units") {
+    illTyped("""TypedEncoder[UnitsOnly]""")
+  }
+
+  test("Unit fields are skipped") {
+    assert(TypedEncoder[(Int, String)].catalystRepr == TypedEncoder[TupleWithUnits].catalystRepr)
+  }
+
+  test("") {
+    val df = session.createDataFrame(Seq((1, "one"), (2, "two")))
+    val ds = df.as[TupleWithUnits](TypedExpressionEncoder[TupleWithUnits])
+    val tds = TypedDataset.create(Seq(TupleWithUnits(1, "one"), TupleWithUnits(2, "two")))
+
+    df.collect shouldEqual tds.toDF.collect
+    ds.collect.toSeq shouldEqual tds.collect.run
+  }
+}

--- a/dataset/src/test/scala/frameless/XN.scala
+++ b/dataset/src/test/scala/frameless/XN.scala
@@ -39,6 +39,19 @@ object X3 {
     Ordering.Tuple3[A, B, C].on(x => (x.a, x.b, x.c))
 }
 
+case class X3U[A, B, C](a: A, b: B, u: Unit, c: C)
+
+object X3U {
+  implicit def arbitrary[A: Arbitrary, B: Arbitrary, C: Arbitrary]: Arbitrary[X3U[A, B, C]] =
+    Arbitrary(Arbitrary.arbTuple3[A, B, C].arbitrary.map(x => X3U[A, B, C](x._1, x._2, (), x._3)))
+
+  implicit def cogen[A, B, C](implicit A: Cogen[A], B: Cogen[B], C: Cogen[C]): Cogen[X3U[A, B, C]] =
+    Cogen.tuple3(A, B, C).contramap(x => (x.a, x.b, x.c))
+
+  implicit def ordering[A: Ordering, B: Ordering, C: Ordering]: Ordering[X3U[A, B, C]] =
+    Ordering.Tuple3[A, B, C].on(x => (x.a, x.b, x.c))
+}
+
 case class X4[A, B, C, D](a: A, b: B, c: C, d: D)
 
 object X4 {

--- a/dataset/src/test/scala/frameless/functions/UdfTests.scala
+++ b/dataset/src/test/scala/frameless/functions/UdfTests.scala
@@ -65,6 +65,7 @@ class UdfTests extends TypedDatasetSuite {
     check(forAll(prop[Int, Int, Int] _))
     check(forAll(prop[String, Int, Int] _))
     check(forAll(prop[X3[Int, String, Boolean], Int, Int] _))
+    check(forAll(prop[X3U[Int, String, Boolean], Int, Int] _))
   }
 
   test("two argument udf") {

--- a/dataset/src/test/scala/frameless/ops/SmartProjectTest.scala
+++ b/dataset/src/test/scala/frameless/ops/SmartProjectTest.scala
@@ -40,4 +40,20 @@ class SmartProjectTest extends TypedDatasetSuite {
     check(forAll(prop[X2[String, Boolean], (Boolean, Boolean), String, Boolean] _))
     check(forAll(prop[X2[String, Boolean], X3[Boolean, Boolean, Long], String, String] _))
   }
+
+  test("X3U to X1,X2,X3 projections") {
+    def prop[A: TypedEncoder, B: TypedEncoder, C: TypedEncoder](data: Vector[X3U[A, B, C]]): Prop = {
+      val dataset = TypedDataset.create(data)
+
+      dataset.project[X3[A, B, C]].collect().run().toVector ?= data.map(x => X3(x.a, x.b, x.c))
+      dataset.project[X2[A, B]].collect().run().toVector ?= data.map(x => X2(x.a, x.b))
+      dataset.project[X1[A]].collect().run().toVector ?= data.map(x => X1(x.a))
+    }
+
+    check(forAll(prop[Int, String, X1[String]] _))
+    check(forAll(prop[Short, Long, String] _))
+    check(forAll(prop[Short, (Boolean, Boolean), String] _))
+    check(forAll(prop[X2[String, Boolean], (Boolean, Boolean), String] _))
+    check(forAll(prop[X2[String, Boolean], X3[Boolean, Boolean, Long], String] _))
+  }
 }


### PR DESCRIPTION
Unit support was removed in #181. This is a different approach: do not encode unit fields at all, but skip them.