### PR TITLE
Non aggregate maths operators

### DIFF
--- a/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
@@ -386,4 +386,87 @@ trait NonAggregateFunctions {
     */
   def year[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, Option[Int]] =
     str.typed(untyped.year(str.untyped))
+
+  /** Non-Aggregate function: Computes the floor of the given value.
+    *
+    * apache/spark
+    */
+  def floor[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Int] =
+    col.typed(untyped.floor(col.cast[Double].untyped)) //TODO: output type
+
+  /** Non-Aggregate function: Computes the ceiling of the given value.
+    *
+    * apache/spark
+    */
+  def ceil[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Int] =
+    col.typed(untyped.ceil(col.cast[Double].untyped)) //TODO: output type
+
+  /** Non-Aggregate function: Returns the value of the first argument raised to the power of the second argument.
+    *
+    * apache/spark
+    */
+  def pow[B, T](left: Double, right: AbstractTypedColumn[T, B])(
+                 implicit
+                 i1: CatalystCast[B, Double]
+  ): right.ThisType[T, Double] =
+    right.typed(untyped.pow(left, right.cast[Double].untyped))
+
+  /** Non-Aggregate function: Returns the value of the first argument raised to the power of the second argument.
+    *
+    * apache/spark
+    */
+  def pow[A, T](left: AbstractTypedColumn[T, A], right: Double)(
+                 implicit
+                 i0: CatalystCast[A, Double]
+  ): left.ThisType[T, Double] =
+    left.typed(untyped.pow(left.cast[Double].untyped, right))
+
+  /** Non-Aggregate function: Returns the value of the first argument raised to the power of the second argument.
+    *
+    * apache/spark
+    */
+  def pow[A, B, T](left: AbstractTypedColumn[T, A], right: AbstractTypedColumn[T, B])(
+    implicit
+      i0: CatalystCast[A, Double],
+      i1: CatalystCast[B, Double]
+  ): left.ThisType[T, Double] =
+    left.typed(untyped.pow(left.cast[Double].untyped, right.cast[Double].untyped))
+
+  /** Non-Aggregate function: Computes the square root of the specified float value.
+    *
+    * Differs from `Column#year` by wrapping it's result into an `Option`.
+    *
+    * apache/spark
+    */
+  def sqrt[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Double] =
+    col.typed(untyped.sqrt(col.cast[Double].untyped))
+
+  /** Non-Aggregate function: Computes the natural logarithm of the given value.
+    *
+    * apache/spark
+    */
+  def log[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Double] =
+    col.typed(untyped.log(col.cast[Double].untyped))
+
+  /** Non-Aggregate function: Computes the natural logarithm of the given value plus one.
+    *
+    * apache/spark
+    */
+  def log1p[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Double] =
+    col.typed(untyped.log1p(col.cast[Double].untyped))
+
+  /** Non-Aggregate function: Computes the logarithm of the given column in base 2.
+    *
+    * apache/spark
+    */
+  def log2[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Double] =
+    col.typed(untyped.log2(col.cast[Double].untyped))
+
+  /** Non-Aggregate function: Computes the logarithm of the given value in base 10.
+    *
+    * apache/spark
+    */
+  def log10[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Double] =
+    col.typed(untyped.log10(col.cast[Double].untyped))
+
 }

--- a/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
@@ -434,12 +434,32 @@ trait NonAggregateFunctions {
 
   /** Non-Aggregate function: Computes the square root of the specified float value.
     *
-    * Differs from `Column#year` by wrapping it's result into an `Option`.
-    *
     * apache/spark
     */
   def sqrt[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Double] =
     col.typed(untyped.sqrt(col.cast[Double].untyped))
+
+  /** Non-Aggregate function: Returns the double value that is closest in value to the argument and
+    * is equal to a mathematical integer.
+    *
+    * apache/spark
+    */
+  def rint[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Double] =
+    col.typed(untyped.rint(col.cast[Double].untyped))
+
+  /** Non-Aggregate function: Computes the exponential of the given value.
+    *
+    * apache/spark
+    */
+  def exp[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Double] =
+    col.typed(untyped.exp(col.cast[Double].untyped))
+
+  /** Non-Aggregate function: Computes the exponential of the given value minus one.
+    *
+    * apache/spark
+    */
+  def expm1[A, T](col: AbstractTypedColumn[T, A])(implicit i0: CatalystCast[A, Double]): col.ThisType[T, Double] =
+    col.typed(untyped.expm1(col.cast[Double].untyped))
 
   /** Non-Aggregate function: Computes the natural logarithm of the given value.
     *

--- a/dataset/src/test/scala/frameless/functions/NonAggregateFunctionsTests.scala
+++ b/dataset/src/test/scala/frameless/functions/NonAggregateFunctionsTests.scala
@@ -1213,6 +1213,54 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     check(prop[Short] _)
   }
 
+  test("rint") {
+    val spark = session
+    import spark.implicits._
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: Vector[X1[A]])(implicit ev: CatalystCast[A, Double]): Prop = {
+      val typedDS = TypedDataset.create(values)
+      propDoubleArithmetic1(typedDS)(rint(typedDS('a)), untyped.rint)
+    }
+
+    check(prop[BigDecimal] _)
+    check(prop[Byte] _)
+    check(prop[Double] _)
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[Short] _)
+  }
+
+  test("exp") {
+    val spark = session
+    import spark.implicits._
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: Vector[X1[A]])(implicit ev: CatalystCast[A, Double]): Prop = {
+      val typedDS = TypedDataset.create(values)
+      propDoubleArithmetic1(typedDS)(exp(typedDS('a)), untyped.exp)
+    }
+
+    check(prop[BigDecimal] _)
+    check(prop[Byte] _)
+    check(prop[Double] _)
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[Short] _)
+  }
+
+  test("expm1") {
+    val spark = session
+    import spark.implicits._
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: Vector[X1[A]])(implicit ev: CatalystCast[A, Double]): Prop = {
+      val typedDS = TypedDataset.create(values)
+      propDoubleArithmetic1(typedDS)(expm1(typedDS('a)), untyped.exp)
+    }
+
+    check(prop[BigDecimal] _)
+    check(prop[Byte] _)
+    check(prop[Double] _)
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[Short] _)
+  }
+
   test("log") {
     val spark = session
     import spark.implicits._

--- a/dataset/src/test/scala/frameless/functions/NonAggregateFunctionsTests.scala
+++ b/dataset/src/test/scala/frameless/functions/NonAggregateFunctionsTests.scala
@@ -82,26 +82,48 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     check(forAll(prop[Double] _))
   }
 
-  def propTrigonometric[A: CatalystNumeric: TypedEncoder : Encoder](typedDS: TypedDataset[X1[A]])
-    (typedCol: TypedColumn[X1[A], Double], sparkFunc: Column => Column): Prop = {
-      val spark = session
-      import spark.implicits._
+  def propDoubleArithmetic1[A: CatalystNumeric: TypedEncoder : Encoder](typedDS: TypedDataset[X1[A]])
+                                                                       (typedCol: TypedColumn[X1[A], Double], sparkFunc: Column => Column): Prop = {
+    val spark = session
+    import spark.implicits._
 
-      val resCompare = typedDS.dataset
-        .select(sparkFunc($"a"))
-        .map(_.getAs[Double](0))
-        .map(DoubleBehaviourUtils.nanNullHandler)
-        .collect().toList
+    val resCompare = typedDS.dataset
+      .select(sparkFunc($"a"))
+      .map(_.getAs[Double](0))
+      .map(DoubleBehaviourUtils.nanNullHandler)
+      .collect().toList
 
-      val res = typedDS
-        .select(typedCol)
-        .deserialized
-        .map(DoubleBehaviourUtils.nanNullHandler)
-        .collect()
-        .run()
-        .toList
+    val res = typedDS
+      .select(typedCol)
+      .deserialized
+      .map(DoubleBehaviourUtils.nanNullHandler)
+      .collect()
+      .run()
+      .toList
 
-      res ?= resCompare
+    res ?= resCompare
+  }
+
+  def propDoubleArithmetic2[A: CatalystNumeric: TypedEncoder : Encoder](typedDS: TypedDataset[X2[A, A]])
+                                                                       (typedCol: TypedColumn[X2[A, A], Double], sparkFunc: (Column, Column) => Column): Prop = {
+    val spark = session
+    import spark.implicits._
+
+    val resCompare = typedDS.dataset
+      .select(sparkFunc($"a", $"b"))
+      .map(_.getAs[Double](0))
+      .map(DoubleBehaviourUtils.nanNullHandler)
+      .collect().toList
+
+    val res = typedDS
+      .select(typedCol)
+      .deserialized
+      .map(DoubleBehaviourUtils.nanNullHandler)
+      .collect()
+      .run()
+      .toList
+
+    res ?= resCompare
   }
 
   test("cos") {
@@ -111,7 +133,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(cos(typedDS('a)), untyped.cos)
+        propDoubleArithmetic1(typedDS)(cos(typedDS('a)), untyped.cos)
     }
 
     check(forAll(prop[Int] _))
@@ -129,7 +151,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(cosh(typedDS('a)), untyped.cosh)
+        propDoubleArithmetic1(typedDS)(cosh(typedDS('a)), untyped.cosh)
     }
 
     check(forAll(prop[Int] _))
@@ -147,7 +169,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(acos(typedDS('a)), untyped.acos)
+        propDoubleArithmetic1(typedDS)(acos(typedDS('a)), untyped.acos)
     }
 
     check(forAll(prop[Int] _))
@@ -165,7 +187,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(sin(typedDS('a)), untyped.sin)
+        propDoubleArithmetic1(typedDS)(sin(typedDS('a)), untyped.sin)
     }
 
     check(forAll(prop[Int] _))
@@ -183,7 +205,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(sinh(typedDS('a)), untyped.sinh)
+        propDoubleArithmetic1(typedDS)(sinh(typedDS('a)), untyped.sinh)
     }
 
     check(forAll(prop[Int] _))
@@ -201,7 +223,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(asin(typedDS('a)), untyped.asin)
+        propDoubleArithmetic1(typedDS)(asin(typedDS('a)), untyped.asin)
     }
 
     check(forAll(prop[Int] _))
@@ -219,7 +241,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(tan(typedDS('a)), untyped.tan)
+        propDoubleArithmetic1(typedDS)(tan(typedDS('a)), untyped.tan)
     }
 
     check(forAll(prop[Int] _))
@@ -237,7 +259,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(tanh(typedDS('a)), untyped.tanh)
+        propDoubleArithmetic1(typedDS)(tanh(typedDS('a)), untyped.tanh)
     }
 
     check(forAll(prop[Int] _))
@@ -1155,5 +1177,103 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
 
     check(forAll(dateTimeStringGen)(data => prop(data.map(X1.apply))))
     check(forAll(prop _))
+  }
+
+  test("pow") {
+    val spark = session
+    import spark.implicits._
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X2[A, A]])
+                                                         (implicit encX2:Encoder[X2[A, A]]) = {
+      val typedDS = TypedDataset.create(values)
+      propDoubleArithmetic2(typedDS)(pow(typedDS('a), typedDS('b)), untyped.pow)
+    }
+
+    check(prop[BigDecimal] _)
+    check(prop[Byte] _)
+    check(prop[Double] _)
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[Short] _)
+  }
+
+  test("sqrt") {
+    val spark = session
+    import spark.implicits._
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
+                                                         (implicit encX1:Encoder[X1[A]]) = {
+      val typedDS = TypedDataset.create(values)
+      propDoubleArithmetic1(typedDS)(sqrt(typedDS('a)), untyped.sqrt)
+    }
+
+    check(prop[BigDecimal] _)
+    check(prop[Byte] _)
+    check(prop[Double] _)
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[Short] _)
+  }
+
+  test("log") {
+    val spark = session
+    import spark.implicits._
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: Vector[X1[A]])(implicit ev: CatalystCast[A, Double]): Prop = {
+      val typedDS = TypedDataset.create(values)
+      propDoubleArithmetic1(typedDS)(log(typedDS('a)), untyped.log)
+    }
+
+    check(prop[BigDecimal] _)
+    check(prop[Byte] _)
+    check(prop[Double] _)
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[Short] _)
+  }
+
+  test("log2") {
+    val spark = session
+    import spark.implicits._
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: Vector[X1[A]])(implicit ev: CatalystCast[A, Double]): Prop = {
+      val typedDS = TypedDataset.create(values)
+      propDoubleArithmetic1(typedDS)(log2(typedDS('a)), untyped.log2)
+    }
+
+    check(prop[BigDecimal] _)
+    check(prop[Byte] _)
+    check(prop[Double] _)
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[Short] _)
+  }
+
+  test("log1p") {
+    val spark = session
+    import spark.implicits._
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: Vector[X1[A]])(implicit ev: CatalystCast[A, Double]): Prop = {
+      val typedDS = TypedDataset.create(values)
+      propDoubleArithmetic1(typedDS)(log1p(typedDS('a)), untyped.log1p)
+    }
+
+    check(prop[BigDecimal] _)
+    check(prop[Byte] _)
+    check(prop[Double] _)
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[Short] _)
+  }
+
+  test("log10") {
+    val spark = session
+    import spark.implicits._
+    def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: Vector[X1[A]])(implicit ev: CatalystCast[A, Double]): Prop = {
+      val typedDS = TypedDataset.create(values)
+      propDoubleArithmetic1(typedDS)(log10(typedDS('a)), untyped.log10)
+    }
+
+    check(prop[BigDecimal] _)
+    check(prop[Byte] _)
+    check(prop[Double] _)
+    check(prop[Int] _)
+    check(prop[Long] _)
+    check(prop[Short] _)
   }
 }


### PR DESCRIPTION
Still working on that, since some methods that should behave well (since they are just forwarded) return different results than the sparks ones.

Moreover, I'd also like to know how would you like to handle functions' behaviour on args outside from their domain. For example: Should log return TypedColumn[T, Double] or TypedColumn[T, Option[Double] since it returns NaN for args that are out of the domain.