### PR TITLE
Remove `Lazy` for Scala 2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.10, 2.12.16]
+        scala: [2.13.10, 2.12.17]
         java: [temurin@8]
         project: [root-spark31, root-spark32, root-spark33]
         exclude:
@@ -104,7 +104,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.16]
+        scala: [2.12.17]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -160,7 +160,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.16]
+        scala: [2.12.17]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/dataset/src/main/scala-2.13+/frameless/RecordEncoder.scala
+++ b/dataset/src/main/scala-2.13+/frameless/RecordEncoder.scala
@@ -1,0 +1,75 @@
+package frameless
+
+import org.apache.spark.sql.FramelessInternals
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.objects.{ Invoke, NewInstance }
+import org.apache.spark.sql.types._
+
+import shapeless._
+import shapeless.ops.hlist.IsHCons
+
+import scala.reflect.ClassTag
+
+class RecordEncoder[F, G <: HList, H <: HList]
+  (implicit
+    i0: LabelledGeneric.Aux[F, G],
+    i1: DropUnitValues.Aux[G, H],
+    i2: IsHCons[H],
+    fields: RecordEncoderFields[H],
+    newInstanceExprs: NewInstanceExprs[G],
+    classTag: ClassTag[F]
+  ) extends TypedEncoder[F] {
+    def nullable: Boolean = false
+
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[F]
+
+    def catalystRepr: DataType = {
+      val structFields = fields.value.map { field =>
+        StructField(
+          name = field.name,
+          dataType = field.encoder.catalystRepr,
+          nullable = field.encoder.nullable,
+          metadata = Metadata.empty
+        )
+      }
+
+      StructType(structFields)
+    }
+
+    def toCatalyst(path: Expression): Expression = {
+      val nameExprs = fields.value.map { field =>
+        Literal(field.name)
+      }
+
+      val valueExprs = fields.value.map { field =>
+        val fieldPath = Invoke(path, field.name, field.encoder.jvmRepr, Nil)
+        field.encoder.toCatalyst(fieldPath)
+      }
+
+      // the way exprs are encoded in CreateNamedStruct
+      val exprs = nameExprs.zip(valueExprs).flatMap {
+        case (nameExpr, valueExpr) => nameExpr :: valueExpr :: Nil
+      }
+
+      val createExpr = CreateNamedStruct(exprs)
+      val nullExpr = Literal.create(null, createExpr.dataType)
+
+      If(IsNull(path), nullExpr, createExpr)
+    }
+
+    def fromCatalyst(path: Expression): Expression = {
+      val exprs = fields.value.map { field =>
+        field.encoder.fromCatalyst(
+          GetStructField(path, field.ordinal, Some(field.name)))
+      }
+
+      val newArgs = newInstanceExprs.from(exprs)
+      val newExpr = NewInstance(
+        classTag.runtimeClass, newArgs, jvmRepr, propagateNull = true)
+
+      val nullExpr = Literal.create(null, jvmRepr)
+
+      If(IsNull(path), nullExpr, newExpr)
+    }
+}

--- a/dataset/src/main/scala-2.13+/frameless/TypedEncoderCompat.scala
+++ b/dataset/src/main/scala-2.13+/frameless/TypedEncoderCompat.scala
@@ -1,0 +1,196 @@
+package frameless
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.sql.types._
+
+import org.apache.spark.sql.FramelessInternals
+
+import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.objects._
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData}
+
+import shapeless._
+import shapeless.ops.hlist.IsHCons
+
+private[frameless] trait TypedEncoderCompat {
+  /** Encodes things using injection if there is one defined */
+  implicit def usingInjection[A: ClassTag, B]
+    (implicit inj: Injection[A, B], trb: TypedEncoder[B]): TypedEncoder[A] =
+      new TypedEncoder[A] {
+        def nullable: Boolean = trb.nullable
+        def jvmRepr: DataType = FramelessInternals.objectTypeFor[A](classTag)
+        def catalystRepr: DataType = trb.catalystRepr
+
+        def fromCatalyst(path: Expression): Expression = {
+          val bexpr = trb.fromCatalyst(path)
+          Invoke(Literal.fromObject(inj), "invert", jvmRepr, Seq(bexpr))
+        }
+
+        def toCatalyst(path: Expression): Expression =
+          trb.toCatalyst(Invoke(
+            Literal.fromObject(inj), "apply", trb.jvmRepr, Seq(path)))
+      }
+
+  /** Encodes things as records if there is no Injection defined */
+  implicit def usingDerivation[F, G <: HList, H <: HList]
+    (implicit
+      i0: LabelledGeneric.Aux[F, G],
+      i1: DropUnitValues.Aux[G, H],
+      i2: IsHCons[H],
+      i3: RecordEncoderFields[H],
+      i4: NewInstanceExprs[G],
+      i5: ClassTag[F]
+    ): TypedEncoder[F] = new RecordEncoder[F, G, H]
+
+  implicit def arrayEncoder[T: ClassTag](
+    implicit i0: RecordFieldEncoder[T]): TypedEncoder[Array[T]] =
+    new TypedEncoder[Array[T]] {
+      private lazy val encodeT = i0.encoder
+
+      def nullable: Boolean = false
+
+      lazy val jvmRepr: DataType = i0.jvmRepr match {
+        case ByteType => BinaryType
+        case _        => FramelessInternals.objectTypeFor[Array[T]]
+      }
+
+      lazy val catalystRepr: DataType = i0.jvmRepr match {
+        case ByteType => BinaryType
+        case _        => ArrayType(encodeT.catalystRepr, encodeT.nullable)
+      }
+
+      def toCatalyst(path: Expression): Expression =
+        i0.jvmRepr match {
+          case IntegerType | LongType | DoubleType | FloatType |
+              ShortType | BooleanType =>
+            StaticInvoke(
+              classOf[UnsafeArrayData],
+              catalystRepr, "fromPrimitiveArray", path :: Nil)
+
+          case ByteType => path
+
+          case _ => MapObjects(
+            i0.toCatalyst, path, i0.jvmRepr, encodeT.nullable)
+        }
+
+      def fromCatalyst(path: Expression): Expression =
+        encodeT.jvmRepr match {
+          case IntegerType => Invoke(path, "toIntArray", jvmRepr)
+          case LongType => Invoke(path, "toLongArray", jvmRepr)
+          case DoubleType => Invoke(path, "toDoubleArray", jvmRepr)
+          case FloatType => Invoke(path, "toFloatArray", jvmRepr)
+          case ShortType => Invoke(path, "toShortArray", jvmRepr)
+          case BooleanType => Invoke(path, "toBooleanArray", jvmRepr)
+
+          case ByteType => path
+
+          case _ =>
+            Invoke(MapObjects(
+              i0.fromCatalyst, path,
+              encodeT.catalystRepr, encodeT.nullable), "array", jvmRepr)
+        }
+
+      override def toString: String = s"arrayEncoder($jvmRepr)"
+    }
+
+  implicit def collectionEncoder[C[X] <: Seq[X], T]
+    (implicit
+      i0: RecordFieldEncoder[T],
+      i1: ClassTag[C[T]]): TypedEncoder[C[T]] = new TypedEncoder[C[T]] {
+    private lazy val encodeT = i0.encoder
+
+    def nullable: Boolean = false
+
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[C[T]](i1)
+
+    def catalystRepr: DataType =
+      ArrayType(encodeT.catalystRepr, encodeT.nullable)
+
+    def toCatalyst(path: Expression): Expression = {
+      if (ScalaReflection.isNativeType(i0.jvmRepr)) {
+        NewInstance(classOf[GenericArrayData], path :: Nil, catalystRepr)
+      } else {
+        MapObjects(i0.toCatalyst, path, i0.jvmRepr, encodeT.nullable)
+      }
+    }
+
+    def fromCatalyst(path: Expression): Expression =
+      MapObjects(
+        i0.fromCatalyst,
+        path,
+        encodeT.catalystRepr,
+        encodeT.nullable,
+        Some(i1.runtimeClass) // This will cause MapObjects to build a collection of type C[_] directly
+      )
+
+    override def toString: String = s"collectionEncoder($jvmRepr)"
+  }
+
+  /**
+   * @tparam A the key type
+   * @tparam B the value type
+   * @param i0 the keys encoder
+   * @param i1 the values encoder
+   */
+  implicit def mapEncoder[A: NotCatalystNullable, B]
+    (implicit
+      i0: RecordFieldEncoder[A],
+      i1: RecordFieldEncoder[B],
+    ): TypedEncoder[Map[A, B]] = new TypedEncoder[Map[A, B]] {
+      def nullable: Boolean = false
+
+      def jvmRepr: DataType = FramelessInternals.objectTypeFor[Map[A, B]]
+
+      private lazy val encodeA = i0.encoder
+      private lazy val encodeB = i1.encoder
+
+      lazy val catalystRepr: DataType = MapType(
+        encodeA.catalystRepr, encodeB.catalystRepr, encodeB.nullable)
+
+      def fromCatalyst(path: Expression): Expression = {
+        val keyArrayType = ArrayType(encodeA.catalystRepr, containsNull = false)
+
+        val keyData = Invoke(
+          MapObjects(
+            i0.fromCatalyst,
+            Invoke(path, "keyArray", keyArrayType),
+            encodeA.catalystRepr
+          ),
+          "array",
+          FramelessInternals.objectTypeFor[Array[Any]]
+        )
+
+        val valueArrayType = ArrayType(encodeB.catalystRepr, encodeB.nullable)
+
+        val valueData = Invoke(
+          MapObjects(
+            i1.fromCatalyst,
+            Invoke(path, "valueArray", valueArrayType),
+            encodeB.catalystRepr
+          ),
+          "array",
+          FramelessInternals.objectTypeFor[Array[Any]]
+        )
+
+        StaticInvoke(
+          ArrayBasedMapData.getClass,
+          jvmRepr,
+          "toScalaMap",
+          keyData :: valueData :: Nil)
+      }
+
+      def toCatalyst(path: Expression): Expression =
+        ExternalMapToCatalyst(
+          path,
+          i0.jvmRepr,
+          i0.toCatalyst,
+          false,
+          i1.jvmRepr,
+          i1.toCatalyst,
+          encodeB.nullable)
+
+      override def toString = s"mapEncoder($jvmRepr)"
+    }
+}

--- a/dataset/src/main/scala-2.13+/frameless/ops/LowPriorityAs.scala
+++ b/dataset/src/main/scala-2.13+/frameless/ops/LowPriorityAs.scala
@@ -1,0 +1,22 @@
+package frameless.ops
+
+import shapeless.{::, Generic, HList}
+
+trait LowPriorityAs {
+
+  import As.Equiv
+
+  implicit def equivHList[AH, AT <: HList, BH, BT <: HList]
+    (implicit
+      i0: Equiv[AH, BH],
+      i1: Equiv[AT, BT]
+    ): Equiv[AH :: AT, BH :: BT] = new Equiv[AH :: AT, BH :: BT]
+
+  implicit def equivGeneric[A, B, R, S]
+    (implicit
+      i0: Generic.Aux[A, R],
+      i1: Generic.Aux[B, S],
+      i2: Equiv[R, S]
+    ): Equiv[A, B] = new Equiv[A, B]
+
+}

--- a/dataset/src/main/scala-2.13-/frameless/RecordEncoder.scala
+++ b/dataset/src/main/scala-2.13-/frameless/RecordEncoder.scala
@@ -1,0 +1,75 @@
+package frameless
+
+import org.apache.spark.sql.FramelessInternals
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.objects.{ Invoke, NewInstance }
+import org.apache.spark.sql.types._
+
+import shapeless._
+import shapeless.ops.hlist.IsHCons
+
+import scala.reflect.ClassTag
+
+class RecordEncoder[F, G <: HList, H <: HList]
+  (implicit
+    i0: LabelledGeneric.Aux[F, G],
+    i1: DropUnitValues.Aux[G, H],
+    i2: IsHCons[H],
+    fields: Lazy[RecordEncoderFields[H]],
+    newInstanceExprs: Lazy[NewInstanceExprs[G]],
+    classTag: ClassTag[F]
+  ) extends TypedEncoder[F] {
+    def nullable: Boolean = false
+
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[F]
+
+    def catalystRepr: DataType = {
+      val structFields = fields.value.value.map { field =>
+        StructField(
+          name = field.name,
+          dataType = field.encoder.catalystRepr,
+          nullable = field.encoder.nullable,
+          metadata = Metadata.empty
+        )
+      }
+
+      StructType(structFields)
+    }
+
+    def toCatalyst(path: Expression): Expression = {
+      val nameExprs = fields.value.value.map { field =>
+        Literal(field.name)
+      }
+
+      val valueExprs = fields.value.value.map { field =>
+        val fieldPath = Invoke(path, field.name, field.encoder.jvmRepr, Nil)
+        field.encoder.toCatalyst(fieldPath)
+      }
+
+      // the way exprs are encoded in CreateNamedStruct
+      val exprs = nameExprs.zip(valueExprs).flatMap {
+        case (nameExpr, valueExpr) => nameExpr :: valueExpr :: Nil
+      }
+
+      val createExpr = CreateNamedStruct(exprs)
+      val nullExpr = Literal.create(null, createExpr.dataType)
+
+      If(IsNull(path), nullExpr, createExpr)
+    }
+
+    def fromCatalyst(path: Expression): Expression = {
+      val exprs = fields.value.value.map { field =>
+        field.encoder.fromCatalyst(
+          GetStructField(path, field.ordinal, Some(field.name)))
+      }
+
+      val newArgs = newInstanceExprs.value.from(exprs)
+      val newExpr = NewInstance(
+        classTag.runtimeClass, newArgs, jvmRepr, propagateNull = true)
+
+      val nullExpr = Literal.create(null, jvmRepr)
+
+      If(IsNull(path), nullExpr, newExpr)
+    }
+}

--- a/dataset/src/main/scala-2.13-/frameless/TypedEncoderCompat.scala
+++ b/dataset/src/main/scala-2.13-/frameless/TypedEncoderCompat.scala
@@ -1,0 +1,205 @@
+package frameless
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.sql.types._
+
+import org.apache.spark.sql.FramelessInternals
+
+import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.objects._
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData}
+
+import shapeless._
+import shapeless.ops.hlist.IsHCons
+
+private[frameless] trait TypedEncoderCompat {
+  /** Encodes things using injection if there is one defined */
+  implicit def usingInjection[A: ClassTag, B]
+    (implicit inj: Injection[A, B], trb: TypedEncoder[B]): TypedEncoder[A] =
+      new TypedEncoder[A] {
+        def nullable: Boolean = trb.nullable
+        def jvmRepr: DataType = FramelessInternals.objectTypeFor[A](classTag)
+        def catalystRepr: DataType = trb.catalystRepr
+
+        def fromCatalyst(path: Expression): Expression = {
+          val bexpr = trb.fromCatalyst(path)
+          Invoke(Literal.fromObject(inj), "invert", jvmRepr, Seq(bexpr))
+        }
+
+        def toCatalyst(path: Expression): Expression =
+          trb.toCatalyst(Invoke(
+            Literal.fromObject(inj), "apply", trb.jvmRepr, Seq(path)))
+      }
+
+  /** Encodes things as records if there is no Injection defined */
+  implicit def usingDerivation[F, G <: HList, H <: HList]
+    (implicit
+      i0: LabelledGeneric.Aux[F, G],
+      i1: DropUnitValues.Aux[G, H],
+      i2: IsHCons[H],
+      i3: Lazy[RecordEncoderFields[H]],
+      i4: Lazy[NewInstanceExprs[G]],
+      i5: ClassTag[F]
+    ): TypedEncoder[F] = new RecordEncoder[F, G, H]
+
+  implicit def arrayEncoder[T: ClassTag](
+    implicit i0: Lazy[RecordFieldEncoder[T]]): TypedEncoder[Array[T]] =
+    new TypedEncoder[Array[T]] {
+      private lazy val encodeT = i0.value.encoder
+
+      def nullable: Boolean = false
+
+      lazy val jvmRepr: DataType = i0.value.jvmRepr match {
+        case ByteType => BinaryType
+        case _        => FramelessInternals.objectTypeFor[Array[T]]
+      }
+
+      lazy val catalystRepr: DataType = i0.value.jvmRepr match {
+        case ByteType => BinaryType
+        case _        => ArrayType(encodeT.catalystRepr, encodeT.nullable)
+      }
+
+      def toCatalyst(path: Expression): Expression = {
+        val enc = i0.value
+
+        enc.jvmRepr match {
+          case IntegerType | LongType | DoubleType | FloatType |
+              ShortType | BooleanType =>
+            StaticInvoke(
+              classOf[UnsafeArrayData],
+              catalystRepr, "fromPrimitiveArray", path :: Nil)
+
+          case ByteType => path
+
+          case _ => MapObjects(
+            enc.toCatalyst, path, enc.jvmRepr, encodeT.nullable)
+        }
+      }
+
+      def fromCatalyst(path: Expression): Expression =
+        encodeT.jvmRepr match {
+          case IntegerType => Invoke(path, "toIntArray", jvmRepr)
+          case LongType => Invoke(path, "toLongArray", jvmRepr)
+          case DoubleType => Invoke(path, "toDoubleArray", jvmRepr)
+          case FloatType => Invoke(path, "toFloatArray", jvmRepr)
+          case ShortType => Invoke(path, "toShortArray", jvmRepr)
+          case BooleanType => Invoke(path, "toBooleanArray", jvmRepr)
+
+          case ByteType => path
+
+          case _ =>
+            Invoke(MapObjects(
+              i0.value.fromCatalyst, path,
+              encodeT.catalystRepr, encodeT.nullable), "array", jvmRepr)
+        }
+
+      override def toString: String = s"arrayEncoder($jvmRepr)"
+    }
+
+  implicit def collectionEncoder[C[X] <: Seq[X], T]
+    (implicit
+      i0: Lazy[RecordFieldEncoder[T]],
+      i1: ClassTag[C[T]]): TypedEncoder[C[T]] = new TypedEncoder[C[T]] {
+    private lazy val encodeT = i0.value.encoder
+
+    def nullable: Boolean = false
+
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[C[T]](i1)
+
+    def catalystRepr: DataType =
+      ArrayType(encodeT.catalystRepr, encodeT.nullable)
+
+    def toCatalyst(path: Expression): Expression = {
+      val enc = i0.value
+
+      if (ScalaReflection.isNativeType(enc.jvmRepr)) {
+        NewInstance(classOf[GenericArrayData], path :: Nil, catalystRepr)
+      } else {
+        MapObjects(enc.toCatalyst, path, enc.jvmRepr, encodeT.nullable)
+      }
+    }
+
+    def fromCatalyst(path: Expression): Expression =
+      MapObjects(
+        i0.value.fromCatalyst,
+        path,
+        encodeT.catalystRepr,
+        encodeT.nullable,
+        Some(i1.runtimeClass) // This will cause MapObjects to build a collection of type C[_] directly
+      )
+
+    override def toString: String = s"collectionEncoder($jvmRepr)"
+  }
+
+  /**
+   * @tparam A the key type
+   * @tparam B the value type
+   * @param i0 the keys encoder
+   * @param i1 the values encoder
+   */
+  implicit def mapEncoder[A: NotCatalystNullable, B]
+    (implicit
+      i0: Lazy[RecordFieldEncoder[A]],
+      i1: Lazy[RecordFieldEncoder[B]],
+    ): TypedEncoder[Map[A, B]] = new TypedEncoder[Map[A, B]] {
+      def nullable: Boolean = false
+
+      def jvmRepr: DataType = FramelessInternals.objectTypeFor[Map[A, B]]
+
+      private lazy val encodeA = i0.value.encoder
+      private lazy val encodeB = i1.value.encoder
+
+      lazy val catalystRepr: DataType = MapType(
+        encodeA.catalystRepr, encodeB.catalystRepr, encodeB.nullable)
+
+      def fromCatalyst(path: Expression): Expression = {
+        val keyArrayType = ArrayType(encodeA.catalystRepr, containsNull = false)
+
+        val keyData = Invoke(
+          MapObjects(
+            i0.value.fromCatalyst,
+            Invoke(path, "keyArray", keyArrayType),
+            encodeA.catalystRepr
+          ),
+          "array",
+          FramelessInternals.objectTypeFor[Array[Any]]
+        )
+
+        val valueArrayType = ArrayType(encodeB.catalystRepr, encodeB.nullable)
+
+        val valueData = Invoke(
+          MapObjects(
+            i1.value.fromCatalyst,
+            Invoke(path, "valueArray", valueArrayType),
+            encodeB.catalystRepr
+          ),
+          "array",
+          FramelessInternals.objectTypeFor[Array[Any]]
+        )
+
+        StaticInvoke(
+          ArrayBasedMapData.getClass,
+          jvmRepr,
+          "toScalaMap",
+          keyData :: valueData :: Nil)
+      }
+
+      def toCatalyst(path: Expression): Expression = {
+        val encA = i0.value
+        val encB = i1.value
+
+        ExternalMapToCatalyst(
+          path,
+          encA.jvmRepr,
+          encA.toCatalyst,
+          false,
+          encB.jvmRepr,
+          encB.toCatalyst,
+          encodeB.nullable)
+      }
+
+      override def toString = s"mapEncoder($jvmRepr)"
+    }
+}

--- a/dataset/src/main/scala-2.13-/frameless/ops/LowPriorityAs.scala
+++ b/dataset/src/main/scala-2.13-/frameless/ops/LowPriorityAs.scala
@@ -1,0 +1,22 @@
+package frameless.ops
+
+import shapeless.{::, Generic, HList, Lazy}
+
+trait LowPriorityAs {
+
+  import As.Equiv
+
+  implicit def equivHList[AH, AT <: HList, BH, BT <: HList]
+    (implicit
+      i0: Lazy[Equiv[AH, BH]],
+      i1: Equiv[AT, BT]
+    ): Equiv[AH :: AT, BH :: BT] = new Equiv[AH :: AT, BH :: BT]
+
+  implicit def equivGeneric[A, B, R, S]
+    (implicit
+      i0: Generic.Aux[A, R],
+      i1: Generic.Aux[B, S],
+      i2: Lazy[Equiv[R, S]]
+    ): Equiv[A, B] = new Equiv[A, B]
+
+}

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -8,12 +8,9 @@ import org.apache.spark.sql.FramelessInternals.UserDefinedType
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.objects._
-import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, DateTimeUtils, GenericArrayData}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-
-import shapeless._
-import shapeless.ops.hlist.IsHCons
 
 abstract class TypedEncoder[T](implicit val classTag: ClassTag[T]) extends Serializable {
   def nullable: Boolean
@@ -40,7 +37,7 @@ abstract class TypedEncoder[T](implicit val classTag: ClassTag[T]) extends Seria
 //   - import TypedEncoder.usingDerivation
 //   - import TypedEncoder.usingUserDefinedType
 // """)
-object TypedEncoder {
+object TypedEncoder extends TypedEncoderCompat {
   def apply[T: TypedEncoder]: TypedEncoder[T] = implicitly[TypedEncoder[T]]
 
   implicit val stringEncoder: TypedEncoder[String] = new TypedEncoder[String] {
@@ -270,165 +267,6 @@ object TypedEncoder {
   implicit val timePeriodEncoder: TypedEncoder[Period] = TypedEncoder.usingInjection
   implicit val timeDurationEncoder: TypedEncoder[Duration] = TypedEncoder.usingInjection
 
-  implicit def arrayEncoder[T: ClassTag](
-    implicit i0: Lazy[RecordFieldEncoder[T]]): TypedEncoder[Array[T]] =
-    new TypedEncoder[Array[T]] {
-      private lazy val encodeT = i0.value.encoder
-
-      def nullable: Boolean = false
-
-      lazy val jvmRepr: DataType = i0.value.jvmRepr match {
-        case ByteType => BinaryType
-        case _        => FramelessInternals.objectTypeFor[Array[T]]
-      }
-
-      lazy val catalystRepr: DataType = i0.value.jvmRepr match {
-        case ByteType => BinaryType
-        case _        => ArrayType(encodeT.catalystRepr, encodeT.nullable)
-      }
-
-      def toCatalyst(path: Expression): Expression = {
-        val enc = i0.value
-
-        enc.jvmRepr match {
-          case IntegerType | LongType | DoubleType | FloatType |
-              ShortType | BooleanType =>
-            StaticInvoke(
-              classOf[UnsafeArrayData],
-              catalystRepr, "fromPrimitiveArray", path :: Nil)
-
-          case ByteType => path
-
-          case _ => MapObjects(
-            enc.toCatalyst, path, enc.jvmRepr, encodeT.nullable)
-        }
-      }
-
-      def fromCatalyst(path: Expression): Expression =
-        encodeT.jvmRepr match {
-          case IntegerType => Invoke(path, "toIntArray", jvmRepr)
-          case LongType => Invoke(path, "toLongArray", jvmRepr)
-          case DoubleType => Invoke(path, "toDoubleArray", jvmRepr)
-          case FloatType => Invoke(path, "toFloatArray", jvmRepr)
-          case ShortType => Invoke(path, "toShortArray", jvmRepr)
-          case BooleanType => Invoke(path, "toBooleanArray", jvmRepr)
-
-          case ByteType => path
-
-          case _ =>
-            Invoke(MapObjects(
-              i0.value.fromCatalyst, path,
-              encodeT.catalystRepr, encodeT.nullable), "array", jvmRepr)
-        }
-
-      override def toString: String = s"arrayEncoder($jvmRepr)"
-    }
-
-  implicit def collectionEncoder[C[X] <: Seq[X], T]
-    (implicit
-      i0: Lazy[RecordFieldEncoder[T]],
-      i1: ClassTag[C[T]]): TypedEncoder[C[T]] = new TypedEncoder[C[T]] {
-    private lazy val encodeT = i0.value.encoder
-
-    def nullable: Boolean = false
-
-    def jvmRepr: DataType = FramelessInternals.objectTypeFor[C[T]](i1)
-
-    def catalystRepr: DataType =
-      ArrayType(encodeT.catalystRepr, encodeT.nullable)
-
-    def toCatalyst(path: Expression): Expression = {
-      val enc = i0.value
-
-      if (ScalaReflection.isNativeType(enc.jvmRepr)) {
-        NewInstance(classOf[GenericArrayData], path :: Nil, catalystRepr)
-      } else {
-        MapObjects(enc.toCatalyst, path, enc.jvmRepr, encodeT.nullable)
-      }
-    }
-
-    def fromCatalyst(path: Expression): Expression =
-      MapObjects(
-        i0.value.fromCatalyst,
-        path,
-        encodeT.catalystRepr,
-        encodeT.nullable,
-        Some(i1.runtimeClass) // This will cause MapObjects to build a collection of type C[_] directly
-      )
-
-    override def toString: String = s"collectionEncoder($jvmRepr)"
-  }
-
-  /**
-   * @tparam A the key type
-   * @tparam B the value type
-   * @param i0 the keys encoder
-   * @param i1 the values encoder
-   */
-  implicit def mapEncoder[A: NotCatalystNullable, B]
-    (implicit
-      i0: Lazy[RecordFieldEncoder[A]],
-      i1: Lazy[RecordFieldEncoder[B]],
-    ): TypedEncoder[Map[A, B]] = new TypedEncoder[Map[A, B]] {
-      def nullable: Boolean = false
-
-      def jvmRepr: DataType = FramelessInternals.objectTypeFor[Map[A, B]]
-
-      private lazy val encodeA = i0.value.encoder
-      private lazy val encodeB = i1.value.encoder
-
-      lazy val catalystRepr: DataType = MapType(
-        encodeA.catalystRepr, encodeB.catalystRepr, encodeB.nullable)
-
-      def fromCatalyst(path: Expression): Expression = {
-        val keyArrayType = ArrayType(encodeA.catalystRepr, containsNull = false)
-
-        val keyData = Invoke(
-          MapObjects(
-            i0.value.fromCatalyst,
-            Invoke(path, "keyArray", keyArrayType),
-            encodeA.catalystRepr
-          ),
-          "array",
-          FramelessInternals.objectTypeFor[Array[Any]]
-        )
-
-        val valueArrayType = ArrayType(encodeB.catalystRepr, encodeB.nullable)
-
-        val valueData = Invoke(
-          MapObjects(
-            i1.value.fromCatalyst,
-            Invoke(path, "valueArray", valueArrayType),
-            encodeB.catalystRepr
-          ),
-          "array",
-          FramelessInternals.objectTypeFor[Array[Any]]
-        )
-
-        StaticInvoke(
-          ArrayBasedMapData.getClass,
-          jvmRepr,
-          "toScalaMap",
-          keyData :: valueData :: Nil)
-      }
-
-      def toCatalyst(path: Expression): Expression = {
-        val encA = i0.value
-        val encB = i1.value
-
-        ExternalMapToCatalyst(
-          path,
-          encA.jvmRepr,
-          encA.toCatalyst,
-          false,
-          encB.jvmRepr,
-          encB.toCatalyst,
-          encodeB.nullable)
-      }
-
-      override def toString = s"mapEncoder($jvmRepr)"
-    }
-
   implicit def optionEncoder[A](implicit underlying: TypedEncoder[A]): TypedEncoder[Option[A]] =
     new TypedEncoder[Option[A]] {
       def nullable: Boolean = true
@@ -493,35 +331,6 @@ object TypedEncoder {
     def fromCatalyst(path: Expression): Expression =
       WrapOption(underlying.fromCatalyst(path), underlying.jvmRepr)
   }
-
-  /** Encodes things using injection if there is one defined */
-  implicit def usingInjection[A: ClassTag, B]
-    (implicit inj: Injection[A, B], trb: TypedEncoder[B]): TypedEncoder[A] =
-      new TypedEncoder[A] {
-        def nullable: Boolean = trb.nullable
-        def jvmRepr: DataType = FramelessInternals.objectTypeFor[A](classTag)
-        def catalystRepr: DataType = trb.catalystRepr
-
-        def fromCatalyst(path: Expression): Expression = {
-          val bexpr = trb.fromCatalyst(path)
-          Invoke(Literal.fromObject(inj), "invert", jvmRepr, Seq(bexpr))
-        }
-
-        def toCatalyst(path: Expression): Expression =
-          trb.toCatalyst(Invoke(
-            Literal.fromObject(inj), "apply", trb.jvmRepr, Seq(path)))
-      }
-
-  /** Encodes things as records if there is no Injection defined */
-  implicit def usingDerivation[F, G <: HList, H <: HList]
-    (implicit
-      i0: LabelledGeneric.Aux[F, G],
-      i1: DropUnitValues.Aux[G, H],
-      i2: IsHCons[H],
-      i3: Lazy[RecordEncoderFields[H]],
-      i4: Lazy[NewInstanceExprs[G]],
-      i5: ClassTag[F]
-    ): TypedEncoder[F] = new RecordEncoder[F, G, H]
 
   /** Encodes things using a Spark SQL's User Defined Type (UDT) if there is one defined in implicit */
   implicit def usingUserDefinedType[A >: Null : UserDefinedType : ClassTag]: TypedEncoder[A] = {

--- a/dataset/src/main/scala/frameless/ops/As.scala
+++ b/dataset/src/main/scala/frameless/ops/As.scala
@@ -1,8 +1,6 @@
 package frameless
 package ops
 
-import shapeless.{::, Generic, HList, Lazy}
-
 /** Evidence for correctness of `TypedDataset[T].as[U]` */
 class As[T, U] private (implicit val encoder: TypedEncoder[U])
 
@@ -17,24 +15,5 @@ object As extends LowPriorityAs {
       i0: TypedEncoder[B],
       i1: Equiv[A, B]
     ): As[A, B] = new As[A, B]
-
-}
-
-trait LowPriorityAs {
-
-  import As.Equiv
-
-  implicit def equivHList[AH, AT <: HList, BH, BT <: HList]
-    (implicit
-      i0: Lazy[Equiv[AH, BH]],
-      i1: Equiv[AT, BT]
-    ): Equiv[AH :: AT, BH :: BT] = new Equiv[AH :: AT, BH :: BT]
-
-  implicit def equivGeneric[A, B, R, S]
-    (implicit
-      i0: Generic.Aux[A, R],
-      i1: Generic.Aux[B, S],
-      i2: Lazy[Equiv[R, S]]
-    ): Equiv[A, B] = new Equiv[A, B]
 
 }


### PR DESCRIPTION
`Lazy` is not only not required for Scala 2.13, but it raised warnings (see https://github.com/tpolecat/doobie/issues/1513 ).

Removing it only for Scala 2.13 using cross version compatiblity.