### PR TITLE
Mute Spark in tests

### DIFF
--- a/cats/src/test/resources/log4j2.properties
+++ b/cats/src/test/resources/log4j2.properties
@@ -1,0 +1,24 @@
+# Set to debug or trace if log4j initialization is failing
+status = warn
+
+# Name of the configuration
+name = ConsoleAppender
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c:%L - %m%n
+appender.console.target = SYSTEM_OUT
+
+# Root logger level
+rootLogger.level = error
+
+# Root logger referring to console appender
+rootLogger.appenderRef.stdout.ref = consoleLogger
+
+logger.spark.name = org.apache.spark
+logger.spark.level = warn
+
+logger.hadoop.name = org.apache.hadoop
+logger.hadoop.level = warn

--- a/dataset/src/test/resources/log4j2.properties
+++ b/dataset/src/test/resources/log4j2.properties
@@ -1,0 +1,24 @@
+# Set to debug or trace if log4j initialization is failing
+status = warn
+
+# Name of the configuration
+name = ConsoleAppender
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c:%L - %m%n
+appender.console.target = SYSTEM_OUT
+
+# Root logger level
+rootLogger.level = error
+
+# Root logger referring to console appender
+rootLogger.appenderRef.stdout.ref = consoleLogger
+
+logger.spark.name = org.apache.spark
+logger.spark.level = warn
+
+logger.hadoop.name = org.apache.hadoop
+logger.hadoop.level = warn


### PR DESCRIPTION
Spark 3.3.2 is officially moved to `log4j2`; `log4j.properties` => `log4j2.properties` to mute logs and speed up CI.