### PR TITLE
add support for .as[A] when A is nested type

### DIFF
--- a/dataset/src/main/scala/frameless/ops/As.scala
+++ b/dataset/src/main/scala/frameless/ops/As.scala
@@ -1,15 +1,40 @@
 package frameless
 package ops
 
-import shapeless.{Generic, HList}
+import shapeless.{::, Generic, HList, Lazy}
 
-class As[T, U](implicit val encoder: TypedEncoder[U])
+/** Evidence for correctness of `TypedDataset[T].as[U]` */
+class As[T, U] private (implicit val encoder: TypedEncoder[U])
 
-object As {
-  implicit def deriveProduct[T, U, S <: HList]
+object As extends LowPriorityAs {
+
+  final class Equiv[A, B] private[ops] ()
+
+  implicit def equivIdentity[A] = new Equiv[A, A]
+
+  implicit def deriveAs[A, B]
     (implicit
-      i0: TypedEncoder[U],
-      i1: Generic.Aux[T, S],
-      i2: Generic.Aux[U, S]
-    ): As[T, U] = new As[T, U]
+      i0: TypedEncoder[B],
+      i1: Equiv[A, B]
+    ): As[A, B] = new As[A, B]
+
+}
+
+trait LowPriorityAs {
+
+  import As.Equiv
+
+  implicit def equivHList[AH, AT <: HList, BH, BT <: HList]
+    (implicit
+      i0: Lazy[Equiv[AH, BH]],
+      i1: Equiv[AT, BT]
+    ): Equiv[AH :: AT, BH :: BT] = new Equiv[AH :: AT, BH :: BT]
+
+  implicit def equivGeneric[A, B, R, S]
+    (implicit
+      i0: Generic.Aux[A, R],
+      i1: Generic.Aux[B, S],
+      i2: Lazy[Equiv[R, S]]
+    ): Equiv[A, B] = new Equiv[A, B]
+
 }

--- a/dataset/src/test/scala/frameless/AsTests.scala
+++ b/dataset/src/test/scala/frameless/AsTests.scala
@@ -22,5 +22,32 @@ class AsTests extends TypedDatasetSuite {
     check(forAll(prop[String, String] _))
     check(forAll(prop[String, Int] _))
     check(forAll(prop[Long, Int] _))
+    check(forAll(prop[Seq[Seq[Option[Seq[Long]]]], Seq[Int]] _))
+    check(forAll(prop[Seq[Option[Seq[String]]], Seq[Int]] _))
+  }
+
+  test("as[X2[X2[A, B], C]") {
+    def prop[A, B, C](data: Vector[(A, B, C)])(
+      implicit
+      eab: TypedEncoder[((A, B), C)],
+      ex2: TypedEncoder[X2[X2[A, B], C]]
+    ): Prop = {
+      val data2 = data.map {
+        case (a, b, c) => ((a, b), c)
+      }
+      val dataset = TypedDataset.create(data2)
+
+      val dataset2 = dataset.as[X2[X2[A,B], C]]().collect().run().toVector
+      val data3 = data2.map { case ((a, b), c) => X2(X2(a, b), c) }
+
+      dataset2 ?= data3
+    }
+
+    check(forAll(prop[String, Int, Int] _))
+    check(forAll(prop[String, Int, String] _))
+    check(forAll(prop[String, String, Int] _))
+    check(forAll(prop[Long, Int, String] _))
+    check(forAll(prop[Seq[Seq[Option[Seq[Long]]]], Seq[Int], Option[Seq[Option[Int]]]] _))
+    check(forAll(prop[Seq[Option[Seq[String]]], Seq[Int], Seq[Option[String]]] _))
   }
 }


### PR DESCRIPTION
Fix for #279.

I don't have a lot of experience with shapeless so I would appreciate your feedback on the implicits I've added. I'm confident they are correct, but I wonder if it could have been done more elegantly.

Thanks!