### PR TITLE
add explicit jdk version setting in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 sudo: false
-
+jdk: openjdk8
 sbt_args: "-J-Xmx2G"
 
 jobs:


### PR DESCRIPTION
https://travis-ci.community/t/default-jdk-on-xenial-openjdk8-or-openjdk11/4542