### PR TITLE
Update scalafmt-core to 3.8.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.17
+version = 3.8.0
 runner.dialect = scala213
 
 newlines.beforeMultilineDef = keep


### PR DESCRIPTION
Making a proper version of https://github.com/typelevel/frameless/pull/791