### PR TITLE
Add Na Function 'drop'

### DIFF
--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.DecimalType
 import org.apache.spark.sql.{Column, FramelessInternals}
 import shapeless._
-import shapeless.ops.record.Selector
+import shapeless.ops.record.{SelectAll, Selector}
 
 import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
@@ -812,6 +812,19 @@ object TypedColumn {
 
   @implicitNotFound(msg = "No columns ${K} of type ${V} in ${T}")
   trait ExistsMany[T, K <: HList, V]
+
+  /** Evidence that all column names in `K` exist. */
+  @implicitNotFound(msg = "Cannot find all columns ${K} in ${T}")
+  trait ExistsAllByName[T, K <: HList]
+
+  object ExistsAllByName {
+    implicit def derive[T, H <: HList, K <: HList]
+      (implicit
+        i0: LabelledGeneric.Aux[T, H],
+        i1: SelectAll.Aux[H, K, _]
+      ): ExistsAllByName[T, K] =
+        new ExistsAllByName[T, K] {}
+  }
 
   object ExistsMany {
     implicit def deriveCons[T, KH, KT <: HList, V0, V1]

--- a/dataset/src/main/scala/frameless/TypedDataset.scala
+++ b/dataset/src/main/scala/frameless/TypedDataset.scala
@@ -1189,6 +1189,8 @@ class TypedDataset[T] protected[frameless](val dataset: Dataset[T])(implicit val
         sparkExplode(df(column.value.name))).as[Out](TypedExpressionEncoder[Out])
     TypedDataset.create[Out](trans)
   }
+
+  def na: NaFunctions[T] = new NaFunctions(this)
 }
 
 object TypedDataset {

--- a/dataset/src/main/scala/frameless/ops/NaFunctions.scala
+++ b/dataset/src/main/scala/frameless/ops/NaFunctions.scala
@@ -1,0 +1,53 @@
+package frameless
+package ops
+
+import shapeless.ops.hlist.ToTraversable
+import shapeless.{HList, SingletonProductArgs}
+import syntax._
+
+sealed abstract class DropStrategy(val value: String)
+
+object DropStrategy {
+  /** Drops rows only if every specified column is null or NaN for that row. */
+  case object All extends DropStrategy("all")
+
+  /** Drops rows containing any null or NaN values. */
+  case object Any extends DropStrategy("any")
+}
+
+class NaFunctions[T](self: TypedDataset[T])(implicit val encoder: TypedEncoder[T]) {
+
+  /** Returns a new `TypedDataset` that drops rows containing any null or NaN values. */
+  def drop(): TypedDataset[T] = self.toDF().na.drop().unsafeTyped
+
+  /** Returns a new `TypedDataset` that drops rows containing less than minNonNulls
+    * non-null and non-NaN values.
+    */
+  def drop(minNonNulls: Int): TypedDataset[T] = self.toDF().na.drop(minNonNulls).unsafeTyped
+
+  /** Returns a new `TypedDataset` that drops rows containing null or NaN values in the
+    * specified columns.
+    */
+  def drop(how: DropStrategy): TypedDataset[T] = self.toDF().na.drop(how.value).unsafeTyped
+
+  /** Returns a new `TypedDataset` that drops rows containing null or NaN values in
+    * the provided columns.
+    * {{{
+    *   ds.na.dropMany('a, 'b)
+    * }}}
+    */
+  object dropMany extends SingletonProductArgs {
+    def applyProduct[U <: HList](columns: U)
+      (implicit
+       i0: ToTraversable.Aux[U, List, Symbol],
+       i1: TypedColumn.ExistsAllByName[T, U]
+      ): TypedDataset[T] = {
+
+      val names = columns.toList[Symbol].map(_.name)
+      val dropped = self.toDF().na.drop(names).as[T](TypedExpressionEncoder[T])
+
+      TypedDataset.create[T](dropped)
+    }
+  }
+
+}

--- a/dataset/src/test/scala/frameless/ops/NaFunctionsTests.scala
+++ b/dataset/src/test/scala/frameless/ops/NaFunctionsTests.scala
@@ -1,0 +1,31 @@
+package frameless
+package ops
+
+import org.scalacheck.Prop
+import org.scalacheck.Prop._
+import org.scalatest.Matchers._
+
+class NaFunctionsTests extends TypedDatasetSuite {
+
+  test("should be able to use `dropMany` with existing columns") {
+    def prop[A <: Option[_] : TypedEncoder, B <: Option[_] : TypedEncoder]
+    (data: List[X2[A, B]]): Prop = {
+
+      val ds = TypedDataset.create(data)
+
+      val dropped = ds.na.dropMany('a, 'b).collect().run()
+      val expected = ds.filter(ds('a).isNotNone && ds('b).isNotNone).collect().run()
+
+      dropped ?= expected
+    }
+
+    check(forAll(prop[Option[Int], Option[String]] _))
+  }
+
+  test("dropMany with an un-existing column should not compile") {
+    val data = Seq(X1(0))
+    val ds = TypedDataset.create(data)
+
+    "ds.na.dropMany('b)" shouldNot typeCheck
+  }
+}


### PR DESCRIPTION
This is not a complete coverage for [DataFrameNaFunctions.drop][1]

I'm stuck at trying to implement methods that take `cols: Seq[String]` (e.g. [drop(how, cols)][2]). The problem is I could not find a way to check the existence of each column in `cols` at compile time.

(I thought I can receive `cols` as `Seq[Symbol]` and pass that into `dropMany` and done but there is no way to pass varargs into `ProductArgs`'s `apply`)

Any suggestion on this?

_P.S. hello guys, this is my first MR here. Thank you guys for creating this as I used Spark at work daily and meet the exact same problems that Frameless was created to solved!_

[1]: https://spark.apache.org/docs/2.1.1/api/scala/index.html#org.apache.spark.sql.DataFrameNaFunctions@drop(minNonNulls:Int,cols:Seq[String]):org.apache.spark.sql.DataFrame
[2]: https://spark.apache.org/docs/2.1.1/api/scala/index.html#org.apache.spark.sql.DataFrameNaFunctions@drop(how:String,cols:Seq[String]):org.apache.spark.sql.DataFrame