### PR TITLE
Remove myself from maintainers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ We require at least *one* sign-off (thumbs-up, +1, or similar) to merge pull req
 
 * [adelbertc](https://github.com/adelbertc)
 * [imarios](https://github.com/imarios)
-* [jeremyrsmith](https://github.com/jeremyrsmith)
 * [kanterov](https://github.com/kanterov)
 * [non](https://github.com/non)
 * [OlivierBlanvillain](https://github.com/OlivierBlanvillain/)


### PR DESCRIPTION
I want to say that:

1. I think this project is awesome! It does a lot of good for type-conscious users at the intersection of Spark and FP. 🙏 
2. I love being credited as a maintainer! I'm sure it's a huge source of credibility for me 😀 
3. I do care about this project and I want to see it thrive!

However,

1. I don't think I've ever made a PR to frameless that ended up getting merged (ironically, I hope this one will 😆 ). Listing me as a maintainer is mostly a historical artifact of myself and (I think) @OlivierBlanvillain being at the same place at the same time w.r.t. having the idea of shapeless+spark, googling it, finding that @adelbertc had already started on it, and offering to work on it. I'm grateful for the direction it's gone in since then, but I don't deserve any credit for it!
2. I think that crediting me as a maintainer, when I've essentially never done any maintenance on what frameless currently is, is unfair to the _real_ maintainers and a discredit to them.
3. As much as I would like to, I don't actually get to use frameless in projects I currently work on, so not only do I not actually maintain it but I don't even regularly use it. So it's doubly unfair that I'm listed as a maintainer when there are tons of folks who use & contribute to it (and here I am doing neither).

Someday I hope to be a more active user and if that happens I'll be thrilled to be a contributor as well! But I think it's only fair that I make this change – you're all much too polite to do it I assume – and I should have done it years ago (but I just noticed that I'm still listed).