### PR TITLE
Set generator size to 10 regardless of CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ We require at least *one* sign-off (thumbs-up, +1, or similar) to merge pull req
 * [non](https://github.com/non)
 * [OlivierBlanvillain](https://github.com/OlivierBlanvillain/)
 
+### Testing
+
+Frameless contains several property tests.  To avoid `OutOfMemoryError`s, we
+tune the default generator sizes.  The following environment variables may
+be set to adjust the size of generated collections in the `TypedDataSet` suite:
+
+| Property                    | Default |
+|-----------------------------|--------:|
+| FRAMELESS_GEN_MIN_SIZE      |       0 |
+| FRAMELESS_GEN_SIZE_RANGE    |      20 |
+
 ## License
 Code is provided under the Apache 2.0 license available at http://opensource.org/licenses/Apache-2.0,
 as well as in the LICENSE file. This is the same license used as Spark.

--- a/dataset/src/test/scala/frameless/TypedDatasetSuite.scala
+++ b/dataset/src/test/scala/frameless/TypedDatasetSuite.scala
@@ -39,9 +39,9 @@ trait SparkTesting { self: BeforeAndAfterAll =>
 
 
 class TypedDatasetSuite extends FunSuite with Checkers with BeforeAndAfterAll with SparkTesting {
-  // Limit size of generated collections and number of checks because Travis
+  // Limit size of generated collections and number of checks to avoid OutOfMemoryError
   implicit override val generatorDrivenConfig = {
-    val i: PosZInt = scala.util.Properties.envOrNone("CI").fold(PosZInt(100))(_ => PosZInt(10))
+    val i: PosZInt = PosZInt(10)
     PropertyCheckConfiguration(sizeRange = i, minSize = i)
   }
 

--- a/dataset/src/test/scala/frameless/TypedDatasetSuite.scala
+++ b/dataset/src/test/scala/frameless/TypedDatasetSuite.scala
@@ -7,6 +7,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.scalatest.prop.Checkers
 import org.scalacheck.Prop
 import org.scalacheck.Prop._
+import scala.util.{Properties, Try}
 
 trait SparkTesting { self: BeforeAndAfterAll =>
 
@@ -40,9 +41,15 @@ trait SparkTesting { self: BeforeAndAfterAll =>
 
 class TypedDatasetSuite extends FunSuite with Checkers with BeforeAndAfterAll with SparkTesting {
   // Limit size of generated collections and number of checks to avoid OutOfMemoryError
-  implicit override val generatorDrivenConfig = {
-    val i: PosZInt = PosZInt(10)
-    PropertyCheckConfiguration(sizeRange = i, minSize = i)
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = {
+    def getPosZInt(name: String, default: PosZInt) = Properties.envOrNone(s"FRAMELESS_GEN_${name}")
+      .flatMap(s => Try(s.toInt).toOption)
+      .flatMap(PosZInt.from)
+      .getOrElse(default)
+    PropertyCheckConfiguration(
+      sizeRange = getPosZInt("SIZE_RANGE", PosZInt(20)),
+      minSize = getPosZInt("MIN_SIZE", PosZInt(0))
+    )
   }
 
   implicit val sparkDelay: SparkDelay[Job] = Job.framelessSparkDelayForJob


### PR DESCRIPTION
Currently, one has to set the `CI` environment variable to change the generator sizes to avoid running out of memory.  The default generator size also fails locally, so there is nothing unique about CI.  Setting the size to 10 gives a better clone-and-test experience for new contributors.

If for some reason we do want to keep the generator sizes higher locally, we can close this and I'll submit a developer doc instead.