### PR TITLE
Update dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val sparkVersion = "2.4.4"
 val catsCoreVersion = "2.0.0"
 val catsEffectVersion = "2.0.0"
 val catsMtlVersion = "0.7.0"
-val scalatest = "3.0.5"
+val scalatest = "3.0.8"
 val shapeless = "2.3.3"
 val scalacheck = "1.14.3"
 val irrecVersion = "0.2.1"
@@ -23,7 +23,7 @@ lazy val cats = project
   .settings(framelessSettings: _*)
   .settings(publishSettings: _*)
   .settings(
-    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
+    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full),
     scalacOptions += "-Ypartial-unification"
   )
   .settings(libraryDependencies ++= Seq(
@@ -65,7 +65,8 @@ lazy val ml = project
 lazy val docs = project
   .settings(framelessSettings: _*)
   .settings(noPublishSettings: _*)
-  .settings(tutSettings: _*)
+  .settings(scalacOptions --= Seq("-Xfatal-warnings"))
+  .enablePlugins(TutPlugin)
   .settings(crossTarget := file(".") / "docs" / "target")
   .settings(libraryDependencies ++= Seq(
     "org.apache.spark" %% "spark-core" % sparkVersion,
@@ -73,7 +74,7 @@ lazy val docs = project
     "org.apache.spark" %% "spark-mllib"  % sparkVersion
   ))
   .settings(
-    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
+    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full),
     scalacOptions ++= Seq(
       "-Ypartial-unification",
       "-Ydelambdafy:inline"
@@ -83,7 +84,7 @@ lazy val docs = project
 
 lazy val framelessSettings = Seq(
   organization := "org.typelevel",
-  crossScalaVersions := Seq("2.11.12", "2.12.8"),
+  crossScalaVersions := Seq("2.11.12", "2.12.10"),
   scalaVersion := crossScalaVersions.value.last,
   scalacOptions ++= commonScalacOptions(scalaVersion.value),
   licenses += ("Apache-2.0", url("http://opensource.org/licenses/Apache-2.0")),
@@ -157,7 +158,6 @@ lazy val framelessTypedDatasetREPL = Seq(
 )
 
 lazy val publishSettings = Seq(
-  useGpg := true,
   publishMavenStyle := true,
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
@@ -210,8 +210,8 @@ lazy val publishSettings = Seq(
 )
 
 lazy val noPublishSettings = Seq(
-  publish := (),
-  publishLocal := (),
+  publish := (()),
+  publishLocal := (()),
   publishArtifact := false
 )
 
@@ -228,5 +228,5 @@ lazy val copyReadme = taskKey[Unit]("copy for website generation")
 lazy val copyReadmeImpl = Def.task {
   val from = baseDirectory.value / "README.md"
   val to   = baseDirectory.value / "docs" / "src" / "main" / "tut" / "README.md"
-  sbt.IO.copy(List((from, to)), overwrite = true, preserveLastModified = true)
+  sbt.IO.copy(List((from, to)), overwrite = true, preserveLastModified = true, preserveExecutable = true)
 }

--- a/cats/src/test/scala/frameless/cats/test.scala
+++ b/cats/src/test/scala/frameless/cats/test.scala
@@ -11,11 +11,10 @@ import org.apache.spark.{SparkConf, SparkContext => SC}
 
 import org.scalatest.compatible.Assertion
 import org.scalactic.anyvals.PosInt
-import org.scalatest.Matchers
+import org.scalatest.{Matchers, PropSpec}
 import org.scalacheck.Arbitrary
-import org.scalatest._
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import Arbitrary._
-import prop._
 
 import scala.collection.immutable.SortedMap
 import scala.reflect.ClassTag
@@ -63,7 +62,7 @@ object Tests {
   }
 }
 
-class Test extends PropSpec with Matchers with PropertyChecks with SparkTests {
+class Test extends PropSpec with Matchers with ScalaCheckPropertyChecks with SparkTests {
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(minSize = PosInt(10))
 

--- a/dataset/src/test/scala/frameless/JobTests.scala
+++ b/dataset/src/test/scala/frameless/JobTests.scala
@@ -2,10 +2,10 @@ package frameless
 
 import org.scalacheck.Arbitrary
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 
-class JobTests extends FreeSpec with BeforeAndAfterAll with SparkTesting with GeneratorDrivenPropertyChecks with Matchers {
+class JobTests extends FreeSpec with BeforeAndAfterAll with SparkTesting with ScalaCheckDrivenPropertyChecks with Matchers {
 
   "map" - {
     "identity" in {

--- a/dataset/src/test/scala/frameless/TypedDatasetSuite.scala
+++ b/dataset/src/test/scala/frameless/TypedDatasetSuite.scala
@@ -4,7 +4,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.scalactic.anyvals.PosZInt
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Prop
 import org.scalacheck.Prop._
 import scala.util.{Properties, Try}

--- a/docs/src/main/tut/TypedDataFrame.md
+++ b/docs/src/main/tut/TypedDataFrame.md
@@ -66,7 +66,7 @@ def join2(tf1: TypedDataFrame[Foo], tf2: TypedDataFrame[Bar])
   tf1.innerJoin(tf2).using('i)
 ```
 
-Further example are available in the [TypedDataFrame join tests.](../dataframe/src/test/scala/JoinTests.scala)
+Further example are available in the [TypedDataFrame join tests.](https://github.com/typelevel/frameless/blob/17194d2172e75f8994e9481181e85b4c8dcc0f69/dataframe/src/test/scala/JoinTests.scala)
 
 ### Complete example
 
@@ -130,7 +130,7 @@ def bestNeighborhood
 }
 ```
 
-If you compare this version to vanilla Spark where every line is a `DataFrame`, you see how much types can improve readability. An executable version of this example is available in the [BestNeighborhood test](../dataframe/src/test/scala/BestNeighborhood.scala).
+If you compare this version to vanilla Spark where every line is a `DataFrame`, you see how much types can improve readability. An executable version of this example is available in the [BestNeighborhood test](https://github.com/typelevel/frameless/blob/17194d2172e75f8994e9481181e85b4c8dcc0f69/dataframe/src/test/scala/BestNeighborhood.scala).
 
 ### Limitations
 

--- a/ml/src/test/scala/frameless/ml/FramelessMlSuite.scala
+++ b/ml/src/test/scala/frameless/ml/FramelessMlSuite.scala
@@ -3,7 +3,7 @@ package ml
 
 import org.scalactic.anyvals.PosZInt
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class FramelessMlSuite extends FunSuite with Checkers with BeforeAndAfterAll with SparkTesting {
   // Limit size of generated collections and number of checks because Travis

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.3.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"  % "2.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"  % "3.8.1")
 addSbtPlugin("com.jsuereth"   % "sbt-pgp"       % "2.0.1")
 addSbtPlugin("org.scoverage"  % "sbt-scoverage" % "1.6.1")
-addSbtPlugin("org.tpolecat"   % "tut-plugin"    % "0.4.8")
+addSbtPlugin("org.tpolecat"   % "tut-plugin"    % "0.6.13")


### PR DESCRIPTION
@larsrh, @imarios, @OlivierBlanvillain:

- Update scalatest imports removing deprecated ones
- Update some links in the docs
- Moves to sbt 1.3.4 from 0.13.18

Note: There is some influx of changes on scalatest 3.1 that should be stabilized on scalatest 3.2, so holding until then. More info in: https://github.com/scalatest/scalatest/issues/1735

Note 2: We did not migrate from tut to mdoc due to this issue: https://github.com/scalameta/mdoc/issues/248