### PR TITLE
Fixes #272 Target jvm to be 1.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,6 +96,7 @@ lazy val framelessSettings = Seq(
 )
 
 lazy val commonScalacOptions = Seq(
+  "-target:jvm-1.8", 
   "-deprecation",
   "-encoding", "UTF-8",
   "-feature",


### PR DESCRIPTION
After adding this:

```
$file TypedEncoder.class
TypedEncoder.class: compiled Java class data, version 52.0 (Java 1.8)
```
