### PR TITLE
Making it easier to work with Optional columns.

### DIFF
--- a/dataset/src/test/scala/frameless/ColumnTests.scala
+++ b/dataset/src/test/scala/frameless/ColumnTests.scala
@@ -411,4 +411,18 @@ class ColumnTests extends TypedDatasetSuite with Matchers {
     "ds.select(!ds('_2))" shouldNot typeCheck
     "ds.select(!ds('_3))" shouldNot typeCheck
   }
+
+  test("opt") {
+    val data = (Option(1L), Option(2L)) :: (None, None) :: Nil
+    val ds = TypedDataset.create(data)
+    val rs = ds.select(ds('_1).opt.map(_ * 2), ds('_1).opt.map(_ + 2)).collect().run()
+    val expected = data.map { case (x, y) => (x.map(_ * 2), y.map(_ + 1)) }
+    rs shouldEqual expected
+  }
+
+  test("opt compiles only for columns of type Option[_]") {
+    val ds = TypedDataset.create((1, List(1,2,3)) :: Nil)
+    "ds.select(ds('_1).opt.map(x => x))" shouldNot typeCheck
+    "ds.select(ds('_2).opt.map(x => x))" shouldNot typeCheck
+  }
 }


### PR DESCRIPTION
```scala
case class X(i: Option[Int], j: Option[String])
val t = TypedDataset.create(Seq( X(Some(1), None), X(None, None), X(Some(10), Some("foo"))))
 t.select(t('i).opt.map(_*2), t('j).opt.map(_.startsWith("fo"))).show().run()
+----+----+
|  _1|  _2|
+----+----+
|   2|null|
|null|null|
|  20|true|
+----+----+
```