### PR TITLE
Fix Spark cross publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Test & Compute Coverage
         run: sbt ++${{ matrix.scala }} coverage frameless-test
 
+      - name: Test & Compute Coverage Spark 3.1.x
+        run: sbt ++${{ matrix.scala }} coverage frameless-test-spark31
+
+      - name: Test & Compute Coverage Spark 3.0.x
+        run: sbt ++${{ matrix.scala }} coverage frameless-test-spark30
+
       - name: Upload Codecov Results
         run: codecov -F ${{ matrix.scala }}
 

--- a/build.sbt
+++ b/build.sbt
@@ -72,14 +72,16 @@ lazy val cats = project
   .settings(catsSettings)
   .dependsOn(dataset % "test->test;compile->compile;provided->provided")
 
-lazy val `cats-spark31` = project
+lazy val `cats-spark31` = (project in file("cats"))
   .settings(name := "frameless-cats-spark31")
+  .settings(target := file("cats-spark31/target"))
   .settings(catsSettings)
   .settings(mimaPreviousArtifacts := Set.empty)
   .dependsOn(`dataset-spark31` % "test->test;compile->compile;provided->provided")
 
-lazy val `cats-spark30` = project
+lazy val `cats-spark30` = (project in file("cats"))
   .settings(name := "frameless-cats-spark30")
+  .settings(target := file("cats-spark30/target"))
   .settings(catsSettings)
   .settings(mimaPreviousArtifacts := Set.empty)
   .dependsOn(`dataset-spark30` % "test->test;compile->compile;provided->provided")
@@ -90,15 +92,17 @@ lazy val dataset = project
   .settings(sparkDependencies(sparkVersion))
   .dependsOn(core % "test->test;compile->compile")
 
-lazy val `dataset-spark31` = project
+lazy val `dataset-spark31` = (project in file("dataset"))
   .settings(name := "frameless-dataset-spark31")
+  .settings(target := file("dataset-spark31/target"))
   .settings(datasetSettings)
   .settings(sparkDependencies(spark31Version))
   .settings(mimaPreviousArtifacts := Set.empty)
   .dependsOn(core % "test->test;compile->compile")
 
-lazy val `dataset-spark30` = project
+lazy val `dataset-spark30` = (project in file("dataset"))
   .settings(name := "frameless-dataset-spark30")
+  .settings(target := file("dataset-spark30/target"))
   .settings(datasetSettings)
   .settings(sparkDependencies(spark30Version))
   .settings(mimaPreviousArtifacts := Set.empty)
@@ -109,13 +113,15 @@ lazy val refined = project
   .settings(refinedSettings)
   .dependsOn(dataset % "test->test;compile->compile;provided->provided")
 
-lazy val `refined-spark31` = project
+lazy val `refined-spark31` = (project in file("refined"))
   .settings(name := "frameless-refined-spark31")
+  .settings(target := file("refined-spark31/target"))
   .settings(refinedSettings)
   .dependsOn(`dataset-spark31` % "test->test;compile->compile;provided->provided")
 
-lazy val `refined-spark30` = project
+lazy val `refined-spark30` = (project in file("refined"))
   .settings(name := "frameless-refined-spark30")
+  .settings(target := file("refined-spark30/target"))
   .settings(refinedSettings)
   .dependsOn(`dataset-spark30` % "test->test;compile->compile;provided->provided")
 
@@ -128,8 +134,9 @@ lazy val ml = project
     dataset % "test->test;compile->compile;provided->provided"
   )
 
-lazy val `ml-spark31` = project
+lazy val `ml-spark31` = (project in file("ml"))
   .settings(name := "frameless-ml-spark31")
+  .settings(target := file("ml-spark31/target"))
   .settings(mlSettings)
   .settings(sparkMlDependencies(spark31Version))
   .settings(mimaPreviousArtifacts := Set.empty)
@@ -138,8 +145,9 @@ lazy val `ml-spark31` = project
     `dataset-spark31` % "test->test;compile->compile;provided->provided"
   )
 
-lazy val `ml-spark30` = project
+lazy val `ml-spark30` = (project in file("ml"))
   .settings(name := "frameless-ml-spark30")
+  .settings(target := file("ml-spark30/target"))
   .settings(mlSettings)
   .settings(sparkMlDependencies(spark30Version))
   .settings(mimaPreviousArtifacts := Set.empty)

--- a/build.sbt
+++ b/build.sbt
@@ -79,16 +79,16 @@ lazy val cats = project
   .settings(catsSettings)
   .dependsOn(dataset % "test->test;compile->compile;provided->provided")
 
-lazy val `cats-spark31` = (project in file("cats"))
+lazy val `cats-spark31` = project
   .settings(name := "frameless-cats-spark31")
-  .settings(target := file("cats-spark31/target"))
+  .settings(sourceDirectory := (cats / sourceDirectory).value)
   .settings(catsSettings)
   .settings(mimaPreviousArtifacts := Set.empty)
   .dependsOn(`dataset-spark31` % "test->test;compile->compile;provided->provided")
 
-lazy val `cats-spark30` = (project in file("cats"))
+lazy val `cats-spark30` = project
   .settings(name := "frameless-cats-spark30")
-  .settings(target := file("cats-spark30/target"))
+  .settings(sourceDirectory := (cats / sourceDirectory).value)
   .settings(catsSettings)
   .settings(mimaPreviousArtifacts := Set.empty)
   .dependsOn(`dataset-spark30` % "test->test;compile->compile;provided->provided")
@@ -99,17 +99,17 @@ lazy val dataset = project
   .settings(sparkDependencies(sparkVersion))
   .dependsOn(core % "test->test;compile->compile")
 
-lazy val `dataset-spark31` = (project in file("dataset"))
+lazy val `dataset-spark31` = project
   .settings(name := "frameless-dataset-spark31")
-  .settings(target := file("dataset-spark31/target"))
+  .settings(sourceDirectory := (dataset / sourceDirectory).value)
   .settings(datasetSettings)
   .settings(sparkDependencies(spark31Version))
   .settings(mimaPreviousArtifacts := Set.empty)
   .dependsOn(core % "test->test;compile->compile")
 
-lazy val `dataset-spark30` = (project in file("dataset"))
+lazy val `dataset-spark30` = project
   .settings(name := "frameless-dataset-spark30")
-  .settings(target := file("dataset-spark30/target"))
+  .settings(sourceDirectory := (dataset / sourceDirectory).value)
   .settings(datasetSettings)
   .settings(sparkDependencies(spark30Version))
   .settings(mimaPreviousArtifacts := Set.empty)
@@ -120,15 +120,15 @@ lazy val refined = project
   .settings(refinedSettings)
   .dependsOn(dataset % "test->test;compile->compile;provided->provided")
 
-lazy val `refined-spark31` = (project in file("refined"))
+lazy val `refined-spark31` = project
   .settings(name := "frameless-refined-spark31")
-  .settings(target := file("refined-spark31/target"))
+  .settings(sourceDirectory := (refined / sourceDirectory).value)
   .settings(refinedSettings)
   .dependsOn(`dataset-spark31` % "test->test;compile->compile;provided->provided")
 
-lazy val `refined-spark30` = (project in file("refined"))
+lazy val `refined-spark30` = project
   .settings(name := "frameless-refined-spark30")
-  .settings(target := file("refined-spark30/target"))
+  .settings(sourceDirectory := (refined / sourceDirectory).value)
   .settings(refinedSettings)
   .dependsOn(`dataset-spark30` % "test->test;compile->compile;provided->provided")
 
@@ -141,9 +141,9 @@ lazy val ml = project
     dataset % "test->test;compile->compile;provided->provided"
   )
 
-lazy val `ml-spark31` = (project in file("ml"))
+lazy val `ml-spark31` = project
   .settings(name := "frameless-ml-spark31")
-  .settings(target := file("ml-spark31/target"))
+  .settings(sourceDirectory := (ml / sourceDirectory).value)
   .settings(mlSettings)
   .settings(sparkMlDependencies(spark31Version))
   .settings(mimaPreviousArtifacts := Set.empty)
@@ -152,9 +152,9 @@ lazy val `ml-spark31` = (project in file("ml"))
     `dataset-spark31` % "test->test;compile->compile;provided->provided"
   )
 
-lazy val `ml-spark30` = (project in file("ml"))
+lazy val `ml-spark30` = project
   .settings(name := "frameless-ml-spark30")
-  .settings(target := file("ml-spark30/target"))
+  .settings(sourceDirectory := (ml / sourceDirectory).value)
   .settings(mlSettings)
   .settings(sparkMlDependencies(spark30Version))
   .settings(mimaPreviousArtifacts := Set.empty)


### PR DESCRIPTION
Checking artifacts today I notcied that `-spark3x` artifacts are emtpy 🤦 
This PR should address this issue, I'll release the `0.11.1` shortly after verifying that it works.

The local publish now 100% works, still have no idea how it "worked" before 🤦, mb I checked only `core` imports (and it worked since in this case it is a common dep) and than I switched to `3.2` usage.