### PR TITLE
More Date & Big integer encoders

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.0.6
+version = 3.0.8
 runner.dialect = scala213
 
 newlines.beforeMultilineDef = keep

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -2,6 +2,8 @@ package frameless
 
 import java.util.Date
 
+import java.math.BigInteger
+
 import java.time.{Duration, Instant, Period}
 
 import scala.reflect.ClassTag
@@ -194,6 +196,47 @@ object TypedEncoder {
         Invoke(path, "toJavaBigDecimal", jvmRepr)
 
       override def toString: String = "javaBigDecimalEncoder"
+    }
+
+  implicit val bigIntEncoder: TypedEncoder[BigInt] = new TypedEncoder[BigInt] {
+    def nullable: Boolean = false
+
+    def jvmRepr: DataType = ScalaReflection.dataTypeFor[BigInt]
+    def catalystRepr: DataType = DecimalType(DecimalType.MAX_PRECISION, 0)
+
+      def toCatalyst(path: Expression): Expression =
+        StaticInvoke(
+          Decimal.getClass,
+          catalystRepr,
+          "apply",
+          path :: Nil
+        )
+
+      def fromCatalyst(path: Expression): Expression =
+        Invoke(path, "toScalaBigInt", jvmRepr)
+
+      override def toString: String = "bigIntEncoder"
+    }
+
+  implicit val javaBigIntEncoder: TypedEncoder[BigInteger] = 
+    new TypedEncoder[BigInteger] {
+      def nullable: Boolean = false
+
+      def jvmRepr: DataType = ScalaReflection.dataTypeFor[BigInteger]
+      def catalystRepr: DataType = DecimalType(DecimalType.MAX_PRECISION, 0)
+
+      def toCatalyst(path: Expression): Expression =
+        StaticInvoke(
+          Decimal.getClass,
+          catalystRepr,
+          "apply",
+          path :: Nil
+        )
+
+      def fromCatalyst(path: Expression): Expression =
+        Invoke(path, "toJavaBigInteger", jvmRepr)
+
+      override def toString: String = "javaBigIntEncoder"
     }
 
   implicit val sqlDate: TypedEncoder[SQLDate] = new TypedEncoder[SQLDate] {

--- a/dataset/src/main/scala/frameless/TypedEncoder.scala
+++ b/dataset/src/main/scala/frameless/TypedEncoder.scala
@@ -4,34 +4,41 @@ import java.util.Date
 
 import java.math.BigInteger
 
-import java.time.{Duration, Instant, Period}
+import java.time.{ Duration, Instant, Period }
 
 import scala.reflect.ClassTag
 
 import org.apache.spark.sql.FramelessInternals
 import org.apache.spark.sql.FramelessInternals.UserDefinedType
-import org.apache.spark.sql.{reflection => ScalaReflection}
+import org.apache.spark.sql.{ reflection => ScalaReflection }
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.objects._
-import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, DateTimeUtils, GenericArrayData}
+import org.apache.spark.sql.catalyst.util.{
+  ArrayBasedMapData,
+  DateTimeUtils,
+  GenericArrayData
+}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 import shapeless._
 import shapeless.ops.hlist.IsHCons
 
-abstract class TypedEncoder[T](implicit val classTag: ClassTag[T]) extends Serializable {
+abstract class TypedEncoder[T](implicit val classTag: ClassTag[T])
+    extends Serializable {
   def nullable: Boolean
 
   def jvmRepr: DataType
   def catalystRepr: DataType
 
-  /** From Catalyst representation to T
-    */
+  /**
+   * From Catalyst representation to T
+   */
   def fromCatalyst(path: Expression): Expression
 
-  /** T to Catalyst representation
-    */
+  /**
+   * T to Catalyst representation
+   */
   def toCatalyst(path: Expression): Expression
 }
 
@@ -107,6 +114,7 @@ object TypedEncoder {
   }
 
   implicit val charEncoder: TypedEncoder[Char] = new TypedEncoder[Char] {
+
     // tricky because while Char is primitive type, Spark doesn't support it
     implicit val charAsString: Injection[java.lang.Character, String] =
       new Injection[java.lang.Character, String] {
@@ -173,7 +181,11 @@ object TypedEncoder {
 
       def toCatalyst(path: Expression): Expression =
         StaticInvoke(
-          Decimal.getClass, DecimalType.SYSTEM_DEFAULT, "apply", path :: Nil)
+          Decimal.getClass,
+          DecimalType.SYSTEM_DEFAULT,
+          "apply",
+          path :: Nil
+        )
 
       def fromCatalyst(path: Expression): Expression =
         Invoke(path, "toBigDecimal", jvmRepr)
@@ -190,7 +202,11 @@ object TypedEncoder {
 
       def toCatalyst(path: Expression): Expression =
         StaticInvoke(
-          Decimal.getClass, DecimalType.SYSTEM_DEFAULT, "apply", path :: Nil)
+          Decimal.getClass,
+          DecimalType.SYSTEM_DEFAULT,
+          "apply",
+          path :: Nil
+        )
 
       def fromCatalyst(path: Expression): Expression =
         Invoke(path, "toJavaBigDecimal", jvmRepr)
@@ -204,21 +220,21 @@ object TypedEncoder {
     def jvmRepr: DataType = ScalaReflection.dataTypeFor[BigInt]
     def catalystRepr: DataType = DecimalType(DecimalType.MAX_PRECISION, 0)
 
-      def toCatalyst(path: Expression): Expression =
-        StaticInvoke(
-          Decimal.getClass,
-          catalystRepr,
-          "apply",
-          path :: Nil
-        )
+    def toCatalyst(path: Expression): Expression =
+      StaticInvoke(
+        Decimal.getClass,
+        catalystRepr,
+        "apply",
+        path :: Nil
+      )
 
-      def fromCatalyst(path: Expression): Expression =
-        Invoke(path, "toScalaBigInt", jvmRepr)
+    def fromCatalyst(path: Expression): Expression =
+      Invoke(path, "toScalaBigInt", jvmRepr)
 
-      override def toString: String = "bigIntEncoder"
-    }
+    override def toString: String = "bigIntEncoder"
+  }
 
-  implicit val javaBigIntEncoder: TypedEncoder[BigInteger] = 
+  implicit val javaBigIntEncoder: TypedEncoder[BigInteger] =
     new TypedEncoder[BigInteger] {
       def nullable: Boolean = false
 
@@ -259,7 +275,9 @@ object TypedEncoder {
   }
 
   implicit def timestampEncoder[T <: Date](
-    implicit i0: ClassTag[T]): TypedEncoder[T] =
+      implicit
+      i0: ClassTag[T]
+    ): TypedEncoder[T] =
     new TypedEncoder[T] {
       def nullable: Boolean = false
 
@@ -282,24 +300,25 @@ object TypedEncoder {
       override def toString: String = s"timestampEncoder(${i0.runtimeClass})"
     }
 
-  implicit val sqlTimestamp: TypedEncoder[SQLTimestamp] = new TypedEncoder[SQLTimestamp] {
-    def nullable: Boolean = false
+  implicit val sqlTimestamp: TypedEncoder[SQLTimestamp] =
+    new TypedEncoder[SQLTimestamp] {
+      def nullable: Boolean = false
 
-    def jvmRepr: DataType = ScalaReflection.dataTypeFor[SQLTimestamp]
-    def catalystRepr: DataType = TimestampType
+      def jvmRepr: DataType = ScalaReflection.dataTypeFor[SQLTimestamp]
+      def catalystRepr: DataType = TimestampType
 
-    def toCatalyst(path: Expression): Expression =
-      Invoke(path, "us", TimestampType)
+      def toCatalyst(path: Expression): Expression =
+        Invoke(path, "us", TimestampType)
 
-    def fromCatalyst(path: Expression): Expression =
-      StaticInvoke(
-        staticObject = SQLTimestamp.getClass,
-        dataType = jvmRepr,
-        functionName = "apply",
-        arguments = path :: Nil,
-        propagateNull = true
-      )
-  }
+      def fromCatalyst(path: Expression): Expression =
+        StaticInvoke(
+          staticObject = SQLTimestamp.getClass,
+          dataType = jvmRepr,
+          functionName = "apply",
+          arguments = path :: Nil,
+          propagateNull = true
+        )
+    }
 
   /** java.time Encoders, Spark uses https://github.com/apache/spark/blob/v3.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala for encoding / decoding. */
   implicit val timeInstant: TypedEncoder[Instant] = new TypedEncoder[Instant] {
@@ -314,7 +333,8 @@ object TypedEncoder {
         TimestampType,
         "instantToMicros",
         path :: Nil,
-        returnNullable = false)
+        returnNullable = false
+      )
 
     def fromCatalyst(path: Expression): Expression =
       StaticInvoke(
@@ -327,21 +347,30 @@ object TypedEncoder {
   }
 
   /**
-    * DayTimeIntervalType and YearMonthIntervalType in Spark 3.2.0.
-    * We maintain Spark 3.x cross compilation and handle Duration and Period as an injections to be compatible with Spark versions < 3.2
-    * See
-    *  * https://github.com/apache/spark/blob/v3.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala#L1031-L1047
-    *  * https://github.com/apache/spark/blob/v3.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala#L1075-L1087
-    */
+   * DayTimeIntervalType and YearMonthIntervalType in Spark 3.2.0.
+   * We maintain Spark 3.x cross compilation and handle Duration and Period as an injections to be compatible with Spark versions < 3.2
+   * See
+   *  * https://github.com/apache/spark/blob/v3.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala#L1031-L1047
+   *  * https://github.com/apache/spark/blob/v3.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala#L1075-L1087
+   */
   // DayTimeIntervalType
-  implicit val timeDurationInjection: Injection[Duration, Long] = Injection(_.toMillis, Duration.ofMillis)
+  implicit val timeDurationInjection: Injection[Duration, Long] =
+    Injection(_.toMillis, Duration.ofMillis)
+
   // YearMonthIntervalType
-  implicit val timePeriodInjection: Injection[Period, Int] = Injection(_.getDays, Period.ofDays)
-  implicit val timePeriodEncoder: TypedEncoder[Period] = TypedEncoder.usingInjection
-  implicit val timeDurationEncoder: TypedEncoder[Duration] = TypedEncoder.usingInjection
+  implicit val timePeriodInjection: Injection[Period, Int] =
+    Injection(_.getDays, Period.ofDays)
+
+  implicit val timePeriodEncoder: TypedEncoder[Period] =
+    TypedEncoder.usingInjection
+
+  implicit val timeDurationEncoder: TypedEncoder[Duration] =
+    TypedEncoder.usingInjection
 
   implicit def arrayEncoder[T: ClassTag](
-    implicit i0: Lazy[RecordFieldEncoder[T]]): TypedEncoder[Array[T]] =
+      implicit
+      i0: Lazy[RecordFieldEncoder[T]]
+    ): TypedEncoder[Array[T]] =
     new TypedEncoder[Array[T]] {
       private lazy val encodeT = i0.value.encoder
 
@@ -361,43 +390,54 @@ object TypedEncoder {
         val enc = i0.value
 
         enc.jvmRepr match {
-          case IntegerType | LongType | DoubleType | FloatType |
-              ShortType | BooleanType =>
+          case IntegerType | LongType | DoubleType | FloatType | ShortType |
+              BooleanType =>
             StaticInvoke(
               classOf[UnsafeArrayData],
-              catalystRepr, "fromPrimitiveArray", path :: Nil)
+              catalystRepr,
+              "fromPrimitiveArray",
+              path :: Nil
+            )
 
           case ByteType => path
 
-          case _ => MapObjects(
-            enc.toCatalyst, path, enc.jvmRepr, encodeT.nullable)
+          case _ =>
+            MapObjects(enc.toCatalyst, path, enc.jvmRepr, encodeT.nullable)
         }
       }
 
       def fromCatalyst(path: Expression): Expression =
         encodeT.jvmRepr match {
           case IntegerType => Invoke(path, "toIntArray", jvmRepr)
-          case LongType => Invoke(path, "toLongArray", jvmRepr)
-          case DoubleType => Invoke(path, "toDoubleArray", jvmRepr)
-          case FloatType => Invoke(path, "toFloatArray", jvmRepr)
-          case ShortType => Invoke(path, "toShortArray", jvmRepr)
+          case LongType    => Invoke(path, "toLongArray", jvmRepr)
+          case DoubleType  => Invoke(path, "toDoubleArray", jvmRepr)
+          case FloatType   => Invoke(path, "toFloatArray", jvmRepr)
+          case ShortType   => Invoke(path, "toShortArray", jvmRepr)
           case BooleanType => Invoke(path, "toBooleanArray", jvmRepr)
 
           case ByteType => path
 
           case _ =>
-            Invoke(MapObjects(
-              i0.value.fromCatalyst, path,
-              encodeT.catalystRepr, encodeT.nullable), "array", jvmRepr)
+            Invoke(
+              MapObjects(
+                i0.value.fromCatalyst,
+                path,
+                encodeT.catalystRepr,
+                encodeT.nullable
+              ),
+              "array",
+              jvmRepr
+            )
         }
 
       override def toString: String = s"arrayEncoder($jvmRepr)"
     }
 
-  implicit def collectionEncoder[C[X] <: Seq[X], T]
-    (implicit
+  implicit def collectionEncoder[C[X] <: Seq[X], T](
+      implicit
       i0: Lazy[RecordFieldEncoder[T]],
-      i1: ClassTag[C[T]]): TypedEncoder[C[T]] = new TypedEncoder[C[T]] {
+      i1: ClassTag[C[T]]
+    ): TypedEncoder[C[T]] = new TypedEncoder[C[T]] {
     private lazy val encodeT = i0.value.encoder
 
     def nullable: Boolean = false
@@ -436,10 +476,10 @@ object TypedEncoder {
    * @return a `TypedEncoder` instance for `Set[T]`.
    */
   implicit def setEncoder[T](
-    implicit
+      implicit
       i1: shapeless.Lazy[RecordFieldEncoder[T]],
-    i2: ClassTag[Set[T]],
-  ): TypedEncoder[Set[T]] = {
+      i2: ClassTag[Set[T]]
+    ): TypedEncoder[Set[T]] = {
     implicit val inj: Injection[Set[T], Seq[T]] = Injection(_.toSeq, _.toSet)
 
     TypedEncoder.usingInjection
@@ -451,71 +491,76 @@ object TypedEncoder {
    * @param i0 the keys encoder
    * @param i1 the values encoder
    */
-  implicit def mapEncoder[A: NotCatalystNullable, B]
-    (implicit
+  implicit def mapEncoder[A: NotCatalystNullable, B](
+      implicit
       i0: Lazy[RecordFieldEncoder[A]],
-      i1: Lazy[RecordFieldEncoder[B]],
+      i1: Lazy[RecordFieldEncoder[B]]
     ): TypedEncoder[Map[A, B]] = new TypedEncoder[Map[A, B]] {
-      def nullable: Boolean = false
+    def nullable: Boolean = false
 
-      def jvmRepr: DataType = FramelessInternals.objectTypeFor[Map[A, B]]
+    def jvmRepr: DataType = FramelessInternals.objectTypeFor[Map[A, B]]
 
-      private lazy val encodeA = i0.value.encoder
-      private lazy val encodeB = i1.value.encoder
+    private lazy val encodeA = i0.value.encoder
+    private lazy val encodeB = i1.value.encoder
 
-      lazy val catalystRepr: DataType = MapType(
-        encodeA.catalystRepr, encodeB.catalystRepr, encodeB.nullable)
+    lazy val catalystRepr: DataType =
+      MapType(encodeA.catalystRepr, encodeB.catalystRepr, encodeB.nullable)
 
-      def fromCatalyst(path: Expression): Expression = {
-        val keyArrayType = ArrayType(encodeA.catalystRepr, containsNull = false)
+    def fromCatalyst(path: Expression): Expression = {
+      val keyArrayType = ArrayType(encodeA.catalystRepr, containsNull = false)
 
-        val keyData = Invoke(
-          MapObjects(
-            i0.value.fromCatalyst,
-            Invoke(path, "keyArray", keyArrayType),
-            encodeA.catalystRepr
-          ),
-          "array",
-          FramelessInternals.objectTypeFor[Array[Any]]
-        )
+      val keyData = Invoke(
+        MapObjects(
+          i0.value.fromCatalyst,
+          Invoke(path, "keyArray", keyArrayType),
+          encodeA.catalystRepr
+        ),
+        "array",
+        FramelessInternals.objectTypeFor[Array[Any]]
+      )
 
-        val valueArrayType = ArrayType(encodeB.catalystRepr, encodeB.nullable)
+      val valueArrayType = ArrayType(encodeB.catalystRepr, encodeB.nullable)
 
-        val valueData = Invoke(
-          MapObjects(
-            i1.value.fromCatalyst,
-            Invoke(path, "valueArray", valueArrayType),
-            encodeB.catalystRepr
-          ),
-          "array",
-          FramelessInternals.objectTypeFor[Array[Any]]
-        )
+      val valueData = Invoke(
+        MapObjects(
+          i1.value.fromCatalyst,
+          Invoke(path, "valueArray", valueArrayType),
+          encodeB.catalystRepr
+        ),
+        "array",
+        FramelessInternals.objectTypeFor[Array[Any]]
+      )
 
-        StaticInvoke(
-          ArrayBasedMapData.getClass,
-          jvmRepr,
-          "toScalaMap",
-          keyData :: valueData :: Nil)
-      }
-
-      def toCatalyst(path: Expression): Expression = {
-        val encA = i0.value
-        val encB = i1.value
-
-        ExternalMapToCatalyst(
-          path,
-          encA.jvmRepr,
-          encA.toCatalyst,
-          false,
-          encB.jvmRepr,
-          encB.toCatalyst,
-          encodeB.nullable)
-      }
-
-      override def toString = s"mapEncoder($jvmRepr)"
+      StaticInvoke(
+        ArrayBasedMapData.getClass,
+        jvmRepr,
+        "toScalaMap",
+        keyData :: valueData :: Nil
+      )
     }
 
-  implicit def optionEncoder[A](implicit underlying: TypedEncoder[A]): TypedEncoder[Option[A]] =
+    def toCatalyst(path: Expression): Expression = {
+      val encA = i0.value
+      val encB = i1.value
+
+      ExternalMapToCatalyst(
+        path,
+        encA.jvmRepr,
+        encA.toCatalyst,
+        false,
+        encB.jvmRepr,
+        encB.toCatalyst,
+        encodeB.nullable
+      )
+    }
+
+    override def toString = s"mapEncoder($jvmRepr)"
+  }
+
+  implicit def optionEncoder[A](
+      implicit
+      underlying: TypedEncoder[A]
+    ): TypedEncoder[Option[A]] =
     new TypedEncoder[Option[A]] {
       def nullable: Boolean = true
 
@@ -530,77 +575,92 @@ object TypedEncoder {
           case IntegerType =>
             Invoke(
               UnwrapOption(
-                ScalaReflection.dataTypeFor[java.lang.Integer], path),
+                ScalaReflection.dataTypeFor[java.lang.Integer],
+                path
+              ),
               "intValue",
-              IntegerType)
+              IntegerType
+            )
 
           case LongType =>
             Invoke(
               UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Long], path),
               "longValue",
-              LongType)
+              LongType
+            )
 
           case DoubleType =>
             Invoke(
               UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Double], path),
               "doubleValue",
-              DoubleType)
+              DoubleType
+            )
 
           case FloatType =>
             Invoke(
               UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Float], path),
               "floatValue",
-              FloatType)
+              FloatType
+            )
 
           case ShortType =>
             Invoke(
               UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Short], path),
               "shortValue",
-              ShortType)
+              ShortType
+            )
 
           case ByteType =>
             Invoke(
               UnwrapOption(ScalaReflection.dataTypeFor[java.lang.Byte], path),
               "byteValue",
-              ByteType)
+              ByteType
+            )
 
           case BooleanType =>
             Invoke(
               UnwrapOption(
-                ScalaReflection.dataTypeFor[java.lang.Boolean], path),
+                ScalaReflection.dataTypeFor[java.lang.Boolean],
+                path
+              ),
               "booleanValue",
-              BooleanType)
+              BooleanType
+            )
 
-          case _ => underlying.toCatalyst(
-            UnwrapOption(underlying.jvmRepr, path))
+          case _ =>
+            underlying.toCatalyst(UnwrapOption(underlying.jvmRepr, path))
         }
       }
 
-    def fromCatalyst(path: Expression): Expression =
-      WrapOption(underlying.fromCatalyst(path), underlying.jvmRepr)
-  }
+      def fromCatalyst(path: Expression): Expression =
+        WrapOption(underlying.fromCatalyst(path), underlying.jvmRepr)
+    }
 
   /** Encodes things using injection if there is one defined */
-  implicit def usingInjection[A: ClassTag, B]
-    (implicit inj: Injection[A, B], trb: TypedEncoder[B]): TypedEncoder[A] =
-      new TypedEncoder[A] {
-        def nullable: Boolean = trb.nullable
-        def jvmRepr: DataType = FramelessInternals.objectTypeFor[A](classTag)
-        def catalystRepr: DataType = trb.catalystRepr
+  implicit def usingInjection[A: ClassTag, B](
+      implicit
+      inj: Injection[A, B],
+      trb: TypedEncoder[B]
+    ): TypedEncoder[A] =
+    new TypedEncoder[A] {
+      def nullable: Boolean = trb.nullable
+      def jvmRepr: DataType = FramelessInternals.objectTypeFor[A](classTag)
+      def catalystRepr: DataType = trb.catalystRepr
 
-        def fromCatalyst(path: Expression): Expression = {
-          val bexpr = trb.fromCatalyst(path)
-          Invoke(Literal.fromObject(inj), "invert", jvmRepr, Seq(bexpr))
-        }
-
-        def toCatalyst(path: Expression): Expression =
-          trb.toCatalyst(Invoke(
-            Literal.fromObject(inj), "apply", trb.jvmRepr, Seq(path)))
+      def fromCatalyst(path: Expression): Expression = {
+        val bexpr = trb.fromCatalyst(path)
+        Invoke(Literal.fromObject(inj), "invert", jvmRepr, Seq(bexpr))
       }
 
+      def toCatalyst(path: Expression): Expression =
+        trb.toCatalyst(
+          Invoke(Literal.fromObject(inj), "apply", trb.jvmRepr, Seq(path))
+        )
+    }
+
   /** Encodes things as records if there is no Injection defined */
-  implicit def usingDerivation[F, G <: HList, H <: HList]
-    (implicit
+  implicit def usingDerivation[F, G <: HList, H <: HList](
+      implicit
       i0: LabelledGeneric.Aux[F, G],
       i1: DropUnitValues.Aux[G, H],
       i2: IsHCons[H],
@@ -610,17 +670,20 @@ object TypedEncoder {
     ): TypedEncoder[F] = new RecordEncoder[F, G, H]
 
   /** Encodes things using a Spark SQL's User Defined Type (UDT) if there is one defined in implicit */
-  implicit def usingUserDefinedType[A >: Null : UserDefinedType : ClassTag]: TypedEncoder[A] = {
+  implicit def usingUserDefinedType[
+      A >: Null: UserDefinedType: ClassTag
+    ]: TypedEncoder[A] = {
     val udt = implicitly[UserDefinedType[A]]
-    val udtInstance = NewInstance(
-      udt.getClass, Nil, dataType = ObjectType(udt.getClass))
+    val udtInstance =
+      NewInstance(udt.getClass, Nil, dataType = ObjectType(udt.getClass))
 
     new TypedEncoder[A] {
       def nullable: Boolean = false
       def jvmRepr: DataType = ObjectType(udt.userClass)
       def catalystRepr: DataType = udt
 
-      def toCatalyst(path: Expression): Expression = Invoke(udtInstance, "serialize", udt, Seq(path))
+      def toCatalyst(path: Expression): Expression =
+        Invoke(udtInstance, "serialize", udt, Seq(path))
 
       def fromCatalyst(path: Expression): Expression =
         Invoke(udtInstance, "deserialize", ObjectType(udt.userClass), Seq(path))

--- a/dataset/src/test/resources/log4j.properties
+++ b/dataset/src/test/resources/log4j.properties
@@ -144,6 +144,3 @@ log4j.logger.org.spark-project.jetty.util.thread.QueuedThreadPool=ERROR
 log4j.logger.org.spark-project.jetty.util.thread.Timeout=ERROR
 log4j.logger.org.spark-project.jetty=ERROR
 log4j.logger.Remoting=ERROR
-
-# To debug expressions:
-#log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=DEBUG

--- a/dataset/src/test/resources/log4j2.properties
+++ b/dataset/src/test/resources/log4j2.properties
@@ -22,3 +22,7 @@ logger.spark.level = warn
 
 logger.hadoop.name = org.apache.hadoop
 logger.hadoop.level = warn
+
+# To debug expressions:
+#logger.codegen.name = org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
+#logger.codegen.level = debug

--- a/dataset/src/test/scala/frameless/ColumnTests.scala
+++ b/dataset/src/test/scala/frameless/ColumnTests.scala
@@ -1,6 +1,7 @@
 package frameless
 
 import java.util.Date
+import java.math.BigInteger
 
 import java.time.{Instant, Period, Duration}
 import java.sql.{Date=>SqlDate,Timestamp}
@@ -14,6 +15,9 @@ import scala.math.Ordering.Implicits._
 import scala.util.Try
 
 final class ColumnTests extends TypedDatasetSuite with Matchers {
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSize = 1, sizeRange = 1)
+
   implicit val timestampArb: Arbitrary[Timestamp] = Arbitrary {
     implicitly[Arbitrary[Long]].arbitrary.map { new Timestamp(_) }
   }
@@ -369,6 +373,15 @@ final class ColumnTests extends TypedDatasetSuite with Matchers {
     check(forAll(prop[Timestamp] _))
     check(forAll(prop[SqlDate] _))
     check(forAll(prop[String] _))
+
+    // Scalacheck is too slow
+    check(prop[BigInt](BigInt(Long.MaxValue).+(BigInt(Long.MaxValue)), None))
+    check(prop[BigInt](BigInt("0"), Some(BigInt(Long.MaxValue))))
+    check(prop[BigInt](BigInt(Long.MinValue).-(BigInt(Long.MinValue)), Some(BigInt("0"))))
+
+    check(prop[BigInteger](BigInteger.valueOf(Long.MaxValue).add(BigInteger.valueOf(Long.MaxValue)), None))
+    check(prop[BigInteger](BigInteger.valueOf(0L), Some(BigInteger.valueOf(Long.MaxValue))))
+    check(prop[BigInteger](BigInteger.valueOf(Long.MinValue).subtract(BigInteger.valueOf(Long.MinValue)), Some(BigInteger.valueOf(0L))))
   }
 
   test("asCol") {

--- a/docs/TypedDatasetVsSparkDataset.md
+++ b/docs/TypedDatasetVsSparkDataset.md
@@ -149,19 +149,26 @@ However, the compile type guards implemented in Spark are not sufficient to dete
 For example, using the following case class leads to a runtime failure:
 
 ```scala mdoc
-case class MyDate(jday: java.util.Date)
+case class MyDate(jday: java.util.Calendar)
 ```
 
 ```scala mdoc:crash
-val myDateDs = spark.createDataset(Seq(MyDate(new java.util.Date(System.currentTimeMillis))))
+spark.createDataset(Seq(MyDate {
+  val cal = new java.util.GregorianCalendar()
+  cal.setTime(new java.util.Date(System.currentTimeMillis))
+  cal
+}))
 ```
 
-In comparison, a TypedDataset will notify about the encoding problem at compile time: 
+In comparison, a `TypedDataset` will notify about the encoding problem at compile time: 
 
 ```scala mdoc:fail
-TypedDataset.create(Seq(MyDate(new java.util.Date(System.currentTimeMillis))))
+TypedDataset.create(Seq(MyDate {
+  val cal = new java.util.GregorianCalendar()
+  cal.setTime(new java.util.Date(System.currentTimeMillis))
+  cal
+}))
 ```
-
 
 ## Aggregate vs Projected columns 
 

--- a/docs/TypedEncoder.md
+++ b/docs/TypedEncoder.md
@@ -9,22 +9,27 @@ implicit val spark = SparkSession.builder().config(conf).appName("REPL").getOrCr
 System.setProperty("spark.cleaner.ttl", "300")
 ```
 
-Spark uses Reflection to derive its `Encoder`s, which is why they can fail at run time. For example, because Spark does not support `java.util.Date`, the following leads to an error:
+Spark uses Reflection to derive its `Encoder`s, which is why they can fail at run time. For example, because Spark does not support `java.util.Calendar`, the following leads to an error:
 
 ```scala mdoc:silent
+import java.util.Calendar
+
 import org.apache.spark.sql.Dataset
+
 import spark.implicits._
 
-case class DateRange(s: java.util.Date, e: java.util.Date)
+case class DateRange(s: Calendar, e: Calendar)
 ```
 
 ```scala mdoc:crash
-val ds: Dataset[DateRange] = Seq(DateRange(new java.util.Date, new java.util.Date)).toDS()
+def now = new java.util.GregorianCalendar()
+
+val ds: Dataset[DateRange] = Seq(DateRange(now, now)).toDS()
 ```
 
 As shown by the stack trace, this runtime error goes through [ScalaReflection](https://github.com/apache/spark/blob/19cf208063f035d793d2306295a251a9af7e32f6/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala) to try to derive an `Encoder` for `Dataset` schema. Beside the annoyance of not detecting this error at compile time, a more important limitation of the reflection-based approach is its inability to be extended for custom types. See this Stack Overflow question for a summary of the current situation (as of 2.0) in vanilla Spark: [How to store custom objects in a Dataset?](http://stackoverflow.com/a/39442829/2311362).
 
-Frameless introduces a new type class called `TypeEncoder` to solve these issues. `TypeEncoder`s are passed around as implicit parameters to every Frameless method to ensure that the data being manipulated is `Encoder`. It uses a standard implicit resolution coupled with shapeless' type class derivation mechanism to ensure every that compiling code manipulates encodable data. For example, the `java.util.Date` example won't compile with Frameless:
+Frameless introduces a new type class called `TypeEncoder` to solve these issues. `TypeEncoder`s are passed around as implicit parameters to every Frameless method to ensure that the data being manipulated is `Encoder`. It uses a standard implicit resolution coupled with shapeless' type class derivation mechanism to ensure every that compiling code manipulates encodable data. For example, the `java.util.Calendar` example won't compile with Frameless:
 
 ```scala mdoc:silent
 import frameless.TypedDataset
@@ -32,7 +37,9 @@ import frameless.syntax._
 ```
 
 ```scala mdoc:fail
-val ds: TypedDataset[DateRange] = TypedDataset.create(Seq(DateRange(new java.util.Date, new java.util.Date)))
+def now = new java.util.GregorianCalendar()
+
+val ds: TypedDataset[DateRange] = TypedDataset.create(Seq(DateRange(now, now)))
 ```
 
 Type class derivation takes care of recursively constructing (and proving the existence of) `TypeEncoder`s for case classes. The following works as expected:
@@ -40,22 +47,27 @@ Type class derivation takes care of recursively constructing (and proving the ex
 ```scala mdoc
 case class Bar(d: Double, s: String)
 case class Foo(i: Int, b: Bar)
-val ds: TypedDataset[Foo] = TypedDataset.create(Seq(Foo(1, Bar(1.1, "s"))))
+
+val ds: TypedDataset[Foo] = 
+  TypedDataset.create(Seq(Foo(1, Bar(1.1, "s"))))
+
 ds.collect()
 ```
 
 But any non-encodable in the case class hierarchy will be detected at compile time:
 
 ```scala mdoc:silent
-case class BarDate(d: Double, s: String, t: java.util.Date)
+case class BarDate(d: Double, s: String, t: java.util.Calendar)
 case class FooDate(i: Int, b: BarDate)
 ```
 
 ```scala mdoc:fail
-val ds: TypedDataset[FooDate] = TypedDataset.create(Seq(FooDate(1, BarDate(1.1, "s", new java.util.Date))))
+val ds: TypedDataset[FooDate] = TypedDataset.create(
+  Seq(FooDate(1, BarDate(1.1, "s", new java.util.GregorianCalendar))))
 ```
 
-It should be noted that once derived, reflection-based `Encoder`s and implicitly derived `TypeEncoder`s have identical performance. The derivation mechanism is different, but the objects generated to encode and decode JVM objects in Spark's internal representation behave the same at runtime.
+It should be noted that once derived, reflection-based `Encoder`s and implicitly derived `TypeEncoder`s have identical performance.
+The derivation mechanism is different, but the objects generated to encode and decode JVM objects in Spark's internal representation behave the same at runtime.
 
 ```scala mdoc:invisible
 spark.stop()

--- a/docs/TypedML.md
+++ b/docs/TypedML.md
@@ -270,6 +270,7 @@ as input the label array computed by our previous `indexerModel`:
 
 ```scala mdoc
 case class IndexToStringInput(predictedCityIndexed: Double)
+
 val indexToString = TypedIndexToString[IndexToStringInput](indexerModel.transformer.labels)
 
 case class HouseCityPrediction(


### PR DESCRIPTION
- Add `TypedEncoder` instances for `T <: java.util.Date` (aka `Data`, `sql.Data` and `sql.Timestamp`, often used with Spark data types).
- Add `TypedEncoder` instances for Scala & Java big integer