### PR TITLE
Use the sbt-typelevel plugin to indicate the first artifact version instead of disabling mima

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -263,7 +263,7 @@ lazy val spark31Settings = Seq(
 )
 
 lazy val spark32Settings = Seq(
-  mimaPreviousArtifacts := Set.empty
+  tlVersionIntroduced := Map("2.12" -> "0.13.0", "2.13" -> "0.13.0")
 )
 
 lazy val consoleSettings = Seq(


### PR DESCRIPTION
See https://github.com/typelevel/frameless/pull/637#discussion_r922892066

Thx @armanbilge for keeping an eye on the project!