### PR TITLE
Transition to Temurin in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.15, 2.13.7]
-        java: [adopt@1.8]
+        java: [8]
+        distribution: [temurin]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v2
         with:
+          distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
 
       - name: Setup Python
@@ -55,7 +57,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [adopt@1.8]
+        java: [8]
+        distribution: [temurin]
     runs-on: ${{ matrix.os }}
     env:
       PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
@@ -70,8 +73,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v2
         with:
+          distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
 
       # Sequentially publish different artifacts for different Scala versions.
@@ -94,15 +98,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.15]
-        java: [adopt@1.8]
+        java: [8]
+        distribution: [temurin]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v2
         with:
+          distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
 
       - name: Documentation


### PR DESCRIPTION
See 
* https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/ 
* https://github.com/olafurpg/setup-scala/issues/49