### PR TITLE
Rename untyped to sparkFunctions

### DIFF
--- a/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/AggregateFunctions.scala
@@ -3,7 +3,7 @@ package functions
 
 import org.apache.spark.sql.FramelessInternals.expr
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.{functions => untyped}
+import org.apache.spark.sql.{functions => sparkFunctions}
 import frameless.syntax._
 
 trait AggregateFunctions {
@@ -12,26 +12,26 @@ trait AggregateFunctions {
     * apache/spark
     */
   def count[T](): TypedAggregate[T, Long] =
-    untyped.count(untyped.lit(1)).typedAggregate
+    sparkFunctions.count(sparkFunctions.lit(1)).typedAggregate
 
   /** Aggregate function: returns the number of items in a group for which the selected column is not null.
     *
     * apache/spark
     */
   def count[T](column: TypedColumn[T, _]): TypedAggregate[T, Long] =
-    untyped.count(column.untyped).typedAggregate
+    sparkFunctions.count(column.untyped).typedAggregate
 
   /** Aggregate function: returns the number of distinct items in a group.
     *
     * apache/spark
     */
   def countDistinct[T](column: TypedColumn[T, _]): TypedAggregate[T, Long] =
-    untyped.countDistinct(column.untyped).typedAggregate
+    sparkFunctions.countDistinct(column.untyped).typedAggregate
 
   /** Aggregate function: returns the approximate number of distinct items in a group.
     */
   def approxCountDistinct[T](column: TypedColumn[T, _]): TypedAggregate[T, Long] =
-    untyped.approx_count_distinct(column.untyped).typedAggregate
+    sparkFunctions.approx_count_distinct(column.untyped).typedAggregate
 
   /** Aggregate function: returns the approximate number of distinct items in a group.
     *
@@ -40,21 +40,21 @@ trait AggregateFunctions {
     * apache/spark
     */
   def approxCountDistinct[T](column: TypedColumn[T, _], rsd: Double): TypedAggregate[T, Long] =
-    untyped.approx_count_distinct(column.untyped, rsd).typedAggregate
+    sparkFunctions.approx_count_distinct(column.untyped, rsd).typedAggregate
 
   /** Aggregate function: returns a list of objects with duplicates.
     *
     * apache/spark
     */
   def collectList[T, A: TypedEncoder](column: TypedColumn[T, A]): TypedAggregate[T, Vector[A]] =
-    untyped.collect_list(column.untyped).typedAggregate
+    sparkFunctions.collect_list(column.untyped).typedAggregate
 
   /** Aggregate function: returns a set of objects with duplicate elements eliminated.
     *
     * apache/spark
     */
   def collectSet[T, A: TypedEncoder](column: TypedColumn[T, A]): TypedAggregate[T, Vector[A]] =
-    untyped.collect_set(column.untyped).typedAggregate
+    sparkFunctions.collect_set(column.untyped).typedAggregate
 
   /** Aggregate function: returns the sum of all values in the given column.
     *
@@ -66,7 +66,7 @@ trait AggregateFunctions {
     oencoder: TypedEncoder[Out]
   ): TypedAggregate[T, Out] = {
     val zeroExpr = Literal.create(summable.zero, TypedEncoder[Out].catalystRepr)
-    val sumExpr = expr(untyped.sum(column.untyped))
+    val sumExpr = expr(sparkFunctions.sum(column.untyped))
     val sumOrZero = Coalesce(Seq(sumExpr, zeroExpr))
 
     new TypedAggregate[T, Out](sumOrZero)
@@ -82,7 +82,7 @@ trait AggregateFunctions {
     oencoder: TypedEncoder[Out]
   ): TypedAggregate[T, Out] = {
     val zeroExpr = Literal.create(summable.zero, TypedEncoder[Out].catalystRepr)
-    val sumExpr = expr(untyped.sumDistinct(column.untyped))
+    val sumExpr = expr(sparkFunctions.sumDistinct(column.untyped))
     val sumOrZero = Coalesce(Seq(sumExpr, zeroExpr))
 
     new TypedAggregate[T, Out](sumOrZero)
@@ -97,7 +97,7 @@ trait AggregateFunctions {
     averageable: CatalystAverageable[A, Out],
     oencoder: TypedEncoder[Out]
   ): TypedAggregate[T, Out] = {
-    new TypedAggregate[T, Out](untyped.avg(column.untyped))
+    new TypedAggregate[T, Out](sparkFunctions.avg(column.untyped))
   }
 
   /** Aggregate function: returns the unbiased variance of the values in a group.
@@ -108,7 +108,7 @@ trait AggregateFunctions {
     * apache/spark
     */
   def variance[A: CatalystVariance, T](column: TypedColumn[T, A]): TypedAggregate[T, Double] =
-    untyped.variance(column.untyped).typedAggregate
+    sparkFunctions.variance(column.untyped).typedAggregate
 
   /** Aggregate function: returns the sample standard deviation.
     *
@@ -118,7 +118,7 @@ trait AggregateFunctions {
     * apache/spark
     */
   def stddev[A: CatalystVariance, T](column: TypedColumn[T, A]): TypedAggregate[T, Double] =
-    untyped.stddev(column.untyped).typedAggregate
+    sparkFunctions.stddev(column.untyped).typedAggregate
 
   /**
     * Aggregate function: returns the standard deviation of a column by population.
@@ -132,7 +132,7 @@ trait AggregateFunctions {
     implicit val c1 = column.uencoder
 
     new TypedAggregate[T, Option[Double]](
-      untyped.stddev_pop(column.cast[Double].untyped)
+      sparkFunctions.stddev_pop(column.cast[Double].untyped)
     )
   }
 
@@ -148,7 +148,7 @@ trait AggregateFunctions {
     implicit val c1 = column.uencoder
 
     new TypedAggregate[T, Option[Double]](
-      untyped.stddev_samp(column.cast[Double].untyped)
+      sparkFunctions.stddev_samp(column.cast[Double].untyped)
     )
   }
 
@@ -158,7 +158,7 @@ trait AggregateFunctions {
     */
   def max[A: CatalystOrdered, T](column: TypedColumn[T, A]): TypedAggregate[T, A] = {
     implicit val c = column.uencoder
-    untyped.max(column.untyped).typedAggregate
+    sparkFunctions.max(column.untyped).typedAggregate
   }
 
   /** Aggregate function: returns the minimum value of the column in a group.
@@ -167,7 +167,7 @@ trait AggregateFunctions {
     */
   def min[A: CatalystOrdered, T](column: TypedColumn[T, A]): TypedAggregate[T, A] = {
     implicit val c = column.uencoder
-    untyped.min(column.untyped).typedAggregate
+    sparkFunctions.min(column.untyped).typedAggregate
   }
 
   /** Aggregate function: returns the first value in a group.
@@ -179,7 +179,7 @@ trait AggregateFunctions {
     */
   def first[A, T](column: TypedColumn[T, A]): TypedAggregate[T, A] = {
     implicit val c = column.uencoder
-    untyped.first(column.untyped).typedAggregate(column.uencoder)
+    sparkFunctions.first(column.untyped).typedAggregate(column.uencoder)
   }
 
   /**
@@ -192,7 +192,7 @@ trait AggregateFunctions {
     */
   def last[A, T](column: TypedColumn[T, A]): TypedAggregate[T, A] = {
     implicit val c = column.uencoder
-    untyped.last(column.untyped).typedAggregate
+    sparkFunctions.last(column.untyped).typedAggregate
   }
 
   /**
@@ -211,7 +211,7 @@ trait AggregateFunctions {
       implicit val c1 = column1.uencoder
       implicit val c2 = column2.uencoder
       new TypedAggregate[T, Option[Double]](
-        untyped.corr(column1.cast[Double].untyped, column2.cast[Double].untyped)
+        sparkFunctions.corr(column1.cast[Double].untyped, column2.cast[Double].untyped)
       )
     }
 
@@ -231,7 +231,7 @@ trait AggregateFunctions {
       implicit val c1 = column1.uencoder
       implicit val c2 = column2.uencoder
       new TypedAggregate[T, Option[Double]](
-        untyped.covar_pop(column1.cast[Double].untyped, column2.cast[Double].untyped)
+        sparkFunctions.covar_pop(column1.cast[Double].untyped, column2.cast[Double].untyped)
       )
     }
 
@@ -251,7 +251,7 @@ trait AggregateFunctions {
       implicit val c1 = column1.uencoder
       implicit val c2 = column2.uencoder
       new TypedAggregate[T, Option[Double]](
-        untyped.covar_samp(column1.cast[Double].untyped, column2.cast[Double].untyped)
+        sparkFunctions.covar_samp(column1.cast[Double].untyped, column2.cast[Double].untyped)
       )
     }
 
@@ -267,7 +267,7 @@ trait AggregateFunctions {
   def kurtosis[A, T](column: TypedColumn[T, A])(implicit ev: CatalystCast[A, Double]): TypedAggregate[T, Option[Double]] = {
     implicit val c1 = column.uencoder
     new TypedAggregate[T, Option[Double]](
-      untyped.kurtosis(column.cast[Double].untyped)
+      sparkFunctions.kurtosis(column.cast[Double].untyped)
     )
   }
 
@@ -282,7 +282,7 @@ trait AggregateFunctions {
   def skewness[A, T](column: TypedColumn[T, A])(implicit ev: CatalystCast[A, Double]): TypedAggregate[T, Option[Double]] = {
     implicit val c1 = column.uencoder
     new TypedAggregate[T, Option[Double]](
-      untyped.skewness(column.cast[Double].untyped)
+      sparkFunctions.skewness(column.cast[Double].untyped)
     )
   }
 }

--- a/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
+++ b/dataset/src/main/scala/frameless/functions/NonAggregateFunctions.scala
@@ -1,7 +1,7 @@
 package frameless
 package functions
 
-import org.apache.spark.sql.{Column, functions => untyped}
+import org.apache.spark.sql.{Column, functions => sparkFunctions}
 
 import scala.util.matching.Regex
 
@@ -15,7 +15,7 @@ trait NonAggregateFunctions {
       i0: CatalystAbsolute[A, B],
       i1: TypedEncoder[B]
     ): column.ThisType[T, B] =
-      column.typed(untyped.abs(column.untyped))(i1)
+      column.typed(sparkFunctions.abs(column.untyped))(i1)
 
   /** Non-Aggregate function: Computes the cosine of the given value.
     *
@@ -25,7 +25,7 @@ trait NonAggregateFunctions {
     */
   def cos[A, T](column: AbstractTypedColumn[T, A])
     (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
-      column.typed(untyped.cos(column.cast[Double].untyped))
+      column.typed(sparkFunctions.cos(column.cast[Double].untyped))
 
   /** Non-Aggregate function: Computes the hyperbolic cosine of the given value.
     *
@@ -35,7 +35,7 @@ trait NonAggregateFunctions {
     */
   def cosh[A, T](column: AbstractTypedColumn[T, A])
     (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
-      column.typed(untyped.cosh(column.cast[Double].untyped))
+      column.typed(sparkFunctions.cosh(column.cast[Double].untyped))
 
   /** Non-Aggregate function: Computes the sine of the given value.
     *
@@ -45,7 +45,7 @@ trait NonAggregateFunctions {
     */
   def sin[A, T](column: AbstractTypedColumn[T, A])
     (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
-      column.typed(untyped.sin(column.cast[Double].untyped))
+      column.typed(sparkFunctions.sin(column.cast[Double].untyped))
 
   /** Non-Aggregate function: Computes the hyperbolic sine of the given value.
     *
@@ -55,7 +55,7 @@ trait NonAggregateFunctions {
     */
   def sinh[A, T](column: AbstractTypedColumn[T, A])
     (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
-      column.typed(untyped.sinh(column.cast[Double].untyped))
+      column.typed(sparkFunctions.sinh(column.cast[Double].untyped))
 
   /** Non-Aggregate function: Computes the tangent of the given column.
     *
@@ -65,7 +65,7 @@ trait NonAggregateFunctions {
     */
   def tan[A, T](column: AbstractTypedColumn[T, A])
     (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
-      column.typed(untyped.tan(column.cast[Double].untyped))
+      column.typed(sparkFunctions.tan(column.cast[Double].untyped))
 
   /** Non-Aggregate function: Computes the hyperbolic tangent of the given value.
     *
@@ -75,7 +75,7 @@ trait NonAggregateFunctions {
     */
   def tanh[A, T](column: AbstractTypedColumn[T, A])
     (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
-      column.typed(untyped.tanh(column.cast[Double].untyped))
+      column.typed(sparkFunctions.tanh(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns the acos of a numeric column
     *
@@ -85,14 +85,14 @@ trait NonAggregateFunctions {
     */
   def acos[A, T](column: AbstractTypedColumn[T, A])
     (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
-      column.typed(untyped.acos(column.cast[Double].untyped))
+      column.typed(sparkFunctions.acos(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns true if value is contained with in the array in the specified column
     *
     * apache/spark
     */
   def arrayContains[C[_]: CatalystCollection, A, T](column: AbstractTypedColumn[T, C[A]], value: A): column.ThisType[T, Boolean] =
-    column.typed(untyped.array_contains(column.untyped, value))
+    column.typed(sparkFunctions.array_contains(column.untyped, value))
 
   /** Non-Aggregate function: returns the atan of a numeric column
     *
@@ -102,7 +102,7 @@ trait NonAggregateFunctions {
     */
   def atan[A, T](column: AbstractTypedColumn[T,A])
     (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
-      column.typed(untyped.atan(column.cast[Double].untyped))
+      column.typed(sparkFunctions.atan(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns the asin of a numeric column
     *
@@ -112,7 +112,7 @@ trait NonAggregateFunctions {
     */
   def asin[A, T](column: AbstractTypedColumn[T, A])
     (implicit i0: CatalystCast[A, Double]): column.ThisType[T, Double] =
-      column.typed(untyped.asin(column.cast[Double].untyped))
+      column.typed(sparkFunctions.asin(column.cast[Double].untyped))
 
   /** Non-Aggregate function: returns the angle theta from the conversion of rectangular coordinates (x, y) to
     * polar coordinates (r, theta).
@@ -126,7 +126,7 @@ trait NonAggregateFunctions {
       i0: CatalystCast[A, Double],
       i1: CatalystCast[B, Double]
     ): TypedColumn[T, Double] =
-      r.typed(untyped.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
+      r.typed(sparkFunctions.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
 
   /** Non-Aggregate function: returns the angle theta from the conversion of rectangular coordinates (x, y) to
     * polar coordinates (r, theta).
@@ -140,7 +140,7 @@ trait NonAggregateFunctions {
       i0: CatalystCast[A, Double],
       i1: CatalystCast[B, Double]
     ): TypedAggregate[T, Double] =
-      r.typed(untyped.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
+      r.typed(sparkFunctions.atan2(l.cast[Double].untyped, r.cast[Double].untyped))
 
   def atan2[B, T](l: Double, r: TypedColumn[T, B])
     (implicit i0: CatalystCast[B, Double]): TypedColumn[T, Double] =
@@ -164,14 +164,14 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def bin[T](column: AbstractTypedColumn[T, Long]): column.ThisType[T, String] =
-    column.typed(untyped.bin(column.untyped))
+    column.typed(sparkFunctions.bin(column.untyped))
 
   /** Non-Aggregate function: Computes bitwise NOT.
     *
     * apache/spark
     */
   def bitwiseNOT[A: CatalystBitwise, T](column: AbstractTypedColumn[T, A]): column.ThisType[T, A] =
-    column.typed(untyped.bitwiseNOT(column.untyped))(column.uencoder)
+    column.typed(sparkFunctions.bitwiseNOT(column.untyped))(column.uencoder)
 
   /** Non-Aggregate function: file name of the current Spark task. Empty string if row did not originate from
     * a file
@@ -179,7 +179,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def inputFileName[T](): TypedColumn[T, String] = {
-    new TypedColumn[T, String](untyped.input_file_name())
+    new TypedColumn[T, String](sparkFunctions.input_file_name())
   }
 
   /** Non-Aggregate function: generates monotonically increasing id
@@ -187,7 +187,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def monotonicallyIncreasingId[T](): TypedColumn[T, Long] = {
-    new TypedColumn[T, Long](untyped.monotonically_increasing_id())
+    new TypedColumn[T, Long](sparkFunctions.monotonically_increasing_id())
   }
 
   /** Non-Aggregate function: Evaluates a list of conditions and returns one of multiple
@@ -204,7 +204,7 @@ trait NonAggregateFunctions {
 
   class When[T, A] private (untypedC: Column) {
     private[functions] def this(condition: AbstractTypedColumn[T, Boolean], value: AbstractTypedColumn[T, A]) =
-      this(untyped.when(condition.untyped, value.untyped))
+      this(sparkFunctions.when(condition.untyped, value.untyped))
 
     def when(condition: AbstractTypedColumn[T, Boolean], value: AbstractTypedColumn[T, A]): When[T, A] =
       new When[T, A](untypedC.when(condition.untyped, value.untyped))
@@ -223,7 +223,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def ascii[T](column: AbstractTypedColumn[T, String]): column.ThisType[T, Int] =
-    column.typed(untyped.ascii(column.untyped))
+    column.typed(sparkFunctions.ascii(column.untyped))
 
   /** Non-Aggregate function: Computes the BASE64 encoding of a binary column and returns it as a string column.
     * This is the reverse of unbase64.
@@ -231,7 +231,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def base64[T](column: AbstractTypedColumn[T, Array[Byte]]): column.ThisType[T, String] =
-    column.typed(untyped.base64(column.untyped))
+    column.typed(sparkFunctions.base64(column.untyped))
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column.
     * @note varargs make it harder to generalize so we overload the method for [[TypedColumn]] and [[TypedAggregate]]
@@ -239,7 +239,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def concat[T](columns: TypedColumn[T, String]*): TypedColumn[T, String] =
-    new TypedColumn(untyped.concat(columns.map(_.untyped): _*))
+    new TypedColumn(sparkFunctions.concat(columns.map(_.untyped): _*))
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column.
     * @note varargs make it harder to generalize so we overload the method for [[TypedColumn]] and [[TypedAggregate]]
@@ -247,7 +247,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def concat[T](columns: TypedAggregate[T, String]*): TypedAggregate[T, String] =
-    new TypedAggregate(untyped.concat(columns.map(_.untyped): _*))
+    new TypedAggregate(sparkFunctions.concat(columns.map(_.untyped): _*))
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column,
     * using the given separator.
@@ -256,7 +256,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def concatWs[T](sep: String, columns: TypedAggregate[T, String]*): TypedAggregate[T, String] =
-    new TypedAggregate(untyped.concat_ws(sep, columns.map(_.untyped): _*))
+    new TypedAggregate(sparkFunctions.concat_ws(sep, columns.map(_.untyped): _*))
 
   /** Non-Aggregate function: Concatenates multiple input string columns together into a single string column,
     * using the given separator.
@@ -265,7 +265,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def concatWs[T](sep: String, columns: TypedColumn[T, String]*): TypedColumn[T, String] =
-    new TypedColumn(untyped.concat_ws(sep, columns.map(_.untyped): _*))
+    new TypedColumn(sparkFunctions.concat_ws(sep, columns.map(_.untyped): _*))
 
   /** Non-Aggregate function: Locates the position of the first occurrence of substring column
     * in given string
@@ -276,7 +276,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def instr[T](str: AbstractTypedColumn[T, String], substring: String): str.ThisType[T, Int] =
-    str.typed(untyped.instr(str.untyped, substring))
+    str.typed(sparkFunctions.instr(str.untyped, substring))
 
   /** Non-Aggregate function: Computes the length of a given string.
     *
@@ -284,28 +284,28 @@ trait NonAggregateFunctions {
     */
   //TODO: Also for binary
   def length[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, Int] =
-    str.typed(untyped.length(str.untyped))
+    str.typed(sparkFunctions.length(str.untyped))
 
   /** Non-Aggregate function: Computes the Levenshtein distance of the two given string columns.
     *
     * apache/spark
     */
   def levenshtein[T](l: TypedColumn[T, String], r: TypedColumn[T, String]): TypedColumn[T, Int] =
-    l.typed(untyped.levenshtein(l.untyped, r.untyped))
+    l.typed(sparkFunctions.levenshtein(l.untyped, r.untyped))
 
   /** Non-Aggregate function: Computes the Levenshtein distance of the two given string columns.
     *
     * apache/spark
     */
   def levenshtein[T](l: TypedAggregate[T, String], r: TypedAggregate[T, String]): TypedAggregate[T, Int] =
-    l.typed(untyped.levenshtein(l.untyped, r.untyped))
+    l.typed(sparkFunctions.levenshtein(l.untyped, r.untyped))
 
   /** Non-Aggregate function: Converts a string column to lower case.
     *
     * apache/spark
     */
   def lower[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
-    str.typed(untyped.lower(str.untyped))
+    str.typed(sparkFunctions.lower(str.untyped))
 
   /** Non-Aggregate function: Left-pad the string column with pad to a length of len. If the string column is longer
     * than len, the return value is shortened to len characters.
@@ -315,14 +315,14 @@ trait NonAggregateFunctions {
   def lpad[T](str: AbstractTypedColumn[T, String],
               len: Int,
               pad: String): str.ThisType[T, String] =
-    str.typed(untyped.lpad(str.untyped, len, pad))
+    str.typed(sparkFunctions.lpad(str.untyped, len, pad))
 
   /** Non-Aggregate function: Trim the spaces from left end for the specified string value.
     *
     * apache/spark
     */
   def ltrim[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
-    str.typed(untyped.ltrim(str.untyped))
+    str.typed(sparkFunctions.ltrim(str.untyped))
 
   /** Non-Aggregate function: Replace all substrings of the specified string value that match regexp with rep.
     *
@@ -331,7 +331,7 @@ trait NonAggregateFunctions {
   def regexpReplace[T](str: AbstractTypedColumn[T, String],
                        pattern: Regex,
                        replacement: String): str.ThisType[T, String] =
-    str.typed(untyped.regexp_replace(str.untyped, pattern.regex, replacement))
+    str.typed(sparkFunctions.regexp_replace(str.untyped, pattern.regex, replacement))
 
 
   /** Non-Aggregate function: Reverses the string column and returns it as a new string column.
@@ -339,7 +339,7 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def reverse[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
-    str.typed(untyped.reverse(str.untyped))
+    str.typed(sparkFunctions.reverse(str.untyped))
 
   /** Non-Aggregate function: Right-pad the string column with pad to a length of len.
     * If the string column is longer than len, the return value is shortened to len characters.
@@ -347,14 +347,14 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def rpad[T](str: AbstractTypedColumn[T, String], len: Int, pad: String): str.ThisType[T, String] =
-    str.typed(untyped.rpad(str.untyped, len, pad))
+    str.typed(sparkFunctions.rpad(str.untyped, len, pad))
 
   /** Non-Aggregate function: Trim the spaces from right end for the specified string value.
     *
     * apache/spark
     */
   def rtrim[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
-    str.typed(untyped.rtrim(str.untyped))
+    str.typed(sparkFunctions.rtrim(str.untyped))
 
   /** Non-Aggregate function: Substring starts at `pos` and is of length `len`
     *
@@ -362,21 +362,21 @@ trait NonAggregateFunctions {
     */
   //TODO: Also for byte array
   def substring[T](str: AbstractTypedColumn[T, String], pos: Int, len: Int): str.ThisType[T, String] =
-    str.typed(untyped.substring(str.untyped, pos, len))
+    str.typed(sparkFunctions.substring(str.untyped, pos, len))
 
   /** Non-Aggregate function: Trim the spaces from both ends for the specified string column.
     *
     * apache/spark
     */
   def trim[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
-    str.typed(untyped.trim(str.untyped))
+    str.typed(sparkFunctions.trim(str.untyped))
 
   /** Non-Aggregate function: Converts a string column to upper case.
     *
     * apache/spark
     */
   def upper[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, String] =
-    str.typed(untyped.upper(str.untyped))
+    str.typed(sparkFunctions.upper(str.untyped))
 
   /** Non-Aggregate function: Extracts the year as an integer from a given date/timestamp/string.
     *
@@ -385,5 +385,5 @@ trait NonAggregateFunctions {
     * apache/spark
     */
   def year[T](str: AbstractTypedColumn[T, String]): str.ThisType[T, Option[Int]] =
-    str.typed(untyped.year(str.untyped))
+    str.typed(sparkFunctions.year(str.untyped))
 }

--- a/dataset/src/test/scala/frameless/SelfJoinTests.scala
+++ b/dataset/src/test/scala/frameless/SelfJoinTests.scala
@@ -2,7 +2,7 @@ package frameless
 
 import org.scalacheck.Prop
 import org.scalacheck.Prop._
-import org.apache.spark.sql.{SparkSession, functions => sqlf}
+import org.apache.spark.sql.{SparkSession, functions => sparkFunctions}
 
 class SelfJoinTests extends TypedDatasetSuite {
   // Without crossJoin.enabled=true Spark doesn't like trivial join conditions:
@@ -29,7 +29,7 @@ class SelfJoinTests extends TypedDatasetSuite {
       val df1 = ds.dataset.as("df1")
       val df2 = ds.dataset.as("df2")
       val vanilla = df1.join(df2,
-        sqlf.col("df1.a") === sqlf.col("df2.a")).count()
+        sparkFunctions.col("df1.a") === sparkFunctions.col("df2.a")).count()
 
       val typed = ds.joinInner(ds)(
         ds.colLeft('a) === ds.colRight('a)
@@ -54,8 +54,8 @@ class SelfJoinTests extends TypedDatasetSuite {
         // obtain a trivial join condition of shape df1.a == df1.a, Spark we
         // always interpret that as df1.a == df2.a. For the purpose of this
         // test we fall-back to lit(true) instead.
-        // val trivial = sqlf.col("df1.a") === sqlf.col("df1.a")
-        val trivial = sqlf.lit(true)
+        // val trivial = sparkFunctions.col("df1.a") === sparkFunctions.col("df1.a")
+        val trivial = sparkFunctions.lit(true)
         val vanilla = untyped.as("df1").join(untyped.as("df2"), trivial).count()
 
         val typed = ds.joinInner(ds)(ds.colLeft('a) === ds.colLeft('a)).count().run
@@ -76,8 +76,8 @@ class SelfJoinTests extends TypedDatasetSuite {
       val df2 = ds.dataset.alias("df2")
 
       val vanilla = df1.join(df2,
-        (sqlf.col("df1.a") + sqlf.col("df1.b")) ===
-        (sqlf.col("df2.a") + sqlf.col("df2.b"))).count()
+        (sparkFunctions.col("df1.a") + sparkFunctions.col("df1.b")) ===
+        (sparkFunctions.col("df2.a") + sparkFunctions.col("df2.b"))).count()
 
       val typed = ds.joinInner(ds)(
         (ds.colLeft('a) + ds.colLeft('b)) === (ds.colRight('a) + ds.colRight('b))

--- a/dataset/src/test/scala/frameless/functions/NonAggregateFunctionsTests.scala
+++ b/dataset/src/test/scala/frameless/functions/NonAggregateFunctionsTests.scala
@@ -5,7 +5,7 @@ import java.io.File
 
 import frameless.functions.nonAggregate._
 import org.apache.commons.io.FileUtils
-import org.apache.spark.sql.{Column, Encoder, Row, SaveMode, functions => untyped}
+import org.apache.spark.sql.{Column, Encoder, Row, SaveMode, functions => sparkFunctions}
 import org.scalacheck.Prop._
 import org.scalacheck.{Gen, Prop}
 
@@ -29,7 +29,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       )= {
         val cDS = session.createDataset(values)
         val resCompare = cDS
-          .select(org.apache.spark.sql.functions.abs(cDS("a")))
+          .select(sparkFunctions.abs(cDS("a")))
           .map(_.getAs[B](0))
           .collect().toList
 
@@ -61,7 +61,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     ) = {
       val cDS = session.createDataset(values)
       val resCompare = cDS
-        .select(org.apache.spark.sql.functions.abs(cDS("a")))
+        .select(sparkFunctions.abs(cDS("a")))
         .map(_.getAs[A](0))
         .collect().toList
 
@@ -111,7 +111,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(cos(typedDS('a)), untyped.cos)
+        propTrigonometric(typedDS)(cos(typedDS('a)), sparkFunctions.cos)
     }
 
     check(forAll(prop[Int] _))
@@ -129,7 +129,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(cosh(typedDS('a)), untyped.cosh)
+        propTrigonometric(typedDS)(cosh(typedDS('a)), sparkFunctions.cosh)
     }
 
     check(forAll(prop[Int] _))
@@ -147,7 +147,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(acos(typedDS('a)), untyped.acos)
+        propTrigonometric(typedDS)(acos(typedDS('a)), sparkFunctions.acos)
     }
 
     check(forAll(prop[Int] _))
@@ -165,7 +165,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(sin(typedDS('a)), untyped.sin)
+        propTrigonometric(typedDS)(sin(typedDS('a)), sparkFunctions.sin)
     }
 
     check(forAll(prop[Int] _))
@@ -183,7 +183,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(sinh(typedDS('a)), untyped.sinh)
+        propTrigonometric(typedDS)(sinh(typedDS('a)), sparkFunctions.sinh)
     }
 
     check(forAll(prop[Int] _))
@@ -201,7 +201,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(asin(typedDS('a)), untyped.asin)
+        propTrigonometric(typedDS)(asin(typedDS('a)), sparkFunctions.asin)
     }
 
     check(forAll(prop[Int] _))
@@ -219,7 +219,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(tan(typedDS('a)), untyped.tan)
+        propTrigonometric(typedDS)(tan(typedDS('a)), sparkFunctions.tan)
     }
 
     check(forAll(prop[Int] _))
@@ -237,7 +237,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop[A: CatalystNumeric : TypedEncoder : Encoder](values: List[X1[A]])
       (implicit encX1:Encoder[X1[A]]) = {
         val typedDS = TypedDataset.create(values)
-        propTrigonometric(typedDS)(tanh(typedDS('a)), untyped.tanh)
+        propTrigonometric(typedDS)(tanh(typedDS('a)), sparkFunctions.tanh)
     }
 
     check(forAll(prop[Int] _))
@@ -298,7 +298,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
 
       val cDS = session.createDataset(List(values))
       val resCompare = cDS
-        .select(untyped.array_contains(cDS("value"), contained))
+        .select(sparkFunctions.array_contains(cDS("value"), contained))
         .map(_.getAs[Boolean](0))
         .collect().toList
 
@@ -353,7 +353,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     (na: A, values: List[X1[A]])(implicit encX1: Encoder[X1[A]]) = {
       val cDS = session.createDataset(X1(na) :: values)
       val resCompare = cDS
-        .select(untyped.atan(cDS("a")))
+        .select(sparkFunctions.atan(cDS("a")))
         .map(_.getAs[Double](0))
         .map(DoubleBehaviourUtils.nanNullHandler)
         .collect().toList
@@ -372,7 +372,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       ).firstOption().run().get
 
       val aggrSpark = cDS.select(
-        untyped.atan(untyped.first("a")).as[Double]
+        sparkFunctions.atan(sparkFunctions.first("a")).as[Double]
       ).first()
 
       (res ?= resCompare).&&(aggrTyped ?= aggrSpark)
@@ -395,7 +395,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
             (implicit encEv: Encoder[X2[A,B]]) = {
       val cDS = session.createDataset(na +: values)
       val resCompare = cDS
-        .select(untyped.atan2(cDS("a"), cDS("b")))
+        .select(sparkFunctions.atan2(cDS("a"), cDS("b")))
         .map(_.getAs[Double](0))
         .map(DoubleBehaviourUtils.nanNullHandler)
         .collect().toList
@@ -416,7 +416,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       ).firstOption().run().get
 
       val aggrSpark = cDS.select(
-        untyped.atan2(untyped.first("a"),untyped.first("b")).as[Double]
+        sparkFunctions.atan2(sparkFunctions.first("a"),sparkFunctions.first("b")).as[Double]
       ).first()
 
       (res ?= resCompare).&&(aggrTyped ?= aggrSpark)
@@ -439,7 +439,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     (na: X1[A], value: List[X1[A]], lit:Double)(implicit encX1:Encoder[X1[A]]) = {
       val cDS = session.createDataset(na +: value)
       val resCompare = cDS
-        .select(untyped.atan2(lit, cDS("a")))
+        .select(sparkFunctions.atan2(lit, cDS("a")))
         .map(_.getAs[Double](0))
         .map(DoubleBehaviourUtils.nanNullHandler)
         .collect().toList
@@ -460,7 +460,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       ).firstOption().run().get
 
       val aggrSpark = cDS.select(
-        untyped.atan2(lit, untyped.first("a")).as[Double]
+        sparkFunctions.atan2(lit, sparkFunctions.first("a")).as[Double]
       ).first()
 
       (res ?= resCompare).&&(aggrTyped ?= aggrSpark)
@@ -482,7 +482,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     (na: X1[A], value: List[X1[A]], lit:Double)(implicit encX1:Encoder[X1[A]]) = {
       val cDS = session.createDataset(na +: value)
       val resCompare = cDS
-        .select(untyped.atan2(cDS("a"), lit))
+        .select(sparkFunctions.atan2(cDS("a"), lit))
         .map(_.getAs[Double](0))
         .map(DoubleBehaviourUtils.nanNullHandler)
         .collect().toList
@@ -503,7 +503,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       ).firstOption().run().get
 
       val aggrSpark = cDS.select(
-        untyped.atan2(untyped.first("a"), lit).as[Double]
+        sparkFunctions.atan2(sparkFunctions.first("a"), lit).as[Double]
       ).first()
 
       (res ?= resCompare).&&(aggrTyped ?= aggrSpark)
@@ -525,7 +525,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop(values:List[X1[Array[Byte]]])(implicit encX1:Encoder[X1[Array[Byte]]]) = {
       val cDS = session.createDataset(values)
       val resCompare = cDS
-        .select(untyped.base64(cDS("a")))
+        .select(sparkFunctions.base64(cDS("a")))
         .map(_.getAs[String](0))
         .collect().toList
 
@@ -549,7 +549,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     def prop(values:List[X1[Long]])(implicit encX1:Encoder[X1[Long]]) = {
       val cDS = session.createDataset(values)
       val resCompare = cDS
-        .select(untyped.bin(cDS("a")))
+        .select(sparkFunctions.bin(cDS("a")))
         .map(_.getAs[String](0))
         .collect().toList
 
@@ -574,7 +574,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     (values:List[X1[A]])(implicit encX1:Encoder[X1[A]]) = {
       val cDS = session.createDataset(values)
       val resCompare = cDS
-        .select(untyped.bitwiseNOT(cDS("a")))
+        .select(sparkFunctions.bitwiseNOT(cDS("a")))
         .map(_.getAs[A](0))
         .collect().toList
 
@@ -670,9 +670,9 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
 
       val untypedWhen = ds.toDF()
         .select(
-          untyped.when(untyped.col("a"), untyped.col("c"))
-            .when(untyped.col("b"), untyped.col("d"))
-            .otherwise(untyped.col("e"))
+          sparkFunctions.when(sparkFunctions.col("a"), sparkFunctions.col("c"))
+            .when(sparkFunctions.col("b"), sparkFunctions.col("d"))
+            .otherwise(sparkFunctions.col("e"))
         )
         .as[A]
         .collect()
@@ -705,7 +705,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values)
 
       val sparkResult = ds.toDF()
-        .select(untyped.ascii($"a"))
+        .select(sparkFunctions.ascii($"a"))
         .map(_.getAs[Int](0))
         .collect()
         .toVector
@@ -733,7 +733,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values)
 
       val sparkResult = ds.toDF()
-        .select(untyped.concat($"a", $"b"))
+        .select(sparkFunctions.concat($"a", $"b"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -760,9 +760,9 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     check(forAll(pairs) { values: List[X2[String, String]] =>
       val ds = TypedDataset.create(values)
       val td = ds.agg(concat(first(ds('a)),first(ds('b)))).collect().run().toVector
-      val spark = ds.dataset.select(untyped.concat(
-        untyped.first($"a").as[String],
-        untyped.first($"b").as[String])).as[String].collect().toVector
+      val spark = ds.dataset.select(sparkFunctions.concat(
+        sparkFunctions.first($"a").as[String],
+        sparkFunctions.first($"b").as[String])).as[String].collect().toVector
       td ?= spark
     })
   }
@@ -780,7 +780,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values)
 
       val sparkResult = ds.toDF()
-        .select(untyped.concat_ws(",", $"a", $"b"))
+        .select(sparkFunctions.concat_ws(",", $"a", $"b"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -807,10 +807,10 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
     check(forAll(pairs) { values: List[X2[String, String]] =>
       val ds = TypedDataset.create(values)
       val td = ds.agg(concatWs(",",first(ds('a)),first(ds('b)), last(ds('b)))).collect().run().toVector
-      val spark = ds.dataset.select(untyped.concat_ws(",",
-        untyped.first($"a").as[String],
-        untyped.first($"b").as[String],
-        untyped.last($"b").as[String])).as[String].collect().toVector
+      val spark = ds.dataset.select(sparkFunctions.concat_ws(",",
+        sparkFunctions.first($"a").as[String],
+        sparkFunctions.first($"b").as[String],
+        sparkFunctions.last($"b").as[String])).as[String].collect().toVector
       td ?= spark
     })
   }
@@ -822,7 +822,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values.map(x => X1(x + values.head)))
 
       val sparkResult = ds.toDF()
-        .select(untyped.instr($"a", values.head))
+        .select(sparkFunctions.instr($"a", values.head))
         .map(_.getAs[Int](0))
         .collect()
         .toVector
@@ -844,7 +844,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values)
 
       val sparkResult = ds.toDF()
-        .select(untyped.length($"a"))
+        .select(sparkFunctions.length($"a"))
         .map(_.getAs[Int](0))
         .collect()
         .toVector
@@ -866,7 +866,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(na +: values)
 
       val sparkResult = ds.toDF()
-        .select(untyped.levenshtein($"a", untyped.concat($"a",untyped.lit("Hello"))))
+        .select(sparkFunctions.levenshtein($"a", sparkFunctions.concat($"a",sparkFunctions.lit("Hello"))))
         .map(_.getAs[Int](0))
         .collect()
         .toVector
@@ -883,7 +883,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       ).firstOption().run().get
 
       val aggrSpark = cDS.select(
-        untyped.levenshtein(untyped.first("a"), untyped.lit("Hello")).as[Int]
+        sparkFunctions.levenshtein(sparkFunctions.first("a"), sparkFunctions.lit("Hello")).as[Int]
       ).first()
 
       (typed ?= sparkResult).&&(aggrTyped ?= aggrSpark)
@@ -897,7 +897,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values.map(x => X1(s"$n${x.a}-$n$n")))
 
       val sparkResult = ds.toDF()
-        .select(untyped.regexp_replace($"a", "\\d+", "n"))
+        .select(sparkFunctions.regexp_replace($"a", "\\d+", "n"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -919,7 +919,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values)
 
       val sparkResult = ds.toDF()
-        .select(untyped.reverse($"a"))
+        .select(sparkFunctions.reverse($"a"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -941,7 +941,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values)
 
       val sparkResult = ds.toDF()
-        .select(untyped.rpad($"a", 5, "hello"))
+        .select(sparkFunctions.rpad($"a", 5, "hello"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -963,7 +963,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values)
 
       val sparkResult = ds.toDF()
-        .select(untyped.lpad($"a", 5, "hello"))
+        .select(sparkFunctions.lpad($"a", 5, "hello"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -985,7 +985,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values.map(x => X1(s"  ${x.a}    ")))
 
       val sparkResult = ds.toDF()
-        .select(untyped.rtrim($"a"))
+        .select(sparkFunctions.rtrim($"a"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -1007,7 +1007,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values.map(x => X1(s"  ${x.a}    ")))
 
       val sparkResult = ds.toDF()
-        .select(untyped.ltrim($"a"))
+        .select(sparkFunctions.ltrim($"a"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -1029,7 +1029,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values)
 
       val sparkResult = ds.toDF()
-        .select(untyped.substring($"a", 5, 3))
+        .select(sparkFunctions.substring($"a", 5, 3))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -1051,7 +1051,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values.map(x => X1(s"  ${x.a}    ")))
 
       val sparkResult = ds.toDF()
-        .select(untyped.trim($"a"))
+        .select(sparkFunctions.trim($"a"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -1073,7 +1073,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values.map(X1(_)))
 
       val sparkResult = ds.toDF()
-        .select(untyped.upper($"a"))
+        .select(sparkFunctions.upper($"a"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -1095,7 +1095,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
       val ds = TypedDataset.create(values.map(X1(_)))
 
       val sparkResult = ds.toDF()
-        .select(untyped.lower($"a"))
+        .select(sparkFunctions.lower($"a"))
         .map(_.getAs[String](0))
         .collect()
         .toVector
@@ -1139,7 +1139,7 @@ class NonAggregateFunctionsTests extends TypedDatasetSuite {
         val ds = TypedDataset.create(data)
 
         val sparkResult = ds.toDF()
-          .select(untyped.year($"a"))
+          .select(sparkFunctions.year($"a"))
           .map(nullHandler)
           .collect()
           .toList


### PR DESCRIPTION
`untyped` was used both as a field in TypedColumn and a import alias for spark.sql.functions. The name clash makes it a bit confusing...