### PR TITLE
Implement java.time.{Duration, Instant, Period} type encoders

### DIFF
--- a/core/src/main/scala/frameless/CatalystOrdered.scala
+++ b/core/src/main/scala/frameless/CatalystOrdered.scala
@@ -3,6 +3,7 @@ package frameless
 import scala.annotation.implicitNotFound
 import shapeless.{Generic, HList, Lazy}
 import shapeless.ops.hlist.LiftAll
+import java.time.{Duration, Instant, Period}
 
 /** Types that can be ordered/compared by Catalyst. */
 @implicitNotFound("Cannot compare columns of type ${A}.")
@@ -23,6 +24,9 @@ object CatalystOrdered {
   implicit val framelessSQLDateOrdered     : CatalystOrdered[SQLDate]      = of[SQLDate]
   implicit val framelessSQLTimestampOrdered: CatalystOrdered[SQLTimestamp] = of[SQLTimestamp]
   implicit val framelessStringOrdered      : CatalystOrdered[String]       = of[String]
+  implicit val framelessInstantOrdered     : CatalystOrdered[Instant]      = of[Instant]
+  implicit val framelessDurationOrdered    : CatalystOrdered[Duration]     = of[Duration]
+  implicit val framelessPeriodOrdered      : CatalystOrdered[Period]       = of[Period]
 
   implicit def injectionOrdered[A, B]
     (implicit

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -1,5 +1,6 @@
 package frameless
 
+import java.time.{Duration, Instant, Period}
 import scala.reflect.ClassTag
 
 import org.apache.spark.sql.FramelessInternals
@@ -230,10 +231,10 @@ object TypedEncoder {
       )
   }
 
-  implicit val timeInstant: TypedEncoder[java.time.Instant] = new TypedEncoder[java.time.Instant] {
+  implicit val timeInstant: TypedEncoder[Instant] = new TypedEncoder[Instant] {
     def nullable: Boolean = false
 
-    def jvmRepr: DataType = ScalaReflection.dataTypeFor[java.time.Instant]
+    def jvmRepr: DataType = ScalaReflection.dataTypeFor[Instant]
     def catalystRepr: DataType = TimestampType
 
     def toCatalyst(path: Expression): Expression =
@@ -254,10 +255,10 @@ object TypedEncoder {
       )
   }
 
-  implicit val timeDuration: TypedEncoder[java.time.Duration] = new TypedEncoder[java.time.Duration] {
+  implicit val timeDuration: TypedEncoder[Duration] = new TypedEncoder[Duration] {
     def nullable: Boolean = false
 
-    def jvmRepr: DataType = ScalaReflection.dataTypeFor[java.time.Duration]
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[Duration]
     def catalystRepr: DataType = LongType
 
     def toCatalyst(path: Expression): Expression =
@@ -265,7 +266,7 @@ object TypedEncoder {
 
     def fromCatalyst(path: Expression): Expression =
       StaticInvoke(
-        staticObject = classOf[java.time.Duration],
+        staticObject = classOf[Duration],
         dataType = jvmRepr,
         functionName = "ofMillis",
         arguments = path :: Nil,
@@ -273,10 +274,10 @@ object TypedEncoder {
       )
   }
 
-  implicit val timePeriod: TypedEncoder[java.time.Period] = new TypedEncoder[java.time.Period] {
+  implicit val timePeriod: TypedEncoder[Period] = new TypedEncoder[Period] {
     def nullable: Boolean = false
 
-    def jvmRepr: DataType = ScalaReflection.dataTypeFor[java.time.Period]
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[Period]
     def catalystRepr: DataType = IntegerType
 
     def toCatalyst(path: Expression): Expression =
@@ -284,7 +285,7 @@ object TypedEncoder {
 
     def fromCatalyst(path: Expression): Expression =
       StaticInvoke(
-        staticObject = classOf[java.time.Period],
+        staticObject = classOf[Period],
         dataType = jvmRepr,
         functionName = "ofDays",
         arguments = path :: Nil,

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -230,7 +230,7 @@ object TypedEncoder {
       )
   }
 
-  implicit val timeInstantTimestamp: TypedEncoder[java.time.Instant] = new TypedEncoder[java.time.Instant] {
+  implicit val timeInstant: TypedEncoder[java.time.Instant] = new TypedEncoder[java.time.Instant] {
     def nullable: Boolean = false
 
     def jvmRepr: DataType = ScalaReflection.dataTypeFor[java.time.Instant]
@@ -254,7 +254,7 @@ object TypedEncoder {
       )
   }
 
-  implicit val timeDurationTimestamp: TypedEncoder[java.time.Duration] = new TypedEncoder[java.time.Duration] {
+  implicit val timeDuration: TypedEncoder[java.time.Duration] = new TypedEncoder[java.time.Duration] {
     def nullable: Boolean = false
 
     def jvmRepr: DataType = ScalaReflection.dataTypeFor[java.time.Duration]
@@ -273,7 +273,7 @@ object TypedEncoder {
       )
   }
 
-  implicit val timePeriodTimestamp: TypedEncoder[java.time.Period] = new TypedEncoder[java.time.Period] {
+  implicit val timePeriod: TypedEncoder[java.time.Period] = new TypedEncoder[java.time.Period] {
     def nullable: Boolean = false
 
     def jvmRepr: DataType = ScalaReflection.dataTypeFor[java.time.Period]

--- a/dataset/src/test/scala/frameless/ColumnTests.scala
+++ b/dataset/src/test/scala/frameless/ColumnTests.scala
@@ -1,7 +1,6 @@
 package frameless
 
 import java.time.Instant
-
 import org.scalacheck.Prop._
 import org.scalacheck.{Arbitrary, Gen, Prop}, Arbitrary.arbitrary
 import org.scalatest.matchers.should.Matchers
@@ -14,10 +13,7 @@ final class ColumnTests extends TypedDatasetSuite with Matchers {
   private implicit object OrderingImplicits {
     implicit val sqlDateOrdering: Ordering[SQLDate] = Ordering.by(_.days)
     implicit val sqlTimestmapOrdering: Ordering[SQLTimestamp] = Ordering.by(_.us)
-    implicit val arbInstant: Arbitrary[Instant] =
-      Arbitrary(Gen.choose[Instant](Instant.EPOCH, Instant.now()))
-    implicit val instantAsLongInjection: Injection[Instant, Long] =
-      Injection(_.getEpochSecond, Instant.ofEpochSecond)
+    implicit val arbInstant: Arbitrary[Instant] = Arbitrary(Gen.choose[Instant](Instant.EPOCH, Instant.now))
   }
 
   test("select('a < 'b, 'a <= 'b, 'a > 'b, 'a >= 'b)") {

--- a/dataset/src/test/scala/frameless/ColumnTests.scala
+++ b/dataset/src/test/scala/frameless/ColumnTests.scala
@@ -14,9 +14,8 @@ final class ColumnTests extends TypedDatasetSuite with Matchers {
   private implicit object OrderingImplicits {
     implicit val sqlDateOrdering: Ordering[SQLDate] = Ordering.by(_.days)
     implicit val sqlTimestmapOrdering: Ordering[SQLTimestamp] = Ordering.by(_.us)
-    implicit val arbInstant: Arbitrary[Instant] = Arbitrary(
-      Gen.chooseNum(0L, Instant.MAX.getEpochSecond)
-        .map(Instant.ofEpochSecond))
+    implicit val arbInstant: Arbitrary[Instant] =
+      Arbitrary(Gen.choose[Instant](Instant.EPOCH, Instant.now()))
     implicit val instantAsLongInjection: Injection[Instant, Long] =
       Injection(_.getEpochSecond, Instant.ofEpochSecond)
   }

--- a/dataset/src/test/scala/frameless/EncoderTests.scala
+++ b/dataset/src/test/scala/frameless/EncoderTests.scala
@@ -4,6 +4,9 @@ import org.scalatest.matchers.should.Matchers
 
 object EncoderTests {
   case class Foo(s: Seq[(Int, Int)])
+  case class InstantRow(i: java.time.Instant)
+  case class DurationRow(d: java.time.Duration)
+  case class PeriodRow(p: java.time.Period)
 }
 
 class EncoderTests extends TypedDatasetSuite with Matchers {
@@ -11,5 +14,17 @@ class EncoderTests extends TypedDatasetSuite with Matchers {
 
   test("It should encode deeply nested collections") {
     implicitly[TypedEncoder[Seq[Foo]]]
+  }
+
+  test("It should encode java.time.Instant") {
+    implicitly[TypedEncoder[InstantRow]]
+  }
+
+  test("It should encode java.time.Duration") {
+    implicitly[TypedEncoder[DurationRow]]
+  }
+
+  test("It should encode java.time.Period") {
+    implicitly[TypedEncoder[PeriodRow]]
   }
 }


### PR DESCRIPTION
See #576 (provide TypedEncoder for java.time.{Instant, Duration, Period} in Spark 3.2 #576)

This PR implements the following implicit typeEncoders in frameless.TypedEncoder

1. timeDuration: TypedEncoder[java.time.Duration]
2. timeInstant: TypedEncoder[java.time.Instant]
2. timePeriod: TypedEncoder[java.time.Period]

As DayTimeIntervalType and YearMonthIntervalType were introduced in spark 3.2,
to maintain compatibility through 3.0, 3.1 and 3.2 spark versions,
java.time.Instant is represented as an Int (days) catalyst type and java.time.Duration as a LongType (millis).

