### PR TITLE
Fix publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -358,3 +358,16 @@ ThisBuild / githubWorkflowBuildPostamble ++= Seq(
     name = Some("Upload Codecov Results")
   )
 )
+
+def crossCommand(command: String) =
+  List(s"++$Scala212", s"root/$command", s"++$Scala213", s"root-spark32/$command")
+
+tlReplaceCommandAlias(
+  "tlReleaseLocal",
+  ("reload" :: crossCommand("publishLocal")).mkString("; ")
+)
+
+tlReplaceCommandAlias(
+  "tlRelease",
+  ("reload" :: crossCommand("mimaReportBinaryIssues") ::: crossCommand("publish") ::: List("tlSonatypeBundleReleaseIfRelevant")).mkString("; ")
+)

--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,6 @@ lazy val datasetSettings = framelessSettings ++ framelessTypedDatasetREPL ++ Seq
 )
 
 lazy val refinedSettings = framelessSettings ++ framelessTypedDatasetREPL ++ Seq(
-  mimaPreviousArtifacts := Set.empty,
   libraryDependencies += "eu.timepit" %% "refined" % refinedVersion
 )
 
@@ -252,11 +251,6 @@ lazy val framelessSettings = Seq(
   Test / parallelExecution := false,
   mimaPreviousArtifacts ~= {
     _.filterNot(_.revision == "0.11.0") // didn't release properly
-  },
-  mimaPreviousArtifacts := {
-    if (scalaBinaryVersion.value == "2.13")
-      Set.empty
-    else mimaPreviousArtifacts.value
   },
 ) ++ consoleSettings
 


### PR DESCRIPTION
Fixes https://github.com/typelevel/frameless/issues/598.

This is a bit ugly, but gets publishing working for now by replacing the `tlRelease` command. I think we may be able to solve this in sbt-typelevel so that we can remove this ugly hack from here :)

I also re-enabled MiMa for all artifacts, unless there's a reason it should be disabled?

Thanks for your patience!