### PR TITLE
Derive Injection instance for enum types

### DIFF
--- a/core/src/main/scala/frameless/InjectionEnum.scala
+++ b/core/src/main/scala/frameless/InjectionEnum.scala
@@ -1,7 +1,6 @@
 package frameless
 
 import scala.reflect.{ClassTag, classTag}
-
 import shapeless._
 
 object InjectionEnum {
@@ -9,15 +8,15 @@ object InjectionEnum {
 
   def apply[A: InjectionEnum]: InjectionEnum[A] = implicitly[InjectionEnum[A]]
 
-  def instance[A](f: A => String, g: String => A): Injection[A, String] =
+  def instance[A](f: A => String, g: String => A): InjectionEnum[A] =
     Injection(f, g)
 
-  implicit val cnilInjectionEnum: Injection[CNil, String] =
+  implicit val cnilInjectionEnum: InjectionEnum[CNil] =
     instance(
       _ => throw new Exception("Impossible"),
       name =>
-        throw new Exception(
-          s"Cannot construct a value CNil: $name did not match data constructor names"
+        throw new IllegalArgumentException(
+          s"Cannot construct a value of type CNil: $name did not match data constructor names"
         )
     )
 

--- a/core/src/main/scala/frameless/InjectionEnum.scala
+++ b/core/src/main/scala/frameless/InjectionEnum.scala
@@ -6,13 +6,8 @@ import shapeless._
 object InjectionEnum {
   type InjectionEnum[A] = Injection[A, String]
 
-  def apply[A: InjectionEnum]: InjectionEnum[A] = implicitly[InjectionEnum[A]]
-
-  def instance[A](f: A => String, g: String => A): InjectionEnum[A] =
-    Injection(f, g)
-
   implicit val cnilInjectionEnum: InjectionEnum[CNil] =
-    instance(
+    Injection(
       _ => throw new Exception("Impossible"),
       name =>
         throw new IllegalArgumentException(
@@ -27,7 +22,7 @@ object InjectionEnum {
     ): InjectionEnum[H :+: T] = {
     val canonicalName = classTag[H].runtimeClass.getCanonicalName
 
-    instance(
+    Injection(
       {
         case Inl(_) => canonicalName
         case Inr(t) => tInjectionEnum.apply(t)
@@ -45,7 +40,7 @@ object InjectionEnum {
     gen: Generic.Aux[A, R],
     rInjectionEnum: InjectionEnum[R]
     ): InjectionEnum[A] =
-    instance(
+    Injection(
       value =>
         rInjectionEnum.apply(gen.to(value)),
       name =>

--- a/core/src/main/scala/frameless/InjectionEnum.scala
+++ b/core/src/main/scala/frameless/InjectionEnum.scala
@@ -1,0 +1,55 @@
+package frameless
+
+import scala.reflect.{ClassTag, classTag}
+
+import shapeless._
+
+object InjectionEnum {
+  type InjectionEnum[A] = Injection[A, String]
+
+  def apply[A: InjectionEnum]: InjectionEnum[A] = implicitly[InjectionEnum[A]]
+
+  def instance[A](f: A => String, g: String => A): Injection[A, String] =
+    Injection(f, g)
+
+  implicit val cnilInjectionEnum: Injection[CNil, String] =
+    instance(
+      _ => throw new Exception("Impossible"),
+      name =>
+        throw new Exception(
+          s"Cannot construct a value CNil: $name did not match data constructor names"
+        )
+    )
+
+  implicit def coproductInjectionEnum[H: ClassTag, T <: Coproduct](
+    implicit
+    gen: Generic.Aux[H, HNil],
+    tInjectionEnum: InjectionEnum[T]
+    ): InjectionEnum[H :+: T] = {
+    val canonicalName = classTag[H].runtimeClass.getCanonicalName
+
+    instance(
+      {
+        case Inl(_) => canonicalName
+        case Inr(t) => tInjectionEnum.apply(t)
+      },
+      name =>
+        if (name == canonicalName)
+          Inl(gen.from(HNil))
+        else
+          Inr(tInjectionEnum.invert(name))
+    )
+  }
+
+  implicit def genericInjectionEnum[A, R](
+    implicit
+    gen: Generic.Aux[A, R],
+    rInjectionEnum: InjectionEnum[R]
+    ): InjectionEnum[A] =
+    instance(
+      value =>
+        rInjectionEnum.apply(gen.to(value)),
+      name =>
+        gen.from(rInjectionEnum.invert(name))
+    )
+}

--- a/dataset/src/main/scala/frameless/InjectionEnum.scala
+++ b/dataset/src/main/scala/frameless/InjectionEnum.scala
@@ -2,7 +2,7 @@ package frameless
 
 import shapeless._
 
-object InjectionEnum {
+trait InjectionEnum {
   implicit val cnilInjectionEnum: Injection[CNil, String] =
     Injection(
       _ => throw new Exception("Impossible"),

--- a/dataset/src/main/scala/frameless/InjectionEnum.scala
+++ b/dataset/src/main/scala/frameless/InjectionEnum.scala
@@ -5,7 +5,9 @@ import shapeless._
 trait InjectionEnum {
   implicit val cnilInjectionEnum: Injection[CNil, String] =
     Injection(
+      // $COVERAGE-OFF$No value of type CNil so impossible to test
       _ => throw new Exception("Impossible"),
+      // $COVERAGE-ON$
       name =>
         throw new IllegalArgumentException(
           s"Cannot construct a value of type CNil: $name did not match data constructor names"

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -428,4 +428,6 @@ object TypedEncoder {
         Invoke(udtInstance, "deserialize", ObjectType(udt.userClass), Seq(path))
     }
   }
+
+  object injections extends InjectionEnum
 }

--- a/dataset/src/test/scala/frameless/InjectionTests.scala
+++ b/dataset/src/test/scala/frameless/InjectionTests.scala
@@ -280,24 +280,24 @@ class InjectionTests extends TypedDatasetSuite {
     import InjectionEnum._
 
     assert(implicitly[Injection[Employee, String]].apply(Casual) === "Casual")
-    assert(implicitly[Injection[Switch, String]].apply(Switch.On) === "On")
+    assert(implicitly[Injection[Switch, String]].apply(Switch.On) === "Switch.On")
     assert(implicitly[Injection[Pixel, String]].apply(Blue()) === "Blue")
     assert(implicitly[Injection[Connection[Int], String]].apply(Open) === "Open")
     assert(implicitly[Injection[Vehicle, String]].apply(Bike) === "Bike")
-    assert(implicitly[Injection[Fooo, String]].apply(A.Bar()) === "Bar")
-    assert(implicitly[Injection[Fooo, String]].apply(B.Bar()) === "Bar")
+    assert(implicitly[Injection[Fooo, String]].apply(A.Bar()) === "A.Bar")
+    assert(implicitly[Injection[Fooo, String]].apply(B.Bar()) === "B.Bar")
   }
 
   test("invert method of derived Injection instance produces the correct value") {
     import InjectionEnum._
 
     assert(implicitly[Injection[Employee, String]].invert("Casual") === Casual)
-    assert(implicitly[Injection[Switch, String]].invert("On") === Switch.On)
+    assert(implicitly[Injection[Switch, String]].invert("Switch.On") === Switch.On)
     assert(implicitly[Injection[Pixel, String]].invert("Blue") === Blue())
     assert(implicitly[Injection[Connection[Int], String]].invert("Open") === Open)
     assert(implicitly[Injection[Vehicle, String]].invert("Bike") === Bike)
-    assert(implicitly[Injection[Fooo, String]].invert("Bar") === A.Bar())
-    assert(implicitly[Injection[Fooo, String]].invert("Bar") === B.Bar())
+    assert(implicitly[Injection[Fooo, String]].invert("A.Bar") === A.Bar())
+    assert(implicitly[Injection[Fooo, String]].invert("B.Bar") === B.Bar())
   }
 
   test(

--- a/dataset/src/test/scala/frameless/InjectionTests.scala
+++ b/dataset/src/test/scala/frameless/InjectionTests.scala
@@ -90,6 +90,10 @@ object Employee {
     Arbitrary(Gen.oneOf(Casual, PartTime, FullTime))
 }
 
+sealed trait Maybe
+case object Nothing extends Maybe
+case class Just(get: Int) extends Maybe
+
 class InjectionTests extends TypedDatasetSuite {
   test("Injection based encoders") {
     check(forAll(prop[Country] _))
@@ -160,5 +164,14 @@ class InjectionTests extends TypedDatasetSuite {
     check(forAll(prop[Employee] _))
 
     assert(TypedEncoder[Employee].catalystRepr == TypedEncoder[String].catalystRepr)
+  }
+
+  test("TypedEncoder[Maybe] cannot be derived") {
+    import InjectionEnum._
+
+    illTyped(
+      "implicitly[TypedEncoder[Maybe]]",
+      "could not find implicit value for parameter e.*"
+    )
   }
 }

--- a/dataset/src/test/scala/frameless/InjectionTests.scala
+++ b/dataset/src/test/scala/frameless/InjectionTests.scala
@@ -260,7 +260,7 @@ class InjectionTests extends TypedDatasetSuite {
     import frameless.TypedEncoder.injections._
 
     assert(implicitly[Injection[Employee, String]].apply(Casual) === "Casual")
-    assert(implicitly[Injection[Switch, String]].apply(Switch.On) === "Switch.On")
+    assert(implicitly[Injection[Switch, String]].apply(Switch.On) === "On")
     assert(implicitly[Injection[Pixel, String]].apply(Blue()) === "Blue")
     assert(implicitly[Injection[Connection[Int], String]].apply(Open) === "Open")
     assert(implicitly[Injection[Vehicle, String]].apply(Bike) === "Bike")
@@ -270,7 +270,7 @@ class InjectionTests extends TypedDatasetSuite {
     import frameless.TypedEncoder.injections._
 
     assert(implicitly[Injection[Employee, String]].invert("Casual") === Casual)
-    assert(implicitly[Injection[Switch, String]].invert("Switch.On") === Switch.On)
+    assert(implicitly[Injection[Switch, String]].invert("On") === Switch.On)
     assert(implicitly[Injection[Pixel, String]].invert("Blue") === Blue())
     assert(implicitly[Injection[Connection[Int], String]].invert("Open") === Open)
     assert(implicitly[Injection[Vehicle, String]].invert("Bike") === Bike)

--- a/dataset/src/test/scala/frameless/InjectionTests.scala
+++ b/dataset/src/test/scala/frameless/InjectionTests.scala
@@ -255,4 +255,14 @@ class InjectionTests extends TypedDatasetSuite {
 
     assert(TypedEncoder[Vehicle].catalystRepr == TypedEncoder[String].catalystRepr)
   }
+
+  test("apply method of derived Injection instance produces the correct string") {
+    import InjectionEnum._
+
+    assert(implicitly[Injection[Employee, String]].apply(Casual) === "Casual")
+    assert(implicitly[Injection[Switch, String]].apply(Switch.On) === "On")
+    assert(implicitly[Injection[Pixel, String]].apply(Blue()) === "Blue")
+    assert(implicitly[Injection[Connection[Int], String]].apply(Open) === "Open")
+    assert(implicitly[Injection[Vehicle, String]].apply(Bike) === "Bike")
+  }
 }

--- a/dataset/src/test/scala/frameless/InjectionTests.scala
+++ b/dataset/src/test/scala/frameless/InjectionTests.scala
@@ -131,15 +131,6 @@ object Vehicle {
     Arbitrary(Gen.oneOf(Car, Bike))
 }
 
-sealed trait Fooo
-object A { case class Bar() extends Fooo }
-object B { case class Bar() extends Fooo }
-
-object Fooo {
-  implicit def arbitrary: Arbitrary[Fooo] =
-    Arbitrary(Gen.oneOf(A.Bar(), B.Bar()))
-}
-
 class InjectionTests extends TypedDatasetSuite {
   test("Injection based encoders") {
     check(forAll(prop[Country] _))
@@ -202,7 +193,7 @@ class InjectionTests extends TypedDatasetSuite {
   }
 
   test("Resolve missing implicit by deriving Injection instance") {
-    import InjectionEnum._
+    import frameless.TypedEncoder.injections._
 
     check(forAll(prop[X1[Employee]] _))
     check(forAll(prop[X1[X1[Employee]]] _))
@@ -213,7 +204,7 @@ class InjectionTests extends TypedDatasetSuite {
   }
 
   test("TypedEncoder[Maybe] cannot be derived") {
-    import InjectionEnum._
+    import frameless.TypedEncoder.injections._
 
     illTyped(
       "implicitly[TypedEncoder[Maybe]]",
@@ -222,7 +213,7 @@ class InjectionTests extends TypedDatasetSuite {
   }
 
   test("Derive encoder for type with data constructors defined in the companion object") {
-    import InjectionEnum._
+    import frameless.TypedEncoder.injections._
 
     check(forAll(prop[X1[Switch]] _))
     check(forAll(prop[X1[X1[Switch]]] _))
@@ -233,7 +224,7 @@ class InjectionTests extends TypedDatasetSuite {
   }
 
   test("Derive encoder for type with data constructors defined as parameterless case classes") {
-    import InjectionEnum._
+    import frameless.TypedEncoder.injections._
 
     check(forAll(prop[X1[Pixel]] _))
     check(forAll(prop[X1[X1[Pixel]]] _))
@@ -244,7 +235,7 @@ class InjectionTests extends TypedDatasetSuite {
   }
 
   test("Derive encoder for phantom type") {
-    import InjectionEnum._
+    import frameless.TypedEncoder.injections._
 
     check(forAll(prop[X1[Connection[Int]]] _))
     check(forAll(prop[X1[X1[Connection[Int]]]] _))
@@ -255,7 +246,7 @@ class InjectionTests extends TypedDatasetSuite {
   }
 
   test("Derive encoder for ADT with abstract class as the base type") {
-    import InjectionEnum._
+    import frameless.TypedEncoder.injections._
 
     check(forAll(prop[X1[Vehicle]] _))
     check(forAll(prop[X1[X1[Vehicle]]] _))
@@ -265,45 +256,30 @@ class InjectionTests extends TypedDatasetSuite {
     assert(TypedEncoder[Vehicle].catalystRepr == TypedEncoder[String].catalystRepr)
   }
 
-    test("Derive encoder for ADT containing constructors with the same name") {
-    import InjectionEnum._
-
-    check(forAll(prop[X1[Fooo]] _))
-    check(forAll(prop[X1[X1[Fooo]]] _))
-    check(forAll(prop[X2[Fooo, Fooo]] _))
-    check(forAll(prop[Fooo] _))
-
-    assert(TypedEncoder[Fooo].catalystRepr == TypedEncoder[String].catalystRepr)
-  }
-
   test("apply method of derived Injection instance produces the correct string") {
-    import InjectionEnum._
+    import frameless.TypedEncoder.injections._
 
     assert(implicitly[Injection[Employee, String]].apply(Casual) === "Casual")
     assert(implicitly[Injection[Switch, String]].apply(Switch.On) === "Switch.On")
     assert(implicitly[Injection[Pixel, String]].apply(Blue()) === "Blue")
     assert(implicitly[Injection[Connection[Int], String]].apply(Open) === "Open")
     assert(implicitly[Injection[Vehicle, String]].apply(Bike) === "Bike")
-    assert(implicitly[Injection[Fooo, String]].apply(A.Bar()) === "A.Bar")
-    assert(implicitly[Injection[Fooo, String]].apply(B.Bar()) === "B.Bar")
   }
 
   test("invert method of derived Injection instance produces the correct value") {
-    import InjectionEnum._
+    import frameless.TypedEncoder.injections._
 
     assert(implicitly[Injection[Employee, String]].invert("Casual") === Casual)
     assert(implicitly[Injection[Switch, String]].invert("Switch.On") === Switch.On)
     assert(implicitly[Injection[Pixel, String]].invert("Blue") === Blue())
     assert(implicitly[Injection[Connection[Int], String]].invert("Open") === Open)
     assert(implicitly[Injection[Vehicle, String]].invert("Bike") === Bike)
-    assert(implicitly[Injection[Fooo, String]].invert("A.Bar") === A.Bar())
-    assert(implicitly[Injection[Fooo, String]].invert("B.Bar") === B.Bar())
   }
 
   test(
     "invert method of derived Injection instance should throw exception if string does not match data constructor names"
   ) {
-    import InjectionEnum._
+    import frameless.TypedEncoder.injections._
 
     val caught = intercept[IllegalArgumentException] {
       implicitly[Injection[Employee, String]].invert("cassual")

--- a/dataset/src/test/scala/frameless/InjectionTests.scala
+++ b/dataset/src/test/scala/frameless/InjectionTests.scala
@@ -265,4 +265,29 @@ class InjectionTests extends TypedDatasetSuite {
     assert(implicitly[Injection[Connection[Int], String]].apply(Open) === "Open")
     assert(implicitly[Injection[Vehicle, String]].apply(Bike) === "Bike")
   }
+
+  test("invert method of derived Injection instance produces the correct value") {
+    import InjectionEnum._
+
+    assert(implicitly[Injection[Employee, String]].invert("Casual") === Casual)
+    assert(implicitly[Injection[Switch, String]].invert("On") === Switch.On)
+    assert(implicitly[Injection[Pixel, String]].invert("Blue") === Blue())
+    assert(implicitly[Injection[Connection[Int], String]].invert("Open") === Open)
+    assert(implicitly[Injection[Vehicle, String]].invert("Bike") === Bike)
+  }
+
+  test(
+    "invert method of derived Injection instance should throw exception if string does not match data constructor names"
+  ) {
+    import InjectionEnum._
+
+    val caught = intercept[IllegalArgumentException] {
+      implicitly[Injection[Employee, String]].invert("cassual")
+    }
+
+    assert(
+      caught.getMessage ===
+        "Cannot construct a value of type CNil: cassual did not match data constructor names"
+    )
+  }
 }

--- a/docs/src/main/tut/Injection.md
+++ b/docs/src/main/tut/Injection.md
@@ -117,7 +117,7 @@ import, `import frameless.TypedEncoder.injections._`. This will encode the data 
 For example, consider the following sealed family:
 
 ```tut:book
-sealed treat Foo
+sealed trait Foo
 object A { case object Bar extends Foo }
 object B { case object Bar extends Foo }
 ```

--- a/docs/src/main/tut/Injection.md
+++ b/docs/src/main/tut/Injection.md
@@ -109,3 +109,9 @@ val personDS = TypedDataset.create(people)
 ```tut:invisible
 spark.stop()
 ```
+
+Alternatively, an injection instance can be derived for sealed families such as `Gender` using the following 
+import, `import frameless.TypedEncoder.injections._`. This will encode the data constructors as strings.
+
+**Known issue**: An invalid injection instance will be derived if there are data constructors with the same name, 
+i.e., `A.Bar` and `B.Bar` since both constructors will be encoded as `"Bar"`.

--- a/docs/src/main/tut/Injection.md
+++ b/docs/src/main/tut/Injection.md
@@ -113,5 +113,13 @@ spark.stop()
 Alternatively, an injection instance can be derived for sealed families such as `Gender` using the following 
 import, `import frameless.TypedEncoder.injections._`. This will encode the data constructors as strings.
 
-**Known issue**: An invalid injection instance will be derived if there are data constructors with the same name, 
-i.e., `A.Bar` and `B.Bar` since both constructors will be encoded as `"Bar"`.
+**Known issue**: An invalid injection instance will be derived if there are data constructors with the same name.
+For example, consider the following sealed family:
+
+```tut:book
+sealed treat Foo
+object A { case object Bar extends Foo }
+object B { case object Bar extends Foo }
+```
+
+`A.Bar` and `B.Bar` will both be encoded as `"Bar"` thereby breaking the law that `invert(apply(x)) == x`.


### PR DESCRIPTION
This pull request provides capability to derive `Injection` instances for enum types. Frameless currently allows custom encoders to be defined for unsupported types. For example, see  below -
```
implicit val genderToInt: Injection[Gender, Int] = Injection(
  {
    case Male   => 1
    case Female => 2
    case Other  => 3
  },
  {
    case 1 => Male
    case 2 => Female
    case 3 => Other
  })
```

This definition is rather mechanical and makes a good candidate for generic programming. Considering how widely "enum types" are used in big data (usually just defined using strings), I hope this PR brings something useful to the table.