### PR TITLE
Resolve a possible explodeMap column names collision

### DIFF
--- a/dataset/src/test/scala/frameless/ExplodeTests.scala
+++ b/dataset/src/test/scala/frameless/ExplodeTests.scala
@@ -77,4 +77,19 @@ class ExplodeTests extends TypedDatasetSuite {
     check(forAll(prop[String, Int, Long] _))
     check(forAll(prop[Long, String, Int] _))
   }
+
+  test("explode on maps making sure no key / value naming collision happens") {
+    def prop[K: TypedEncoder: ClassTag, V: TypedEncoder: ClassTag, A: TypedEncoder: ClassTag, B: TypedEncoder: ClassTag](xs: List[X3KV[K, V, Map[A, B]]]): Prop = {
+      val tds = TypedDataset.create(xs)
+
+      val framelessResults = tds.explodeMap('c).collect().run().toVector
+      val scalaResults = xs.flatMap { x3 => x3.c.toList.map((x3.key, x3.value, _)) }.toVector
+
+      framelessResults ?= scalaResults
+    }
+
+    check(forAll(prop[String, Int, Long, String] _))
+    check(forAll(prop[Long, String, Int, Long] _))
+    check(forAll(prop[Int, Long, String, Int] _))
+  }
 }

--- a/dataset/src/test/scala/frameless/XN.scala
+++ b/dataset/src/test/scala/frameless/XN.scala
@@ -52,6 +52,19 @@ object X3U {
     Ordering.Tuple3[A, B, C].on(x => (x.a, x.b, x.c))
 }
 
+case class X3KV[A, B, C](key: A, value: B, c: C)
+
+object X3KV {
+  implicit def arbitrary[A: Arbitrary, B: Arbitrary, C: Arbitrary]: Arbitrary[X3KV[A, B, C]] =
+    Arbitrary(Arbitrary.arbTuple3[A, B, C].arbitrary.map((X3KV.apply[A, B, C] _).tupled))
+
+  implicit def cogen[A, B, C](implicit A: Cogen[A], B: Cogen[B], C: Cogen[C]): Cogen[X3KV[A, B, C]] =
+    Cogen.tuple3(A, B, C).contramap(x => (x.key, x.value, x.c))
+
+  implicit def ordering[A: Ordering, B: Ordering, C: Ordering]: Ordering[X3KV[A, B, C]] =
+    Ordering.Tuple3[A, B, C].on(x => (x.key, x.value, x.c))
+}
+
 case class X4[A, B, C, D](a: A, b: B, c: C, d: D)
 
 object X4 {


### PR DESCRIPTION
This PR complements #488 and makes sure that no naming collision happens when performing the explodeMap.