### PR TITLE
Add column method 'isNaN'

### DIFF
--- a/core/src/main/scala/frameless/CatalystNaN.scala
+++ b/core/src/main/scala/frameless/CatalystNaN.scala
@@ -1,0 +1,16 @@
+package frameless
+
+import scala.annotation.implicitNotFound
+
+/** Spark does NaN check only for these types */
+@implicitNotFound("Columns of type ${A} cannot be NaN.")
+trait CatalystNaN[A]
+
+object CatalystNaN {
+  private[this] val theInstance = new CatalystNaN[Any] {}
+  private[this] def of[A]: CatalystNaN[A] = theInstance.asInstanceOf[CatalystNaN[A]]
+
+  implicit val framelessFloatNaN     : CatalystNaN[Float]      = of[Float]
+  implicit val framelessDoubleNaN    : CatalystNaN[Double]     = of[Double]
+}
+

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -139,6 +139,13 @@ abstract class AbstractTypedColumn[T, U]
   def isNotNone(implicit i0: U <:< Option[_]): ThisType[T, Boolean] =
     typed(Not(equalsTo(lit(None.asInstanceOf[U])).expr))
 
+  /** True if the current expression is a fractional number and is not NaN.
+    *
+    * apache/spark
+    */
+  def isNaN(implicit i0: Fractional[U]): ThisType[T, Boolean] =
+    typed(self.untyped.isNaN)
+
   /** Convert an Optional column by providing a default value
     * {{{
     *   df( df('opt).getOrElse(df('defaultValue)) )

--- a/dataset/src/main/scala/frameless/TypedColumn.scala
+++ b/dataset/src/main/scala/frameless/TypedColumn.scala
@@ -143,7 +143,7 @@ abstract class AbstractTypedColumn[T, U]
     *
     * apache/spark
     */
-  def isNaN(implicit i0: Fractional[U]): ThisType[T, Boolean] =
+  def isNaN(implicit n: CatalystNaN[U]): ThisType[T, Boolean] =
     typed(self.untyped.isNaN)
 
   /** Convert an Optional column by providing a default value

--- a/dataset/src/test/scala/frameless/NumericTests.scala
+++ b/dataset/src/test/scala/frameless/NumericTests.scala
@@ -182,7 +182,7 @@ class NumericTests extends TypedDatasetSuite {
     }
     implicit val x1 = Arbitrary{ doubleWithNaN.arbitrary.map(X1(_)) }
 
-    def prop[A : TypedEncoder : Encoder : Fractional](data: List[X1[A]]): Prop = {
+    def prop[A : TypedEncoder : Encoder : CatalystNaN](data: List[X1[A]]): Prop = {
       val ds = TypedDataset.create(data)
 
       val expected = ds.toDF().filter(!$"a".isNaN).map(_.getAs[A](0)).collect().toSeq
@@ -195,7 +195,7 @@ class NumericTests extends TypedDatasetSuite {
     check(forAll(prop[Double] _))
   }
 
-  test("isNaN with non-fractional types should not compile") {
+  test("isNaN with non-nan types should not compile") {
     val ds = TypedDataset.create((1, false, 'a, "b") :: Nil)
 
     "ds.filter(ds('_1).isNaN)" shouldNot typeCheck

--- a/dataset/src/test/scala/frameless/NumericTests.scala
+++ b/dataset/src/test/scala/frameless/NumericTests.scala
@@ -1,7 +1,10 @@
 package frameless
 
-import org.scalacheck.Prop
+import org.apache.spark.sql.Encoder
+import org.scalacheck.{Arbitrary, Gen, Prop}
 import org.scalacheck.Prop._
+import org.scalatest.Matchers._
+
 import scala.reflect.ClassTag
 
 class NumericTests extends TypedDatasetSuite {
@@ -168,5 +171,36 @@ class NumericTests extends TypedDatasetSuite {
     check(prop[Long  ] _)
     check(prop[Short ] _)
     check(prop[BigDecimal] _)
+  }
+
+  test("isNaN") {
+    val spark = session
+    import spark.implicits._
+
+    implicit val doubleWithNaN = Arbitrary {
+      implicitly[Arbitrary[Double]].arbitrary.flatMap(Gen.oneOf(_, Double.NaN))
+    }
+    implicit val x1 = Arbitrary{ doubleWithNaN.arbitrary.map(X1(_)) }
+
+    def prop[A : TypedEncoder : Encoder : Fractional](data: List[X1[A]]): Prop = {
+      val ds = TypedDataset.create(data)
+
+      val expected = ds.toDF().filter(!$"a".isNaN).map(_.getAs[A](0)).collect().toSeq
+      val rs = ds.filter(!ds('a).isNaN).collect().run().map(_.a)
+
+      rs ?= expected
+    }
+
+    check(forAll(prop[Float] _))
+    check(forAll(prop[Double] _))
+  }
+
+  test("isNaN with non-fractional types should not compile") {
+    val ds = TypedDataset.create((1, false, 'a, "b") :: Nil)
+
+    "ds.filter(ds('_1).isNaN)" shouldNot typeCheck
+    "ds.filter(ds('_2).isNaN)" shouldNot typeCheck
+    "ds.filter(ds('_3).isNaN)" shouldNot typeCheck
+    "ds.filter(ds('_4).isNaN)" shouldNot typeCheck
   }
 }


### PR DESCRIPTION
I'm trying to add `isNotNaN` as well. It should be like this:
```scala
def isNotNaN(implicit i0: Fractional[U]): ThisType[T, Boolean] =
    !isNaN
```
with `!` is `unary_!` added in #312 

But the types don't match:
- `isNotNaN` requires returns type `ThisType[T, Boolean]`
- `!isNaN` has type `ThisType[T, Boolean]#ThisType[T, Boolean]`

Any suggestion on this?