### PR TITLE
Update to sbt-typelevel 0.4.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,21 +88,6 @@ jobs:
       - name: Upload Codecov Results
         run: codecov -F ${{ matrix.scala }}
 
-      - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master')
-        run: mkdir -p refined-spark30/target refined/target ml-spark30/target target mdocs/target ml-spark31/target refined-spark31/target .spark31/target ml/target cats-spark31/target dataset-spark31/target dataset/target cats-spark30/target .spark30/target .spark32/target cats/target core/target dataset-spark30/target project/target
-
-      - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master')
-        run: tar cf targets.tar refined-spark30/target refined/target ml-spark30/target target mdocs/target ml-spark31/target refined-spark31/target .spark31/target ml/target cats-spark31/target dataset-spark31/target dataset/target cats-spark30/target .spark30/target .spark32/target cats/target core/target dataset-spark30/target project/target
-
-      - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master')
-        uses: actions/upload-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
-          path: targets.tar
-
   publish:
     name: Publish Artifacts
     needs: [build]
@@ -137,46 +122,6 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
-
-      - name: Download target directories (2.13.8, root-spark32)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-root-spark32
-
-      - name: Inflate target directories (2.13.8, root-spark32)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.12.15, root-spark30)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-root-spark30
-
-      - name: Inflate target directories (2.12.15, root-spark30)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.12.15, root-spark31)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-root-spark31
-
-      - name: Inflate target directories (2.12.15, root-spark31)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.12.15, root-spark32)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-root-spark32
-
-      - name: Inflate target directories (2.12.15, root-spark32)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
 
       - name: Import signing key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ ThisBuild / tlBaseVersion := "0.11"
 
 ThisBuild / crossScalaVersions := Seq(Scala213, Scala212)
 ThisBuild / scalaVersion := Scala212
+ThisBuild / tlSkipIrrelevantScalas := true
+ThisBuild / githubWorkflowArtifactUpload := false // doesn't work with scoverage
 
 lazy val root = project.in(file("."))
   .enablePlugins(NoPublishPlugin)
@@ -352,17 +354,4 @@ ThisBuild / githubWorkflowBuildPostamble ++= Seq(
     List(s"codecov -F $${{ matrix.scala }}"),
     name = Some("Upload Codecov Results")
   )
-)
-
-def crossCommand(command: String) =
-  List(s"++$Scala212", s"root/$command", s"++$Scala213", s"root-spark32/$command")
-
-tlReplaceCommandAlias(
-  "tlReleaseLocal",
-  ("reload" :: crossCommand("publishLocal")).mkString("; ")
-)
-
-tlReplaceCommandAlias(
-  "tlRelease",
-  ("reload" :: crossCommand("mimaReportBinaryIssues") ::: crossCommand("publish") ::: List("tlSonatypeBundleReleaseIfRelevant")).mkString("; ")
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-val sbtTypelevelVersion = "0.4.4"
+val sbtTypelevelVersion = "0.4.5"
 addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % sbtTypelevelVersion)
 addSbtPlugin("org.typelevel" % "sbt-typelevel-site"       % sbtTypelevelVersion)
 addSbtPlugin("org.scoverage" % "sbt-scoverage"            % "1.9.3")


### PR DESCRIPTION
This uses the new `tlSkipIrrelevantScalas` feature so you no longer need a custom release command.