### PR TITLE
implement the FlatMap typeclass on Job. This allows Job to be used as a  Kleisli/Reader

### DIFF
--- a/dataset/src/main/scala/frameless/Job.scala
+++ b/dataset/src/main/scala/frameless/Job.scala
@@ -2,6 +2,7 @@ package frameless
 
 import org.apache.spark.sql.SparkSession
 
+
 sealed abstract class Job[A](implicit spark: SparkSession) { self =>
   /** Runs a new Spark job. */
   def run(): A
@@ -30,10 +31,14 @@ sealed abstract class Job[A](implicit spark: SparkSession) { self =>
   def flatMap[B](fn: A => Job[B]): Job[B] = new Job[B]()(spark) {
     def run(): B = fn(Job.this.run()).run()
   }
+
+
 }
 
 
 object Job {
+
+
   def apply[A](a: => A)(implicit spark: SparkSession): Job[A] = new Job[A] {
     def run(): A = a
   }


### PR DESCRIPTION
this pull request allows us to make Job into cats Reader/Kleisli monads. It opens up the proper monad stack for Job and enables the potential to use Job in Monad Transformer stacks . Some example code will probably help explain this best.

```scala
import frameless.cats.jobber._
import frameless.{Job, TypedDataset}
import org.apache.spark.sql.{Dataset, SparkSession}
import cats.data.Kleisli

class Library extends App {
  val spark = SparkSession
    .builder()
    .appName("Spark SQL basic example")
    .config("spark.some.config.option", "some-value")
    .getOrCreate()
  import spark.implicits._
  implicit val sc = spark
  val ds1: Dataset[Int] = Seq(1, 2, 3, 4).toDS()
  val ds2: Dataset[Int] = TypedDataset.create(1 to 200).dataset

  def countAndTakeSumJob(sumFrom: Double): Job[Int] =
    for {
      count <- ds1.count()
      sample: Array[Int] = ds1.take(count)
    } yield sample.fold(sumFrom)(_ + _)

  def addAndConcat(delta: Int): Job[String] =
    for {
      sample <- ds2.map(_ + delta)
      result <- ds2.map((n: Int) => (n + sample).toString())
    } yield result
  val k1: Kleisli[Job, Double, Int] = Kleisli(countAndTakeSumJob _)
  val k2: Kleisli[Job, Int, String] = Kleisli(addAndConcat _)
  // This PR enables...
  //  I want to be able to be able to compose the Kleisli i.e.
  val composed: Kleisli[Job, Double, String] = k2.compose(k1)
  composed.run(5d)
}```